### PR TITLE
[US-013] Schema introspection endpoint

### DIFF
--- a/backend/src/pqdb_api/routes/db.py
+++ b/backend/src/pqdb_api/routes/db.py
@@ -46,10 +46,7 @@ class ColumnSchema(BaseModel):
     @classmethod
     def validate_sensitivity(cls, v: str) -> str:
         if v not in ("plain", "private", "searchable"):
-            msg = (
-                "sensitivity must be 'plain', "
-                "'private', or 'searchable'"
-            )
+            msg = "sensitivity must be 'plain', 'private', or 'searchable'"
             raise ValueError(msg)
         return v
 
@@ -89,23 +86,23 @@ async def create_table_endpoint(
                 ColumnDefinition(
                     name=c.name,
                     data_type=c.data_type,
-                    sensitivity=cast(
-                        Sensitivity, c.sensitivity
-                    ),
+                    sensitivity=cast(Sensitivity, c.sensitivity),
                 )
                 for c in body.columns
             ],
         )
     except ValueError as exc:
         raise HTTPException(
-            status_code=400, detail=str(exc),
+            status_code=400,
+            detail=str(exc),
         ) from exc
 
     try:
         result = await create_table(session, table_def)
     except ValueError as exc:
         raise HTTPException(
-            status_code=409, detail=str(exc),
+            status_code=409,
+            detail=str(exc),
         ) from exc
 
     return result
