### PR TITLE
[US-018] SDK defineTable and query builder

### DIFF
--- a/sdk/src/client/index.ts
+++ b/sdk/src/client/index.ts
@@ -3,10 +3,19 @@
  */
 import { HttpClient } from "./http.js";
 import { AuthClient } from "./auth.js";
+import { QueryBuilder } from "../query/builder.js";
+import { defineTableSchema } from "../query/schema.js";
+import type { SchemaColumns, TableSchema } from "../query/schema.js";
 import type { PqdbClientOptions } from "./types.js";
 
 export interface PqdbClient {
   auth: AuthClient;
+
+  /** Define a table schema for use with the query builder. */
+  defineTable<S extends SchemaColumns>(name: string, columns: S): TableSchema<S>;
+
+  /** Create a query builder for the given table schema. */
+  from<S extends SchemaColumns>(schema: TableSchema<S>): QueryBuilder<S>;
 }
 
 /**
@@ -29,7 +38,15 @@ export function createClient(
 
   const auth = new AuthClient(http);
 
-  return { auth };
+  function defineTable<S extends SchemaColumns>(name: string, columns: S): TableSchema<S> {
+    return defineTableSchema(name, columns);
+  }
+
+  function from<S extends SchemaColumns>(schema: TableSchema<S>): QueryBuilder<S> {
+    return new QueryBuilder(http, schema);
+  }
+
+  return { auth, defineTable, from };
 }
 
 export type { PqdbClientOptions, PqdbClient as PqdbClientInterface };

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -16,3 +16,20 @@ export type {
   PqdbResponse,
 } from "./client/types.js";
 export { AuthClient } from "./client/auth.js";
+
+// Query builder exports
+export { column, defineTableSchema, ColumnDef } from "./query/schema.js";
+export type {
+  Sensitivity,
+  ColumnType,
+  SchemaColumns,
+  InferRow,
+  TableSchema,
+} from "./query/schema.js";
+export { QueryBuilder } from "./query/builder.js";
+export type {
+  FilterOp,
+  FilterClause,
+  OrderDirection,
+  QueryModifiers,
+} from "./query/types.js";

--- a/sdk/src/query/builder.ts
+++ b/sdk/src/query/builder.ts
@@ -1,0 +1,208 @@
+/**
+ * Query builder for pqdb — produces request payloads for SELECT, INSERT, UPDATE, DELETE.
+ *
+ * All operations return { data, error } — never throw.
+ */
+import type { HttpClient } from "../client/http.js";
+import type { PqdbResponse } from "../client/types.js";
+import type { SchemaColumns, InferRow, TableSchema } from "./schema.js";
+import type {
+  FilterClause,
+  FilterOp,
+  OrderDirection,
+  QueryModifiers,
+} from "./types.js";
+
+/** Query operation type. */
+type QueryOp = "select" | "insert" | "update" | "delete";
+
+/**
+ * An executable query that has been configured with an operation, filters, and modifiers.
+ */
+class ExecutableQuery<Row> {
+  private readonly http: HttpClient;
+  private readonly tableName: string;
+  private readonly op: QueryOp;
+  private readonly filters: FilterClause[];
+  private readonly modifiers: QueryModifiers;
+  private readonly payload: Record<string, unknown>;
+
+  constructor(
+    http: HttpClient,
+    tableName: string,
+    op: QueryOp,
+    payload: Record<string, unknown>,
+    filters: FilterClause[] = [],
+    modifiers: QueryModifiers = {},
+  ) {
+    this.http = http;
+    this.tableName = tableName;
+    this.op = op;
+    this.payload = payload;
+    this.filters = filters;
+    this.modifiers = modifiers;
+  }
+
+  /** Add an equals filter. */
+  eq(col: string, value: unknown): ExecutableQuery<Row> {
+    return this.addFilter(col, "eq", value);
+  }
+
+  /** Add a greater-than filter. */
+  gt(col: string, value: unknown): ExecutableQuery<Row> {
+    return this.addFilter(col, "gt", value);
+  }
+
+  /** Add a less-than filter. */
+  lt(col: string, value: unknown): ExecutableQuery<Row> {
+    return this.addFilter(col, "lt", value);
+  }
+
+  /** Add a greater-than-or-equal filter. */
+  gte(col: string, value: unknown): ExecutableQuery<Row> {
+    return this.addFilter(col, "gte", value);
+  }
+
+  /** Add a less-than-or-equal filter. */
+  lte(col: string, value: unknown): ExecutableQuery<Row> {
+    return this.addFilter(col, "lte", value);
+  }
+
+  /** Add an "in" filter (value must be in the given array). */
+  in(col: string, values: unknown[]): ExecutableQuery<Row> {
+    return this.addFilter(col, "in", values);
+  }
+
+  /** Set a row limit. */
+  limit(n: number): ExecutableQuery<Row> {
+    return new ExecutableQuery<Row>(
+      this.http,
+      this.tableName,
+      this.op,
+      this.payload,
+      this.filters,
+      { ...this.modifiers, limit: n },
+    );
+  }
+
+  /** Set a row offset. */
+  offset(n: number): ExecutableQuery<Row> {
+    return new ExecutableQuery<Row>(
+      this.http,
+      this.tableName,
+      this.op,
+      this.payload,
+      this.filters,
+      { ...this.modifiers, offset: n },
+    );
+  }
+
+  /** Set ordering. */
+  order(col: string, direction: OrderDirection): ExecutableQuery<Row> {
+    return new ExecutableQuery<Row>(
+      this.http,
+      this.tableName,
+      this.op,
+      this.payload,
+      this.filters,
+      { ...this.modifiers, order: { column: col, direction } },
+    );
+  }
+
+  /** Execute the query against the backend. Returns { data, error } — never throws. */
+  async execute(): Promise<PqdbResponse<Row[]>> {
+    const body = this.buildBody();
+    return this.http.request<Row[]>({
+      method: "POST",
+      path: `/v1/db/${this.tableName}/${this.op}`,
+      body,
+    });
+  }
+
+  private addFilter(col: string, op: FilterOp, value: unknown): ExecutableQuery<Row> {
+    return new ExecutableQuery<Row>(
+      this.http,
+      this.tableName,
+      this.op,
+      this.payload,
+      [...this.filters, { column: col, op, value }],
+      this.modifiers,
+    );
+  }
+
+  private buildBody(): Record<string, unknown> {
+    switch (this.op) {
+      case "select":
+        return {
+          ...this.payload,
+          filters: this.filters,
+          modifiers: this.modifiers,
+        };
+      case "insert":
+        return { ...this.payload };
+      case "update":
+        return {
+          ...this.payload,
+          filters: this.filters,
+        };
+      case "delete":
+        return {
+          filters: this.filters,
+        };
+    }
+  }
+}
+
+/**
+ * QueryBuilder — entry point for building typed queries against a table.
+ */
+export class QueryBuilder<S extends SchemaColumns> {
+  private readonly http: HttpClient;
+  private readonly schema: TableSchema<S>;
+
+  constructor(http: HttpClient, schema: TableSchema<S>) {
+    this.http = http;
+    this.schema = schema;
+  }
+
+  /** Build a SELECT query. Optionally specify columns to select. */
+  select(...columns: (keyof S & string)[]): ExecutableQuery<InferRow<S>> {
+    const cols = columns.length > 0 ? columns : "*";
+    return new ExecutableQuery<InferRow<S>>(
+      this.http,
+      this.schema.name,
+      "select",
+      { columns: cols },
+    );
+  }
+
+  /** Build an INSERT query with one or more rows. */
+  insert(rows: Partial<InferRow<S>>[]): ExecutableQuery<InferRow<S>> {
+    return new ExecutableQuery<InferRow<S>>(
+      this.http,
+      this.schema.name,
+      "insert",
+      { rows },
+    );
+  }
+
+  /** Build an UPDATE query with values to set. */
+  update(values: Partial<InferRow<S>>): ExecutableQuery<InferRow<S>> {
+    return new ExecutableQuery<InferRow<S>>(
+      this.http,
+      this.schema.name,
+      "update",
+      { values },
+    );
+  }
+
+  /** Build a DELETE query. */
+  delete(): ExecutableQuery<InferRow<S>> {
+    return new ExecutableQuery<InferRow<S>>(
+      this.http,
+      this.schema.name,
+      "delete",
+      {},
+    );
+  }
+}

