### PR TITLE
[US-008] Project API key generation

### DIFF
--- a/backend/alembic/versions/003_create_api_keys_table.py
+++ b/backend/alembic/versions/003_create_api_keys_table.py
@@ -1,0 +1,42 @@
+"""Create api_keys table.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-03-13
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "003"
+down_revision: str | None = "002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "api_keys",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("projects.id"),
+            nullable=False,
+        ),
+        sa.Column("key_hash", sa.Text, nullable=False),
+        sa.Column("key_prefix", sa.String(20), nullable=False),
+        sa.Column("role", sa.String(50), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("api_keys")

--- a/backend/src/pqdb_api/app.py
+++ b/backend/src/pqdb_api/app.py
@@ -13,6 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pqdb_api.config import Settings
 from pqdb_api.database import dispose_engine, init_engine
 from pqdb_api.logging import setup_logging
+from pqdb_api.routes.api_keys import router as api_keys_router
 from pqdb_api.routes.auth import router as auth_router
 from pqdb_api.routes.health import router as health_router
 from pqdb_api.routes.projects import router as projects_router
@@ -64,5 +65,6 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(health_router)
     app.include_router(auth_router)
     app.include_router(projects_router)
+    app.include_router(api_keys_router)
 
     return app

--- a/backend/src/pqdb_api/models/__init__.py
+++ b/backend/src/pqdb_api/models/__init__.py
@@ -1,7 +1,8 @@
 """Database models."""
 
+from pqdb_api.models.api_key import ApiKey
 from pqdb_api.models.base import Base
 from pqdb_api.models.developer import Developer
 from pqdb_api.models.project import Project
 
-__all__ = ["Base", "Developer", "Project"]
+__all__ = ["ApiKey", "Base", "Developer", "Project"]

--- a/backend/src/pqdb_api/models/api_key.py
+++ b/backend/src/pqdb_api/models/api_key.py
@@ -1,0 +1,29 @@
+"""ApiKey model for project API key management."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from pqdb_api.models.base import Base
+
+
+class ApiKey(Base):
+    """An API key for authenticating against a project's database."""
+
+    __tablename__ = "api_keys"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id"), nullable=False
+    )
+    key_hash: Mapped[str] = mapped_column(Text, nullable=False)
+    key_prefix: Mapped[str] = mapped_column(String(20), nullable=False)
+    role: Mapped[str] = mapped_column(String(50), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/src/pqdb_api/routes/api_keys.py
+++ b/backend/src/pqdb_api/routes/api_keys.py
@@ -1,0 +1,110 @@
+"""API key endpoints: list and rotate project keys."""
+
+import uuid
+from datetime import datetime
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from pqdb_api.database import get_session
+from pqdb_api.middleware.auth import get_current_developer_id
+from pqdb_api.models.project import Project
+from pqdb_api.services.api_keys import list_project_keys, rotate_project_keys
+
+logger = structlog.get_logger()
+
+router = APIRouter(prefix="/v1/projects", tags=["api-keys"])
+
+
+class ApiKeyListResponse(BaseModel):
+    """Response for listing API keys (prefix only, no full key)."""
+
+    id: str
+    role: str
+    key_prefix: str
+    created_at: datetime
+
+
+class ApiKeyCreatedResponse(BaseModel):
+    """Response for newly created keys (includes full key, one-time display)."""
+
+    id: str
+    role: str
+    key: str
+    key_prefix: str
+
+
+async def _get_project_for_developer(
+    project_id: uuid.UUID,
+    developer_id: uuid.UUID,
+    session: AsyncSession,
+) -> Project:
+    """Fetch a project scoped to a developer, raising 404 if not found."""
+    result = await session.execute(
+        select(Project).where(
+            Project.id == project_id,
+            Project.developer_id == developer_id,
+        )
+    )
+    project = result.scalar_one_or_none()
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return project
+
+
+@router.get(
+    "/{project_id}/keys",
+    response_model=list[ApiKeyListResponse],
+)
+async def list_keys(
+    project_id: uuid.UUID,
+    developer_id: uuid.UUID = Depends(get_current_developer_id),
+    session: AsyncSession = Depends(get_session),
+) -> list[ApiKeyListResponse]:
+    """List API keys for a project (shows prefix only, not full key)."""
+    await _get_project_for_developer(project_id, developer_id, session)
+
+    keys = await list_project_keys(project_id, session)
+    return [
+        ApiKeyListResponse(
+            id=str(k.id),
+            role=k.role,
+            key_prefix=k.key_prefix,
+            created_at=k.created_at,
+        )
+        for k in keys
+    ]
+
+
+@router.post(
+    "/{project_id}/keys/rotate",
+    response_model=list[ApiKeyCreatedResponse],
+)
+async def rotate_keys(
+    project_id: uuid.UUID,
+    developer_id: uuid.UUID = Depends(get_current_developer_id),
+    session: AsyncSession = Depends(get_session),
+) -> list[ApiKeyCreatedResponse]:
+    """Rotate API keys for a project. Returns new full keys (one-time display)."""
+    await _get_project_for_developer(project_id, developer_id, session)
+
+    new_keys = await rotate_project_keys(project_id, session)
+    await session.commit()
+
+    logger.info(
+        "api_keys_rotated",
+        project_id=str(project_id),
+        developer_id=str(developer_id),
+    )
+    return [
+        ApiKeyCreatedResponse(
+            id=k["id"],
+            role=k["role"],
+            key=k["key"],
+            key_prefix=k["key_prefix"],
+        )
+        for k in new_keys
+    ]

--- a/backend/src/pqdb_api/routes/projects.py
+++ b/backend/src/pqdb_api/routes/projects.py
@@ -2,6 +2,7 @@
 
 import uuid
 from datetime import datetime
+from typing import Any
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException
@@ -12,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from pqdb_api.database import get_session
 from pqdb_api.middleware.auth import get_current_developer_id
 from pqdb_api.models.project import Project
+from pqdb_api.services.api_keys import create_project_keys
 
 logger = structlog.get_logger()
 
@@ -25,6 +27,15 @@ class CreateProjectRequest(BaseModel):
     region: str = "us-east-1"
 
 
+class ApiKeyCreatedResponse(BaseModel):
+    """API key info returned at creation time (includes full key)."""
+
+    id: str
+    role: str
+    key: str
+    key_prefix: str
+
+
 class ProjectResponse(BaseModel):
     """Response body for a project."""
 
@@ -35,12 +46,18 @@ class ProjectResponse(BaseModel):
     created_at: datetime
 
 
-@router.post("", response_model=ProjectResponse, status_code=201)
+class ProjectCreateResponse(ProjectResponse):
+    """Response body for project creation (includes one-time API keys)."""
+
+    api_keys: list[ApiKeyCreatedResponse]
+
+
+@router.post("", response_model=ProjectCreateResponse, status_code=201)
 async def create_project(
     body: CreateProjectRequest,
     developer_id: uuid.UUID = Depends(get_current_developer_id),
     session: AsyncSession = Depends(get_session),
-) -> ProjectResponse:
+) -> dict[str, Any]:
     """Create a new project for the authenticated developer."""
     project = Project(
         id=uuid.uuid4(),
@@ -49,6 +66,9 @@ async def create_project(
         region=body.region,
     )
     session.add(project)
+    await session.flush()
+
+    keys = await create_project_keys(project.id, session)
     await session.commit()
     await session.refresh(project)
     logger.info(
@@ -56,13 +76,22 @@ async def create_project(
         project_id=str(project.id),
         developer_id=str(developer_id),
     )
-    return ProjectResponse(
-        id=str(project.id),
-        name=project.name,
-        region=project.region,
-        status=project.status,
-        created_at=project.created_at,
-    )
+    return {
+        "id": str(project.id),
+        "name": project.name,
+        "region": project.region,
+        "status": project.status,
+        "created_at": project.created_at,
+        "api_keys": [
+            {
+                "id": k["id"],
+                "role": k["role"],
+                "key": k["key"],
+                "key_prefix": k["key_prefix"],
+            }
+            for k in keys
+        ],
+    }
 
 
 @router.get("", response_model=list[ProjectResponse])

--- a/backend/src/pqdb_api/services/api_keys.py
+++ b/backend/src/pqdb_api/services/api_keys.py
@@ -1,0 +1,88 @@
+"""API key generation and management service."""
+
+import secrets
+import uuid
+
+from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from pqdb_api.models.api_key import ApiKey
+
+_hasher = PasswordHasher()
+
+_KEY_RANDOM_BYTES = 24  # 24 bytes -> 32 chars in base64url
+
+
+def generate_api_key(role: str) -> str:
+    """Generate a new API key in the format pqdb_{role}_{random_32_chars}."""
+    random_part = secrets.token_urlsafe(_KEY_RANDOM_BYTES)
+    return f"pqdb_{role}_{random_part}"
+
+
+def hash_api_key(key: str) -> str:
+    """Hash an API key using argon2id."""
+    return _hasher.hash(key)
+
+
+def verify_api_key(key_hash: str, key: str) -> bool:
+    """Verify an API key against its argon2id hash."""
+    try:
+        return _hasher.verify(key_hash, key)
+    except VerifyMismatchError:
+        return False
+
+
+async def create_project_keys(
+    project_id: uuid.UUID, session: AsyncSession
+) -> list[dict[str, str]]:
+    """Create both anon and service_role keys for a project.
+
+    Returns the full keys (one-time display). Keys are stored as hashes.
+    """
+    results: list[dict[str, str]] = []
+    for role in ("anon", "service"):
+        full_key = generate_api_key(role)
+        key_hash = hash_api_key(full_key)
+        key_prefix = full_key[:8]
+
+        api_key = ApiKey(
+            id=uuid.uuid4(),
+            project_id=project_id,
+            key_hash=key_hash,
+            key_prefix=key_prefix,
+            role=role,
+        )
+        session.add(api_key)
+        results.append(
+            {
+                "id": str(api_key.id),
+                "role": role,
+                "key": full_key,
+                "key_prefix": key_prefix,
+            }
+        )
+    return results
+
+
+async def list_project_keys(
+    project_id: uuid.UUID, session: AsyncSession
+) -> list[ApiKey]:
+    """List all API keys for a project (returns model objects, not full keys)."""
+    result = await session.execute(
+        select(ApiKey).where(ApiKey.project_id == project_id)
+    )
+    keys: list[ApiKey] = list(result.scalars().all())
+    return keys
+
+
+async def rotate_project_keys(
+    project_id: uuid.UUID, session: AsyncSession
+) -> list[dict[str, str]]:
+    """Rotate all keys for a project: delete old, create new.
+
+    Returns the new full keys (one-time display).
+    """
+    await session.execute(delete(ApiKey).where(ApiKey.project_id == project_id))
+    return await create_project_keys(project_id, session)

--- a/backend/tests/integration/test_api_keys.py
+++ b/backend/tests/integration/test_api_keys.py
@@ -1,0 +1,355 @@
+"""Integration tests for API key endpoints.
+
+Boots the real FastAPI app with an in-process SQLite database,
+exercises key generation on project creation, listing, and rotation.
+"""
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import StaticPool, event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from pqdb_api.database import get_session
+from pqdb_api.models.base import Base
+from pqdb_api.routes.api_keys import router as api_keys_router
+from pqdb_api.routes.auth import router as auth_router
+from pqdb_api.routes.health import router as health_router
+from pqdb_api.routes.projects import router as projects_router
+from pqdb_api.services.auth import generate_ed25519_keypair
+
+
+def _create_test_app() -> FastAPI:
+    """Create a test FastAPI app with in-memory SQLite."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _set_sqlite_pragma(dbapi_conn, connection_record):  # type: ignore[no-untyped-def]
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    test_session_factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    async def _override_get_session() -> AsyncIterator[AsyncSession]:
+        async with test_session_factory() as session:
+            yield session
+
+    private_key, public_key = generate_ed25519_keypair()
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        app.state.jwt_private_key = private_key
+        app.state.jwt_public_key = public_key
+        yield
+        await engine.dispose()
+
+    app = FastAPI(lifespan=lifespan)
+    app.include_router(health_router)
+    app.include_router(auth_router)
+    app.include_router(projects_router)
+    app.include_router(api_keys_router)
+    app.dependency_overrides[get_session] = _override_get_session
+    return app
+
+
+@pytest.fixture()
+def client() -> Iterator[TestClient]:
+    app = _create_test_app()
+    with TestClient(app) as c:
+        yield c
+
+
+def _signup_and_get_token(client: TestClient, email: str = "dev@test.com") -> str:
+    """Sign up a developer and return the access token."""
+    resp = client.post(
+        "/v1/auth/signup",
+        json={"email": email, "password": "testpass123"},
+    )
+    assert resp.status_code == 201
+    token: str = resp.json()["access_token"]
+    return token
+
+
+def _auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_project(client: TestClient, token: str, name: str = "test-project") -> dict:  # type: ignore[type-arg]
+    """Create a project and return the response JSON."""
+    resp = client.post(
+        "/v1/projects",
+        json={"name": name},
+        headers=_auth_headers(token),
+    )
+    assert resp.status_code == 201
+    data: dict = resp.json()  # type: ignore[type-arg]
+    return data
+
+
+class TestApiKeyRoutesExist:
+    """Verify all API key routes are registered and return non-404."""
+
+    def test_list_keys_route_exists(self, client: TestClient) -> None:
+        resp = client.get(f"/v1/projects/{uuid.uuid4()}/keys")
+        assert resp.status_code != 404
+
+    def test_rotate_keys_route_exists(self, client: TestClient) -> None:
+        resp = client.post(f"/v1/projects/{uuid.uuid4()}/keys/rotate")
+        assert resp.status_code != 404
+
+
+class TestApiKeyAuth:
+    """API key endpoints require valid JWT."""
+
+    def test_list_keys_without_auth_returns_401_or_403(
+        self, client: TestClient
+    ) -> None:
+        resp = client.get(f"/v1/projects/{uuid.uuid4()}/keys")
+        assert resp.status_code in (401, 403)
+
+    def test_rotate_keys_without_auth_returns_401_or_403(
+        self, client: TestClient
+    ) -> None:
+        resp = client.post(f"/v1/projects/{uuid.uuid4()}/keys/rotate")
+        assert resp.status_code in (401, 403)
+
+
+class TestProjectCreationGeneratesKeys:
+    """Creating a project should auto-generate API keys."""
+
+    def test_create_project_returns_api_keys(self, client: TestClient) -> None:
+        token = _signup_and_get_token(client)
+        resp = client.post(
+            "/v1/projects",
+            json={"name": "keyed-project"},
+            headers=_auth_headers(token),
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert "api_keys" in data
+        keys = data["api_keys"]
+        assert len(keys) == 2
+        roles = {k["role"] for k in keys}
+        assert roles == {"anon", "service"}
+
+    def test_created_keys_have_correct_format(self, client: TestClient) -> None:
+        token = _signup_and_get_token(client)
+        resp = client.post(
+            "/v1/projects",
+            json={"name": "format-project"},
+            headers=_auth_headers(token),
+        )
+        data = resp.json()
+        for key_info in data["api_keys"]:
+            full_key = key_info["key"]
+            assert full_key.startswith(f"pqdb_{key_info['role']}_")
+            parts = full_key.split("_", 2)
+            assert len(parts[2]) == 32
+
+    def test_created_keys_show_prefix(self, client: TestClient) -> None:
+        token = _signup_and_get_token(client)
+        resp = client.post(
+            "/v1/projects",
+            json={"name": "prefix-project"},
+            headers=_auth_headers(token),
+        )
+        data = resp.json()
+        for key_info in data["api_keys"]:
+            assert "key_prefix" in key_info
+            assert len(key_info["key_prefix"]) == 8
+
+
+class TestListKeys:
+    """Tests for GET /v1/projects/{project_id}/keys."""
+
+    def test_list_keys_for_project(self, client: TestClient) -> None:
+        token = _signup_and_get_token(client)
+        project = _create_project(client, token)
+        project_id = project["id"]
+
+        resp = client.get(
+            f"/v1/projects/{project_id}/keys",
+            headers=_auth_headers(token),
+        )
+        assert resp.status_code == 200
+        keys = resp.json()
+        assert len(keys) == 2
+        roles = {k["role"] for k in keys}
+        assert roles == {"anon", "service"}
+
+    def test_list_keys_does_not_expose_full_key(self, client: TestClient) -> None:
+        token = _signup_and_get_token(client)
+        project = _create_project(client, token)
+        project_id = project["id"]
+
+        resp = client.get(
+            f"/v1/projects/{project_id}/keys",
+            headers=_auth_headers(token),
+        )
+        keys = resp.json()
+        for key in keys:
+            assert "key" not in key
+            assert "key_hash" not in key
+            assert "key_prefix" in key
+
+    def test_list_keys_for_nonexistent_project_returns_404(
+        self, client: TestClient
+    ) -> None:
+        token = _signup_and_get_token(client)
+        resp = client.get(
+            f"/v1/projects/{uuid.uuid4()}/keys",
+            headers=_auth_headers(token),
+        )
+        assert resp.status_code == 404
+
+    def test_list_keys_for_other_developers_project_returns_404(
+        self, client: TestClient
+    ) -> None:
+        token_a = _signup_and_get_token(client, email="keya@test.com")
+        token_b = _signup_and_get_token(client, email="keyb@test.com")
+
+        project = _create_project(client, token_a, name="private-keys")
+        project_id = project["id"]
+
+        resp = client.get(
+            f"/v1/projects/{project_id}/keys",
+            headers=_auth_headers(token_b),
+        )
+        assert resp.status_code == 404
+
+
+class TestRotateKeys:
+    """Tests for POST /v1/projects/{project_id}/keys/rotate."""
+
+    def test_rotate_keys_returns_new_keys(self, client: TestClient) -> None:
+        token = _signup_and_get_token(client)
+        project = _create_project(client, token)
+        project_id = project["id"]
+
+        resp = client.post(
+            f"/v1/projects/{project_id}/keys/rotate",
+            headers=_auth_headers(token),
+        )
+        assert resp.status_code == 200
+        keys = resp.json()
+        assert len(keys) == 2
+        roles = {k["role"] for k in keys}
+        assert roles == {"anon", "service"}
+        for key_info in keys:
+            assert "key" in key_info
+            assert key_info["key"].startswith(f"pqdb_{key_info['role']}_")
+
+    def test_rotate_keys_invalidates_old_keys(self, client: TestClient) -> None:
+        token = _signup_and_get_token(client)
+        project = _create_project(client, token)
+        project_id = project["id"]
+
+        list_resp1 = client.get(
+            f"/v1/projects/{project_id}/keys",
+            headers=_auth_headers(token),
+        )
+        old_ids = {k["id"] for k in list_resp1.json()}
+
+        client.post(
+            f"/v1/projects/{project_id}/keys/rotate",
+            headers=_auth_headers(token),
+        )
+
+        list_resp2 = client.get(
+            f"/v1/projects/{project_id}/keys",
+            headers=_auth_headers(token),
+        )
+        new_ids = {k["id"] for k in list_resp2.json()}
+        assert old_ids != new_ids
+
+    def test_rotate_keys_for_nonexistent_project_returns_404(
+        self, client: TestClient
+    ) -> None:
+        token = _signup_and_get_token(client)
+        resp = client.post(
+            f"/v1/projects/{uuid.uuid4()}/keys/rotate",
+            headers=_auth_headers(token),
+        )
+        assert resp.status_code == 404
+
+    def test_rotate_keys_for_other_developers_project_returns_404(
+        self, client: TestClient
+    ) -> None:
+        token_a = _signup_and_get_token(client, email="rota@test.com")
+        token_b = _signup_and_get_token(client, email="rotb@test.com")
+
+        project = _create_project(client, token_a, name="rotate-private")
+        project_id = project["id"]
+
+        resp = client.post(
+            f"/v1/projects/{project_id}/keys/rotate",
+            headers=_auth_headers(token_b),
+        )
+        assert resp.status_code == 404
+
+
+class TestHealthCheck:
+    """Health check still works with API key routes included."""
+
+    def test_health_returns_200(self, client: TestClient) -> None:
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+
+class TestFullApiKeyFlow:
+    """End-to-end: signup -> create -> list keys -> rotate."""
+
+    def test_complete_api_key_flow(self, client: TestClient) -> None:
+        token = _signup_and_get_token(client, email="flow@test.com")
+
+        create_resp = client.post(
+            "/v1/projects",
+            json={"name": "flow-project"},
+            headers=_auth_headers(token),
+        )
+        assert create_resp.status_code == 201
+        project = create_resp.json()
+        project_id = project["id"]
+
+        assert len(project["api_keys"]) == 2
+        original_keys = {k["key"] for k in project["api_keys"]}
+        assert len(original_keys) == 2
+
+        list_resp = client.get(
+            f"/v1/projects/{project_id}/keys",
+            headers=_auth_headers(token),
+        )
+        assert list_resp.status_code == 200
+        listed_keys = list_resp.json()
+        assert len(listed_keys) == 2
+        for k in listed_keys:
+            assert "key" not in k
+            assert "key_prefix" in k
+
+        rotate_resp = client.post(
+            f"/v1/projects/{project_id}/keys/rotate",
+            headers=_auth_headers(token),
+        )
+        assert rotate_resp.status_code == 200
+        new_keys = {k["key"] for k in rotate_resp.json()}
+        assert len(new_keys) == 2
+        assert new_keys != original_keys
+
+        list_resp2 = client.get(
+            f"/v1/projects/{project_id}/keys",
+            headers=_auth_headers(token),
+        )
+        assert len(list_resp2.json()) == 2

--- a/backend/tests/unit/test_api_key_model.py
+++ b/backend/tests/unit/test_api_key_model.py
@@ -1,0 +1,61 @@
+"""Unit tests for the ApiKey model."""
+
+import uuid
+
+from pqdb_api.models.api_key import ApiKey
+
+
+class TestApiKeyModel:
+    """Tests for ApiKey SQLAlchemy model."""
+
+    def test_table_name(self) -> None:
+        assert ApiKey.__tablename__ == "api_keys"
+
+    def test_columns_exist(self) -> None:
+        columns = {c.name for c in ApiKey.__table__.columns}
+        expected = {
+            "id",
+            "project_id",
+            "key_hash",
+            "key_prefix",
+            "role",
+            "created_at",
+        }
+        assert columns == expected
+
+    def test_id_is_primary_key(self) -> None:
+        pk_cols = [c.name for c in ApiKey.__table__.primary_key]
+        assert pk_cols == ["id"]
+
+    def test_project_id_is_foreign_key(self) -> None:
+        col = ApiKey.__table__.columns["project_id"]
+        fk_targets = [fk.target_fullname for fk in col.foreign_keys]
+        assert "projects.id" in fk_targets
+
+    def test_key_hash_is_not_nullable(self) -> None:
+        col = ApiKey.__table__.columns["key_hash"]
+        assert col.nullable is False
+
+    def test_key_prefix_is_not_nullable(self) -> None:
+        col = ApiKey.__table__.columns["key_prefix"]
+        assert col.nullable is False
+
+    def test_role_is_not_nullable(self) -> None:
+        col = ApiKey.__table__.columns["role"]
+        assert col.nullable is False
+
+    def test_can_instantiate(self) -> None:
+        key_id = uuid.uuid4()
+        proj_id = uuid.uuid4()
+        api_key = ApiKey(
+            id=key_id,
+            project_id=proj_id,
+            key_hash="$argon2id$...",
+            key_prefix="pqdb_ano",
+            role="anon",
+        )
+        assert api_key.id == key_id
+        assert api_key.project_id == proj_id
+        assert api_key.key_hash == "$argon2id$..."
+        assert api_key.key_prefix == "pqdb_ano"
+        assert api_key.role == "anon"

--- a/backend/tests/unit/test_api_key_service.py
+++ b/backend/tests/unit/test_api_key_service.py
@@ -1,0 +1,69 @@
+"""Unit tests for the API key service."""
+
+import re
+
+from pqdb_api.services.api_keys import generate_api_key, hash_api_key
+
+
+class TestGenerateApiKey:
+    """Tests for API key generation."""
+
+    def test_anon_key_format(self) -> None:
+        key = generate_api_key("anon")
+        assert key.startswith("pqdb_anon_")
+        parts = key.split("_", 2)
+        assert len(parts) == 3
+        assert parts[0] == "pqdb"
+        assert parts[1] == "anon"
+        assert len(parts[2]) == 32
+
+    def test_service_key_format(self) -> None:
+        key = generate_api_key("service")
+        assert key.startswith("pqdb_service_")
+        parts = key.split("_", 2)
+        assert len(parts) == 3
+        assert parts[0] == "pqdb"
+        assert parts[1] == "service"
+        assert len(parts[2]) == 32
+
+    def test_key_contains_only_url_safe_chars(self) -> None:
+        key = generate_api_key("anon")
+        random_part = key.split("_", 2)[2]
+        assert re.match(r"^[A-Za-z0-9_-]+$", random_part)
+
+    def test_keys_are_unique(self) -> None:
+        keys = {generate_api_key("anon") for _ in range(10)}
+        assert len(keys) == 10
+
+    def test_key_prefix_is_first_8_chars(self) -> None:
+        key = generate_api_key("anon")
+        assert key[:8] == "pqdb_ano"
+
+    def test_service_key_prefix_is_first_8_chars(self) -> None:
+        key = generate_api_key("service")
+        assert key[:8] == "pqdb_ser"
+
+
+class TestHashApiKey:
+    """Tests for API key hashing."""
+
+    def test_hash_returns_string(self) -> None:
+        key = generate_api_key("anon")
+        hashed = hash_api_key(key)
+        assert isinstance(hashed, str)
+
+    def test_hash_contains_argon2id_marker(self) -> None:
+        key = generate_api_key("anon")
+        hashed = hash_api_key(key)
+        assert "$argon2id$" in hashed
+
+    def test_hash_is_different_from_key(self) -> None:
+        key = generate_api_key("anon")
+        hashed = hash_api_key(key)
+        assert hashed != key
+
+    def test_same_key_produces_different_hashes(self) -> None:
+        key = generate_api_key("anon")
+        h1 = hash_api_key(key)
+        h2 = hash_api_key(key)
+        assert h1 != h2  # argon2id uses random salt


### PR DESCRIPTION
## Summary

- Add `api_keys` table (Alembic migration 003) with id, project_id FK, key_hash (argon2id), key_prefix (first 8 chars), role (anon/service), created_at
- Auto-generate both anon and service API keys when a project is created — full keys shown one-time only at creation
- `GET /v1/projects/{id}/keys` lists keys showing prefix only (never full key or hash)
- `POST /v1/projects/{id}/keys/rotate` invalidates old keys and generates new ones (full keys returned one-time)
- Key format: `pqdb_{role}_{random_32_chars}` using `secrets.token_urlsafe`
- Keys stored as argon2id hashes (never plaintext)
- All endpoints scoped to authenticated developer (JWT required)

## Files changed

- **New:** `models/api_key.py` — ApiKey SQLAlchemy model
- **New:** `services/api_keys.py` — Key generation, hashing, CRUD operations
- **New:** `routes/api_keys.py` — List and rotate key endpoints
- **New:** `alembic/versions/003_create_api_keys_table.py` — Migration
- **Modified:** `routes/projects.py` — Project creation now auto-generates keys
- **Modified:** `app.py` — Register api_keys_router
- **Modified:** `models/__init__.py` — Export ApiKey

## Test plan

- [x] 8 unit tests for ApiKey model (table name, columns, FK, nullable constraints)
- [x] 10 unit tests for API key service (key format, uniqueness, argon2id hashing)
- [x] 17 integration tests (route existence, auth, key generation on create, list, rotate, project scoping, full flow)
- [x] All 140 tests pass
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy --strict` — clean
- [x] Health check returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)