### PR TITLE
[US-003] CI pipeline with service containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         image: hashicorp/vault:1.15
         env:
           VAULT_DEV_ROOT_TOKEN_ID: dev-root-token
+          VAULT_ADDR: http://127.0.0.1:8200
         ports:
           - 8200:8200
         options: >-


### PR DESCRIPTION
## Summary

- Removes conditional "check if exists" guards — backend/ and sdk/ are now established in the monorepo
- Adds PostgreSQL 16 (pgvector/pgvector:pg16) and HashiCorp Vault 1.15 as GitHub Actions service containers for backend integration tests
- Sets DATABASE_URL, VAULT_ADDR, and VAULT_TOKEN environment variables so integration tests can connect to services
- Backend and SDK jobs continue to run in parallel

## Service Containers

| Service | Image | Port | Health Check |
|---------|-------|------|-------------|
| PostgreSQL | pgvector/pgvector:pg16 | 5432 | pg_isready |
| Vault | hashicorp/vault:1.15 | 8200 | wget --spider /v1/sys/health |

## Design Decision

Uses GitHub Actions `services:` directly instead of Docker Compose. This keeps CI self-contained and independent of `infra/compose.yaml` (being developed in US-002).

## Test plan

- [ ] CI triggers on push to main
- [ ] CI triggers on pull request to main
- [ ] Backend job: uv sync, ruff check, ruff format --check, mypy, pytest unit, pytest integration all pass
- [ ] SDK job: npm ci, typecheck, vitest, tsup build all pass
- [ ] PostgreSQL service container starts and is healthy
- [ ] Vault service container starts and is healthy
- [ ] Both jobs run in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)