--- a/sdk/src/query/schema.ts
+++ b/sdk/src/query/schema.ts
@@ -1,0 +1,92 @@
+/**
+ * Column definitions and table schema for pqdb query builder.
+ */
+
+/** Sensitivity levels for columns. */
+export type Sensitivity = "plain" | "searchable" | "private";
+
+/** Column data types. */
+export type ColumnType =
+  | "uuid"
+  | "text"
+  | "integer"
+  | "timestamp"
+  | "boolean"
+  | "vector";
+
+/** A column definition with fluent chaining. */
+export class ColumnDef<T = unknown> {
+  readonly type: ColumnType;
+  readonly sensitivity: Sensitivity;
+  readonly isPrimaryKey: boolean;
+  readonly dimensions?: number;
+
+  constructor(
+    type: ColumnType,
+    sensitivity: Sensitivity = "plain",
+    isPrimaryKey: boolean = false,
+    dimensions?: number,
+  ) {
+    this.type = type;
+    this.sensitivity = sensitivity;
+    this.isPrimaryKey = isPrimaryKey;
+    this.dimensions = dimensions;
+  }
+
+  /** Mark this column with a sensitivity level. */
+  sensitive(level: "searchable" | "private"): ColumnDef<T> {
+    return new ColumnDef<T>(this.type, level, this.isPrimaryKey, this.dimensions);
+  }
+
+  /** Mark this column as the primary key. */
+  primaryKey(): ColumnDef<T> {
+    return new ColumnDef<T>(this.type, this.sensitivity, true, this.dimensions);
+  }
+}
+
+/** TypeScript type mapping from column type to native type. */
+export type InferColumnType<C> = C extends ColumnDef<infer T> ? T : never;
+
+/** Column factory helpers. */
+export const column = {
+  uuid(): ColumnDef<string> {
+    return new ColumnDef<string>("uuid");
+  },
+  text(): ColumnDef<string> {
+    return new ColumnDef<string>("text");
+  },
+  integer(): ColumnDef<number> {
+    return new ColumnDef<number>("integer");
+  },
+  timestamp(): ColumnDef<string> {
+    return new ColumnDef<string>("timestamp");
+  },
+  boolean(): ColumnDef<boolean> {
+    return new ColumnDef<boolean>("boolean");
+  },
+  vector(dimensions: number): ColumnDef<number[]> {
+    return new ColumnDef<number[]>("vector", "plain", false, dimensions);
+  },
+};
+
+/** A record of column name to column definition. */
+export type SchemaColumns = Record<string, ColumnDef>;
+
+/** Infer the row type from a schema columns definition. */
+export type InferRow<S extends SchemaColumns> = {
+  [K in keyof S]: InferColumnType<S[K]>;
+};
+
+/** A table schema definition. */
+export interface TableSchema<S extends SchemaColumns = SchemaColumns> {
+  readonly name: string;
+  readonly columns: S;
+}
+
+/** Create a table schema definition. */
+export function defineTableSchema<S extends SchemaColumns>(
+  name: string,
+  columns: S,
+): TableSchema<S> {
+  return { name, columns };
+}