@@ -130,7 +127,8 @@ async def get_table_endpoint(
         result = await get_table(session, table_name)
     except ValueError as exc:
         raise HTTPException(
-            status_code=400, detail=str(exc),
+            status_code=400,
+            detail=str(exc),
         ) from exc
 
     if result is None:
@@ -159,11 +157,13 @@ async def introspect_table_endpoint(
     """Introspect a single table with queryable info."""
     try:
         result = await introspect_table(
-            session, table_name,
+            session,
+            table_name,
         )
     except ValueError as exc:
         raise HTTPException(
-            status_code=400, detail=str(exc),
+            status_code=400,
+            detail=str(exc),
         ) from exc
 
     if result is None:

--- a/backend/src/pqdb_api/services/schema_engine.py
+++ b/backend/src/pqdb_api/services/schema_engine.py
@@ -389,7 +389,13 @@ async def _get_table_metadata(
 
 
 _PLAIN_OPERATIONS: list[str] = [
-    "eq", "gt", "lt", "gte", "lte", "in", "between",
+    "eq",
+    "gt",
+    "lt",
+    "gte",
+    "lte",
+    "in",
+    "between",
 ]
 _SEARCHABLE_OPERATIONS: list[str] = ["eq", "in"]
 
@@ -415,9 +421,7 @@ def build_introspection_column(
         result["operations"] = list(_SEARCHABLE_OPERATIONS)
     else:  # private
         result["queryable"] = False
-        result["note"] = (
-            "retrieve only \u2014 no server-side filtering"
-        )
+        result["note"] = "retrieve only \u2014 no server-side filtering"
     return result
 
 
@@ -432,14 +436,18 @@ def build_introspection_table(
     """
     introspection_columns: list[dict[str, object]] = []
     summary: dict[str, int] = {
-        "searchable": 0, "private": 0, "plain": 0,
+        "searchable": 0,
+        "private": 0,
+        "plain": 0,
     }
     for col in columns:
         sensitivity = col["sensitivity"]
         summary[sensitivity] = summary.get(sensitivity, 0) + 1
         introspection_columns.append(
             build_introspection_column(
-                col["name"], col["data_type"], sensitivity,
+                col["name"],
+                col["data_type"],
+                sensitivity,
             )
         )
     return {
@@ -461,7 +469,8 @@ async def introspect_all_tables(
     tables: list[dict[str, object]] = []
     for name in table_names:
         table_result = await session.execute(
-            _SQL_TABLE_COLUMNS, {"name": name},
+            _SQL_TABLE_COLUMNS,
+            {"name": name},
         )
         rows = table_result.fetchall()
         columns = [
@@ -472,9 +481,7 @@ async def introspect_all_tables(
             }
             for r in rows
         ]
-        tables.append(
-            build_introspection_table(name, columns)
-        )
+        tables.append(build_introspection_table(name, columns))
 
     return tables
 
@@ -487,7 +494,8 @@ async def introspect_table(
     await ensure_metadata_table(session)
 
     result = await session.execute(
-        _SQL_TABLE_COLUMNS, {"name": table_name},
+        _SQL_TABLE_COLUMNS,
+        {"name": table_name},
     )
     rows = result.fetchall()
     if not rows:

--- a/backend/tests/integration/test_introspection.py
+++ b/backend/tests/integration/test_introspection.py
@@ -34,7 +34,8 @@ def _create_test_app() -> FastAPI:
 
     @event.listens_for(engine.sync_engine, "connect")
     def _set_sqlite_pragma(  # type: ignore[no-untyped-def]
-        dbapi_conn, connection_record,
+        dbapi_conn,
+        connection_record,
     ):
         cursor = dbapi_conn.cursor()
         cursor.execute("PRAGMA foreign_keys=ON")
@@ -53,9 +54,7 @@ def _create_test_app() -> FastAPI:
     app = FastAPI()
     app.include_router(health_router)
     app.include_router(db_router)
-    app.dependency_overrides[get_project_session] = (
-        _override
-    )
+    app.dependency_overrides[get_project_session] = _override
     return app
 
 
@@ -67,7 +66,8 @@ def client() -> Iterator[TestClient]:
 
 
 def _create_mixed_table(
-    client: TestClient, name: str = "users",
+    client: TestClient,
+    name: str = "users",
 ) -> None:
     """Helper to create a table with mixed sensitivity."""
     client.post(
@@ -99,14 +99,16 @@ class TestIntrospectRouteExists:
     """Verify introspection routes are registered."""
 
     def test_introspect_all_route_exists(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         resp = client.get("/v1/db/introspect")
         assert resp.status_code != 404
         assert resp.status_code != 405
 
     def test_introspect_table_route_exists(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         resp = client.get("/v1/db/introspect/anything")
         assert resp.status_code != 405
@@ -116,7 +118,8 @@ class TestIntrospectAllEmpty:
     """Test GET /v1/db/introspect with no tables."""
 
     def test_returns_empty_tables_list(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         resp = client.get("/v1/db/introspect")
         assert resp.status_code == 200
@@ -127,7 +130,8 @@ class TestIntrospectAllWithTables:
     """Test GET /v1/db/introspect after creating tables."""
 
     def test_returns_created_tables(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         _create_mixed_table(client)
         resp = client.get("/v1/db/introspect")
@@ -137,15 +141,14 @@ class TestIntrospectAllWithTables:
         assert data["tables"][0]["name"] == "users"
 
     def test_returns_correct_column_metadata(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         _create_mixed_table(client, "profiles")
         resp = client.get("/v1/db/introspect")
         data = resp.json()
         table = data["tables"][0]
-        col_map = {
-            c["name"]: c for c in table["columns"]
-        }
+        col_map = {c["name"]: c for c in table["columns"]}
 
         # plain column
         assert col_map["display_name"]["type"] == "text"
@@ -153,8 +156,13 @@ class TestIntrospectAllWithTables:
         assert s == "plain"
         assert col_map["display_name"]["queryable"] is True
         assert col_map["display_name"]["operations"] == [
-            "eq", "gt", "lt", "gte", "lte",
-            "in", "between",
+            "eq",
+            "gt",
+            "lt",
+            "gte",
+            "lte",
+            "in",
+            "between",
         ]
 
         # searchable column
@@ -162,7 +170,8 @@ class TestIntrospectAllWithTables:
         assert col_map["email"]["sensitivity"] == "searchable"
         assert col_map["email"]["queryable"] is True
         assert col_map["email"]["operations"] == [
-            "eq", "in",
+            "eq",
+            "in",
         ]
 
         # private column
@@ -175,7 +184,8 @@ class TestIntrospectAllWithTables:
         )
 
     def test_returns_sensitivity_summary(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         client.post(
             "/v1/db/tables",
@@ -211,7 +221,8 @@ class TestIntrospectAllWithTables:
         }
 
     def test_introspect_multiple_tables(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         client.post(
             "/v1/db/tables",
@@ -243,7 +254,8 @@ class TestIntrospectSingleTable:
     """Test GET /v1/db/introspect/{table_name}."""
 
     def test_introspect_existing_table(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         _create_mixed_table(client, "target")
         resp = client.get("/v1/db/introspect/target")
@@ -254,34 +266,41 @@ class TestIntrospectSingleTable:
         assert "sensitivity_summary" in data
 
     def test_nonexistent_table_returns_404(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         resp = client.get("/v1/db/introspect/missing")
         assert resp.status_code == 404
 
     def test_returns_full_metadata(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         _create_mixed_table(client, "fullmeta")
         resp = client.get("/v1/db/introspect/fullmeta")
         data = resp.json()
-        col_map = {
-            c["name"]: c for c in data["columns"]
-        }
+        col_map = {c["name"]: c for c in data["columns"]}
 
         assert col_map["display_name"]["queryable"] is True
         assert col_map["display_name"]["operations"] == [
-            "eq", "gt", "lt", "gte", "lte",
-            "in", "between",
+            "eq",
+            "gt",
+            "lt",
+            "gte",
+            "lte",
+            "in",
+            "between",
         ]
         assert col_map["ssn"]["queryable"] is False
         assert col_map["email"]["queryable"] is True
         assert col_map["email"]["operations"] == [
-            "eq", "in",
+            "eq",
+            "in",
         ]
 
     def test_sensitivity_summary(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         client.post(
             "/v1/db/tables",
@@ -316,7 +335,8 @@ class TestIntrospectSingleTable:
         }
 
     def test_invalid_table_name_returns_400(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         resp = client.get("/v1/db/introspect/1invalid")
         assert resp.status_code == 400
@@ -326,7 +346,8 @@ class TestHealthStillWorks:
     """Health check still works with introspect routes."""
 
     def test_health_returns_200(
-        self, client: TestClient,
+        self,
+        client: TestClient,
     ) -> None:
         resp = client.get("/health")
         assert resp.status_code == 200

--- a/backend/tests/unit/test_introspection.py
+++ b/backend/tests/unit/test_introspection.py
@@ -19,68 +19,91 @@ class TestBuildIntrospectionColumn:
 
     def test_plain_column_is_queryable(self) -> None:
         col = build_introspection_column(
-            "age", "integer", "plain",
+            "age",
+            "integer",
+            "plain",
         )
         assert col["queryable"] is True
 
     def test_plain_column_operations(self) -> None:
         col = build_introspection_column(
-            "age", "integer", "plain",
+            "age",
+            "integer",
+            "plain",
         )
         assert col["operations"] == [
-            "eq", "gt", "lt", "gte", "lte",
-            "in", "between",
+            "eq",
+            "gt",
+            "lt",
+            "gte",
+            "lte",
+            "in",
+            "between",
         ]
 
     def test_plain_column_has_no_note(self) -> None:
         col = build_introspection_column(
-            "age", "integer", "plain",
+            "age",
+            "integer",
+            "plain",
         )
         assert "note" not in col
 
     def test_searchable_column_is_queryable(self) -> None:
         col = build_introspection_column(
-            "email", "text", "searchable",
+            "email",
+            "text",
+            "searchable",
         )
         assert col["queryable"] is True
 
     def test_searchable_column_operations(self) -> None:
         col = build_introspection_column(
-            "email", "text", "searchable",
+            "email",
+            "text",
+            "searchable",
         )
         assert col["operations"] == ["eq", "in"]
 
     def test_searchable_column_has_no_note(self) -> None:
         col = build_introspection_column(
-            "email", "text", "searchable",
+            "email",
+            "text",
+            "searchable",
         )
         assert "note" not in col
 
     def test_private_column_not_queryable(self) -> None:
         col = build_introspection_column(
-            "ssn", "text", "private",
+            "ssn",
+            "text",
+            "private",
         )
         assert col["queryable"] is False
 
     def test_private_column_no_operations(self) -> None:
         col = build_introspection_column(
-            "ssn", "text", "private",
+            "ssn",
+            "text",
+            "private",
         )
         assert "operations" not in col
 
     def test_private_column_has_note(self) -> None:
         col = build_introspection_column(
-            "ssn", "text", "private",
+            "ssn",
+            "text",
+            "private",
         )
-        assert col["note"] == (
-            "retrieve only \u2014 no server-side filtering"
-        )
+        assert col["note"] == ("retrieve only \u2014 no server-side filtering")
 
     def test_column_includes_name_type_sensitivity(
         self,
     ) -> None:
         col = build_introspection_column(
-            "email", "text", "searchable",
+            "email",
+            "text",
+            "searchable",
         )
         assert col["name"] == "email"
         assert col["type"] == "text"
@@ -114,9 +137,7 @@ class TestBuildIntrospectionTable:
             "private": 0,
             "plain": 1,
         }
-        cols: list[dict[str, Any]] = (
-            result["columns"]  # type: ignore[assignment]
-        )
+        cols: list[dict[str, Any]] = result["columns"]  # type: ignore[assignment]
         assert len(cols) == 1
         assert cols[0]["queryable"] is True
 
@@ -139,7 +160,8 @@ class TestBuildIntrospectionTable:
             },
         ]
         result = build_introspection_table(
-            "profiles", columns,
+            "profiles",
+            columns,
         )
         assert result["sensitivity_summary"] == {
             "searchable": 1,
@@ -191,15 +213,14 @@ class TestBuildIntrospectionTable:
             },
         ]
         result = build_introspection_table("users", columns)
-        cols: list[dict[str, Any]] = (
-            result["columns"]  # type: ignore[assignment]
-        )
+        cols: list[dict[str, Any]] = result["columns"]  # type: ignore[assignment]
         col_map = {c["name"]: c for c in cols}
 
         # searchable
         assert col_map["email"]["queryable"] is True
         assert col_map["email"]["operations"] == [
-            "eq", "in",
+            "eq",
+            "in",
         ]
 
         # private
@@ -211,6 +232,11 @@ class TestBuildIntrospectionTable:
         # plain
         assert col_map["age"]["queryable"] is True
         assert col_map["age"]["operations"] == [
-            "eq", "gt", "lt", "gte", "lte",
-            "in", "between",
+            "eq",
+            "gt",
+            "lt",
+            "gte",
+            "lte",
+            "in",
+            "between",
         ]


### PR DESCRIPTION
## Summary
- Add `GET /v1/db/introspect` — returns all tables with enriched column metadata (queryable flag, valid operations, sensitivity summary)
- Add `GET /v1/db/introspect/{table}` — returns single table introspection detail
- Per-column metadata maps sensitivity to queryable/operations: searchable (eq, in), private (retrieve only), plain (eq, gt, lt, gte, lte, in, between)
- Each table response includes `sensitivity_summary` with counts per sensitivity level

## Test plan
- [x] 15 unit tests for `build_introspection_column` and `build_introspection_table` pure functions
- [x] 13 integration tests booting real FastAPI app with SQLite, verifying introspection after table creation
- [x] Route existence verified (non-404/405)
- [x] Empty project returns `{"tables": []}`
- [x] Mixed sensitivity columns return correct queryable/operations/note fields
- [x] Sensitivity summary counts verified
- [x] 404 for nonexistent table, 400 for invalid table name
- [x] Health check unaffected
- [x] `mypy --strict` passes (0 errors)
- [x] `ruff check` passes (0 errors)
- [x] Full test suite: 305 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)