--- a/sdk/src/query/types.ts
+++ b/sdk/src/query/types.ts
@@ -1,0 +1,46 @@
+/**
+ * TypeScript types for query builder payloads.
+ */
+
+/** Filter operator types. */
+export type FilterOp = "eq" | "gt" | "lt" | "gte" | "lte" | "in";
+
+/** A single filter clause. */
+export interface FilterClause {
+  column: string;
+  op: FilterOp;
+  value: unknown;
+}
+
+/** Order direction. */
+export type OrderDirection = "asc" | "desc";
+
+/** Query modifiers (limit, offset, order). */
+export interface QueryModifiers {
+  limit?: number;
+  offset?: number;
+  order?: { column: string; direction: OrderDirection };
+}
+
+/** SELECT query payload. */
+export interface SelectPayload {
+  columns: string[] | "*";
+  filters: FilterClause[];
+  modifiers: QueryModifiers;
+}
+
+/** INSERT query payload. */
+export interface InsertPayload {
+  rows: Record<string, unknown>[];
+}
+
+/** UPDATE query payload. */
+export interface UpdatePayload {
+  values: Record<string, unknown>;
+  filters: FilterClause[];
+}
+
+/** DELETE query payload. */
+export interface DeletePayload {
+  filters: FilterClause[];
+}

--- a/sdk/tests/unit/builder.test.ts
+++ b/sdk/tests/unit/builder.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { column, defineTableSchema } from "../../src/query/schema.js";
+import { QueryBuilder } from "../../src/query/builder.js";
+import { HttpClient } from "../../src/client/http.js";
+
+const usersSchema = defineTableSchema("users", {
+  id: column.uuid().primaryKey(),
+  email: column.text().sensitive("searchable"),
+  name: column.text().sensitive("private"),
+  age: column.integer(),
+  active: column.boolean(),
+});
+
+function createMockHttp(): HttpClient {
+  return new HttpClient("http://localhost:3000", "pqdb_anon_test123");
+}
+
+describe("QueryBuilder.select", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let http: HttpClient;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [{ id: "1", email: "a@b.com", name: "Alice", age: 30, active: true }],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    http = createMockHttp();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("builds a SELECT payload with no columns (select all)", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    const { data, error } = await builder.select().execute();
+
+    expect(error).toBeNull();
+    expect(data).toEqual([{ id: "1", email: "a@b.com", name: "Alice", age: 30, active: true }]);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:3000/v1/db/users/select");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string);
+    expect(body.columns).toBe("*");
+    expect(body.filters).toEqual([]);
+    expect(body.modifiers).toEqual({});
+  });
+
+  it("builds a SELECT payload with specific columns", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder.select("id", "email").execute();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.columns).toEqual(["id", "email"]);
+  });
+
+  it("chains .eq() filter", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder.select().eq("age", 25).execute();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.filters).toEqual([{ column: "age", op: "eq", value: 25 }]);
+  });
+
+  it("chains .gt() filter", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder.select().gt("age", 18).execute();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.filters).toEqual([{ column: "age", op: "gt", value: 18 }]);
+  });
+
+  it("chains .lt() filter", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder.select().lt("age", 65).execute();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.filters).toEqual([{ column: "age", op: "lt", value: 65 }]);
+  });
+
+  it("chains .gte() filter", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder.select().gte("age", 21).execute();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.filters).toEqual([{ column: "age", op: "gte", value: 21 }]);
+  });
+
+  it("chains .lte() filter", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder.select().lte("age", 100).execute();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.filters).toEqual([{ column: "age", op: "lte", value: 100 }]);
+  });
+
+  it("chains .in() filter", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder.select().in("age", [25, 30, 35]).execute();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.filters).toEqual([{ column: "age", op: "in", value: [25, 30, 35] }]);
+  });
+
+  it("chains multiple filters", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder.select().gte("age", 18).lte("age", 65).eq("active", true).execute();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.filters).toEqual([
+      { column: "age", op: "gte", value: 18 },
+      { column: "age", op: "lte", value: 65 },
+      { column: "active", op: "eq", value: true },
+    ]);
+  });
+
+  it("chains .limit() modifier", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder.select().limit(10).execute();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.modifiers.limit).toBe(10);
+  });
+
+  it("chains .offset() modifier", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder.select().offset(20).execute();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.modifiers.offset).toBe(20);
+  });
+
+  it("chains .order() modifier", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder.select().order("age", "desc").execute();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.modifiers.order).toEqual({ column: "age", direction: "desc" });
+  });
+
+  it("chains filters and modifiers together", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder.select().eq("active", true).order("age", "asc").limit(5).offset(0).execute();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.filters).toEqual([{ column: "active", op: "eq", value: true }]);
+    expect(body.modifiers).toEqual({
+      order: { column: "age", direction: "asc" },
+      limit: 5,
+      offset: 0,
+    });
+  });
+});
+
+describe("QueryBuilder.insert", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let http: HttpClient;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [{ id: "1", email: "a@b.com", name: "Alice", age: 30, active: true }],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    http = createMockHttp();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("builds an INSERT payload with a single row", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder
+      .insert([{ id: "1", email: "a@b.com", name: "Alice", age: 30, active: true }])
+      .execute();
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:3000/v1/db/users/insert");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string);
+    expect(body.rows).toEqual([
+      { id: "1", email: "a@b.com", name: "Alice", age: 30, active: true },
+    ]);
+  });
+
+  it("builds an INSERT payload with multiple rows", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder
+      .insert([
+        { id: "1", email: "a@b.com", name: "Alice", age: 30, active: true },
+        { id: "2", email: "b@b.com", name: "Bob", age: 25, active: false },
+      ])
+      .execute();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.rows).toHaveLength(2);
+  });
+});
+
+describe("QueryBuilder.update", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let http: HttpClient;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [{ id: "1", email: "a@b.com", name: "Alice", age: 31, active: true }],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    http = createMockHttp();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("builds an UPDATE payload with values and filters", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder.update({ age: 31 }).eq("id", "1").execute();
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:3000/v1/db/users/update");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string);
+    expect(body.values).toEqual({ age: 31 });
+    expect(body.filters).toEqual([{ column: "id", op: "eq", value: "1" }]);
+  });
+
+  it("builds an UPDATE payload with no filters", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder.update({ active: false }).execute();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.values).toEqual({ active: false });
+    expect(body.filters).toEqual([]);
+  });
+});
+
+describe("QueryBuilder.delete", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let http: HttpClient;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [{ id: "1", email: "a@b.com", name: "Alice", age: 30, active: true }],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    http = createMockHttp();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("builds a DELETE payload with filters", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder.delete().eq("id", "1").execute();
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:3000/v1/db/users/delete");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string);
+    expect(body.filters).toEqual([{ column: "id", op: "eq", value: "1" }]);
+  });
+
+  it("builds a DELETE payload with no filters (delete all)", async () => {
+    const builder = new QueryBuilder(http, usersSchema);
+    await builder.delete().execute();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.filters).toEqual([]);
+  });
+});
+
+describe("QueryBuilder error handling", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let http: HttpClient;
+
+  beforeEach(() => {
+    http = createMockHttp();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns { data: null, error } on HTTP error", async () => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      json: async () => ({ detail: "Invalid query" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const builder = new QueryBuilder(http, usersSchema);
+    const { data, error } = await builder.select().execute();
+
+    expect(data).toBeNull();
+    expect(error).not.toBeNull();
+    expect(error!.code).toBe("HTTP_400");
+    expect(error!.message).toBe("Invalid query");
+  });
+
+  it("returns { data: null, error } on network error", async () => {
+    fetchMock = vi.fn().mockRejectedValue(new Error("Connection refused"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const builder = new QueryBuilder(http, usersSchema);
+    const { data, error } = await builder.select().execute();
+
+    expect(data).toBeNull();
+    expect(error).not.toBeNull();
+    expect(error!.code).toBe("NETWORK_ERROR");
+  });
+});

--- a/sdk/tests/unit/client-query.test.ts
+++ b/sdk/tests/unit/client-query.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createClient } from "../../src/client/index.js";
+import { column } from "../../src/query/schema.js";
+
+describe("client.defineTable", () => {
+  it("registers a table and returns a TableSchema", () => {
+    const client = createClient("http://localhost:3000", "pqdb_anon_test123");
+    const users = client.defineTable("users", {
+      id: column.uuid().primaryKey(),
+      email: column.text().sensitive("searchable"),
+      age: column.integer(),
+    });
+
+    expect(users.name).toBe("users");
+    expect(users.columns.id.type).toBe("uuid");
+    expect(users.columns.email.sensitivity).toBe("searchable");
+    expect(users.columns.age.type).toBe("integer");
+  });
+});
+
+describe("client.from", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [{ id: "1", email: "a@b.com", age: 30 }],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns a QueryBuilder for the given table schema", async () => {
+    const client = createClient("http://localhost:3000", "pqdb_anon_test123");
+    const users = client.defineTable("users", {
+      id: column.uuid().primaryKey(),
+      email: column.text().sensitive("searchable"),
+      age: column.integer(),
+    });
+
+    const { data, error } = await client.from(users).select().execute();
+
+    expect(error).toBeNull();
+    expect(data).toEqual([{ id: "1", email: "a@b.com", age: 30 }]);
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:3000/v1/db/users/select");
+  });
+
+  it("sends the apikey header on query requests", async () => {
+    const client = createClient("http://localhost:3000", "pqdb_anon_mykey");
+    const users = client.defineTable("users", {
+      id: column.uuid().primaryKey(),
+      age: column.integer(),
+    });
+
+    await client.from(users).select().execute();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["apikey"]).toBe("pqdb_anon_mykey");
+  });
+
+  it("allows chaining filters through from()", async () => {
+    const client = createClient("http://localhost:3000", "pqdb_anon_test123");
+    const users = client.defineTable("users", {
+      id: column.uuid().primaryKey(),
+      age: column.integer(),
+    });
+
+    await client.from(users).select().eq("age", 25).limit(10).execute();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.filters).toEqual([{ column: "age", op: "eq", value: 25 }]);
+    expect(body.modifiers.limit).toBe(10);
+  });
+});

--- a/sdk/tests/unit/schema.test.ts
+++ b/sdk/tests/unit/schema.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { column, defineTableSchema } from "../../src/query/schema.js";
+
+describe("column helpers", () => {
+  it("column.uuid() creates a uuid column definition", () => {
+    const col = column.uuid();
+    expect(col.type).toBe("uuid");
+    expect(col.sensitivity).toBe("plain");
+    expect(col.isPrimaryKey).toBe(false);
+  });
+
+  it("column.text() creates a text column definition", () => {
+    const col = column.text();
+    expect(col.type).toBe("text");
+    expect(col.sensitivity).toBe("plain");
+  });
+
+  it("column.integer() creates an integer column definition", () => {
+    const col = column.integer();
+    expect(col.type).toBe("integer");
+    expect(col.sensitivity).toBe("plain");
+  });
+
+  it("column.timestamp() creates a timestamp column definition", () => {
+    const col = column.timestamp();
+    expect(col.type).toBe("timestamp");
+    expect(col.sensitivity).toBe("plain");
+  });
+
+  it("column.boolean() creates a boolean column definition", () => {
+    const col = column.boolean();
+    expect(col.type).toBe("boolean");
+    expect(col.sensitivity).toBe("plain");
+  });
+
+  it("column.vector(dimensions) creates a vector column definition", () => {
+    const col = column.vector(768);
+    expect(col.type).toBe("vector");
+    expect(col.dimensions).toBe(768);
+    expect(col.sensitivity).toBe("plain");
+  });
+});
+
+describe("sensitivity decorator", () => {
+  it(".sensitive('searchable') sets sensitivity to searchable", () => {
+    const col = column.text().sensitive("searchable");
+    expect(col.sensitivity).toBe("searchable");
+  });
+
+  it(".sensitive('private') sets sensitivity to private", () => {
+    const col = column.text().sensitive("private");
+    expect(col.sensitivity).toBe("private");
+  });
+
+  it("chaining sensitive returns a new ColumnDef (immutable)", () => {
+    const base = column.text();
+    const sensitive = base.sensitive("searchable");
+    expect(base.sensitivity).toBe("plain");
+    expect(sensitive.sensitivity).toBe("searchable");
+  });
+});
+
+describe("primaryKey chain", () => {
+  it(".primaryKey() marks column as primary key", () => {
+    const col = column.uuid().primaryKey();
+    expect(col.isPrimaryKey).toBe(true);
+  });
+
+  it("primaryKey returns a new ColumnDef (immutable)", () => {
+    const base = column.uuid();
+    const pk = base.primaryKey();
+    expect(base.isPrimaryKey).toBe(false);
+    expect(pk.isPrimaryKey).toBe(true);
+  });
+
+  it("chaining primaryKey and sensitive together works", () => {
+    const col = column.text().sensitive("searchable").primaryKey();
+    expect(col.sensitivity).toBe("searchable");
+    expect(col.isPrimaryKey).toBe(true);
+  });
+});
+
+describe("defineTableSchema", () => {
+  it("creates a table schema with name and columns", () => {
+    const schema = defineTableSchema("users", {
+      id: column.uuid().primaryKey(),
+      email: column.text().sensitive("searchable"),
+      name: column.text().sensitive("private"),
+      age: column.integer(),
+    });
+
+    expect(schema.name).toBe("users");
+    expect(schema.columns.id.type).toBe("uuid");
+    expect(schema.columns.id.isPrimaryKey).toBe(true);
+    expect(schema.columns.email.sensitivity).toBe("searchable");
+    expect(schema.columns.name.sensitivity).toBe("private");
+    expect(schema.columns.age.type).toBe("integer");
+    expect(schema.columns.age.sensitivity).toBe("plain");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `column` helpers (`uuid()`, `text()`, `integer()`, `timestamp()`, `boolean()`, `vector(n)`) with `.sensitive('searchable'|'private')` and `.primaryKey()` fluent chains
- Add `QueryBuilder` with `.select()`, `.insert()`, `.update()`, `.delete()` operations producing correct POST payloads to `/v1/db/{table}/{op}` endpoints
- Add filter chains (`.eq()`, `.gt()`, `.lt()`, `.gte()`, `.lte()`, `.in()`) and modifier chains (`.limit()`, `.offset()`, `.order()`)
- Wire `defineTable()` and `from()` into `PqdbClient` interface with full TypeScript generic inference (`InferRow<S>`)
- All query execution returns `{ data, error }` — never throws

## Test plan

- [x] 13 unit tests for column helpers (types, sensitivity, primaryKey, immutability)
- [x] 21 unit tests for QueryBuilder (select/insert/update/delete payloads, all filters, all modifiers, error handling)
- [x] 4 integration tests for client.defineTable() and client.from() wiring
- [x] `tsc --noEmit` passes with zero errors
- [x] `tsup` production build succeeds (ESM + CJS + DTS)
- [x] All 67 SDK tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)