### PR TITLE
feat(sdk): add client.auth.users.* end-user auth methods (US-027)

### DIFF
--- a/sdk/src/client/auth.ts
+++ b/sdk/src/client/auth.ts
@@ -4,6 +4,7 @@
  * Tokens are stored in memory (not localStorage) for SSR safety.
  */
 import type { HttpClient } from "./http.js";
+import { UserAuthClient } from "./user-auth.js";
 import type {
   AuthCredentials,
   AuthTokens,
@@ -13,9 +14,11 @@ import type {
 
 export class AuthClient {
   private readonly http: HttpClient;
+  readonly users: UserAuthClient;
 
   constructor(http: HttpClient) {
     this.http = http;
+    this.users = new UserAuthClient(http);
 
     // Register the refresh handler so HTTP client can auto-refresh on 401
     this.http.setRefreshHandler(() => this.tryRefresh());

--- a/sdk/src/client/http.ts
+++ b/sdk/src/client/http.ts
@@ -48,12 +48,15 @@ export class HttpClient {
   async request<T>(options: HttpRequestOptions): Promise<PqdbResponse<T>> {
     const headers: Record<string, string> = {
       apikey: this.apiKey,
-      ...options.headers,
     };
 
-    if (this.accessToken) {
+    // Apply default developer token only if not explicitly overridden
+    if (this.accessToken && !options.headers?.["Authorization"]) {
       headers["Authorization"] = `Bearer ${this.accessToken}`;
     }
+
+    // Spread caller-provided headers last so they take precedence
+    Object.assign(headers, options.headers);
 
     if (options.body !== undefined) {
       headers["Content-Type"] = "application/json";
@@ -78,7 +81,7 @@ export class HttpClient {
       };
     }
 
-    if (response.status === 401 && this.refreshToken && this.onRefreshNeeded) {
+    if (response.status === 401 && !options.skipRefresh && this.refreshToken && this.onRefreshNeeded) {
       const refreshed = await this.onRefreshNeeded();
       if (refreshed) {
         return this.request(options);

--- a/sdk/src/client/types.ts
+++ b/sdk/src/client/types.ts
@@ -51,10 +51,37 @@ export type PqdbResponse<T> = SuccessResponse<T> | ErrorResponse;
 /** Auth method response type. */
 export type AuthResponse = PqdbResponse<AuthTokens>;
 
+/** User profile returned by the backend. */
+export interface UserProfile {
+  id: string;
+  email: string;
+  role: string;
+  email_verified: boolean;
+  metadata: Record<string, unknown>;
+}
+
+/** User auth response (signup/login) — includes user profile and tokens. */
+export interface UserAuthTokens {
+  user: UserProfile;
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+}
+
+/** User auth method response type. */
+export type UserAuthResponse = PqdbResponse<UserAuthTokens>;
+
+/** Data for updating user metadata. */
+export interface UserMetadataUpdate {
+  metadata: Record<string, unknown>;
+}
+
 /** Options for HTTP requests. */
 export interface HttpRequestOptions {
   method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
   path: string;
   body?: unknown;
   headers?: Record<string, string>;
+  /** Skip the automatic 401 refresh handler (used by UserAuthClient which manages its own refresh). */
+  skipRefresh?: boolean;
 }

--- a/sdk/src/client/user-auth.ts
+++ b/sdk/src/client/user-auth.ts
@@ -1,0 +1,147 @@
+/**
+ * UserAuthClient handles end-user authentication.
+ *
+ * User tokens are stored separately from developer tokens so both
+ * auth states can coexist in the same client instance.
+ *
+ * User auth requests go through the same HttpClient but use a dedicated
+ * internal HTTP helper that manages its own Authorization header.
+ */
+import type { HttpClient } from "./http.js";
+import type {
+  AuthCredentials,
+  UserAuthTokens,
+  UserAuthResponse,
+  UserProfile,
+  UserMetadataUpdate,
+  RefreshTokens,
+  PqdbResponse,
+} from "./types.js";
+
+export class UserAuthClient {
+  private readonly http: HttpClient;
+  private userAccessToken: string | null = null;
+  private userRefreshToken: string | null = null;
+
+  constructor(http: HttpClient) {
+    this.http = http;
+  }
+
+  async signUp(credentials: AuthCredentials): Promise<UserAuthResponse> {
+    const result = await this.http.request<UserAuthTokens>({
+      method: "POST",
+      path: "/v1/auth/users/signup",
+      body: credentials,
+    });
+
+    if (result.data) {
+      this.userAccessToken = result.data.access_token;
+      this.userRefreshToken = result.data.refresh_token;
+    }
+
+    return result;
+  }
+
+  async signIn(credentials: AuthCredentials): Promise<UserAuthResponse> {
+    const result = await this.http.request<UserAuthTokens>({
+      method: "POST",
+      path: "/v1/auth/users/login",
+      body: credentials,
+    });
+
+    if (result.data) {
+      this.userAccessToken = result.data.access_token;
+      this.userRefreshToken = result.data.refresh_token;
+    }
+
+    return result;
+  }
+
+  async signOut(): Promise<PqdbResponse<{ message: string }>> {
+    const result = await this.userRequest<{ message: string }>({
+      method: "POST",
+      path: "/v1/auth/users/logout",
+      body: { refresh_token: this.userRefreshToken },
+    });
+
+    // Clear tokens regardless of server response
+    this.userAccessToken = null;
+    this.userRefreshToken = null;
+
+    return result;
+  }
+
+  async getUser(): Promise<PqdbResponse<UserProfile>> {
+    return this.userRequest<UserProfile>({
+      method: "GET",
+      path: "/v1/auth/users/me",
+    });
+  }
+
+  async updateUser(data: UserMetadataUpdate): Promise<PqdbResponse<UserProfile>> {
+    return this.userRequest<UserProfile>({
+      method: "PUT",
+      path: "/v1/auth/users/me",
+      body: data,
+    });
+  }
+
+  /**
+   * Make an HTTP request with user-level Authorization header.
+   *
+   * Handles auto-refresh: on 401, attempts to use the user refresh
+   * token to get a new access token, then retries the original request.
+   */
+  private async userRequest<T>(options: {
+    method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+    path: string;
+    body?: unknown;
+  }): Promise<PqdbResponse<T>> {
+    const headers: Record<string, string> = {};
+    if (this.userAccessToken) {
+      headers["Authorization"] = `Bearer ${this.userAccessToken}`;
+    }
+
+    const result = await this.http.request<T>({
+      ...options,
+      headers,
+      skipRefresh: true,
+    });
+
+    // Handle 401 with user-level auto-refresh
+    if (result.error?.code === "HTTP_401" && this.userRefreshToken) {
+      const refreshed = await this.tryRefresh();
+      if (refreshed) {
+        // Retry with new token
+        const retryHeaders: Record<string, string> = {};
+        if (this.userAccessToken) {
+          retryHeaders["Authorization"] = `Bearer ${this.userAccessToken}`;
+        }
+        return this.http.request<T>({
+          ...options,
+          headers: retryHeaders,
+          skipRefresh: true,
+        });
+      }
+    }
+
+    return result;
+  }
+
+  private async tryRefresh(): Promise<boolean> {
+    if (!this.userRefreshToken) return false;
+
+    const result = await this.http.request<RefreshTokens>({
+      method: "POST",
+      path: "/v1/auth/users/refresh",
+      body: { refresh_token: this.userRefreshToken },
+    });
+
+    if (result.data) {
+      this.userAccessToken = result.data.access_token;
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -12,10 +12,15 @@ export type {
   AuthCredentials,
   AuthTokens,
   AuthResponse,
+  UserProfile,
+  UserAuthTokens,
+  UserAuthResponse,
+  UserMetadataUpdate,
   PqdbError,
   PqdbResponse,
 } from "./client/types.js";
 export { AuthClient } from "./client/auth.js";
+export { UserAuthClient } from "./client/user-auth.js";
 
 // Query builder exports
 export { column, defineTableSchema, ColumnDef } from "./query/schema.js";

--- a/sdk/tests/unit/user-auth.test.ts
+++ b/sdk/tests/unit/user-auth.test.ts
@@ -1,0 +1,539 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createClient } from "../../src/client/index.js";
+
+// Backend response shape for signup/login
+const MOCK_USER_AUTH_RESPONSE = {
+  user: {
+    id: "user-uuid-123",
+    email: "user@test.com",
+    role: "authenticated",
+    email_verified: false,
+    metadata: {},
+  },
+  access_token: "user-access-token",
+  refresh_token: "user-refresh-token",
+  token_type: "bearer",
+};
+
+const MOCK_USER_PROFILE = {
+  id: "user-uuid-123",
+  email: "user@test.com",
+  role: "authenticated",
+  email_verified: false,
+  metadata: {},
+};
+
+function mockFetchOk(body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  });
+}
+
+function mockFetchError(status: number, detail: string) {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status,
+    statusText: "Error",
+    json: async () => ({ detail }),
+  });
+}
+
+describe("UserAuthClient.signUp", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("calls POST /v1/auth/users/signup with email and password", async () => {
+    const fetchMock = mockFetchOk(MOCK_USER_AUTH_RESPONSE);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    await client.auth.users.signUp({ email: "user@test.com", password: "pass123" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:3000/v1/auth/users/signup");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      email: "user@test.com",
+      password: "pass123",
+    });
+  });
+
+  it("returns { data: { user, access_token, refresh_token }, error: null } on success", async () => {
+    vi.stubGlobal("fetch", mockFetchOk(MOCK_USER_AUTH_RESPONSE));
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    const result = await client.auth.users.signUp({
+      email: "user@test.com",
+      password: "pass123",
+    });
+
+    expect(result.data).toEqual(MOCK_USER_AUTH_RESPONSE);
+    expect(result.error).toBeNull();
+  });
+
+  it("stores user tokens after successful signUp", async () => {
+    const fetchMock = mockFetchOk(MOCK_USER_AUTH_RESPONSE);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    await client.auth.users.signUp({ email: "user@test.com", password: "pass123" });
+
+    // Make another request — it should include the user Authorization header
+    await client.auth.users.getUser();
+
+    const [, secondInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    const headers = secondInit.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer user-access-token");
+  });
+
+  it("returns { data: null, error } on failure", async () => {
+    vi.stubGlobal("fetch", mockFetchError(409, "Email already registered"));
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    const result = await client.auth.users.signUp({
+      email: "user@test.com",
+      password: "pass123",
+    });
+
+    expect(result.data).toBeNull();
+    expect(result.error).toEqual({
+      code: "HTTP_409",
+      message: "Email already registered",
+    });
+  });
+});
+
+describe("UserAuthClient.signIn", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("calls POST /v1/auth/users/login with email and password", async () => {
+    const fetchMock = mockFetchOk(MOCK_USER_AUTH_RESPONSE);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    await client.auth.users.signIn({ email: "user@test.com", password: "pass123" });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:3000/v1/auth/users/login");
+    expect(init.method).toBe("POST");
+  });
+
+  it("returns { data, error: null } on success", async () => {
+    vi.stubGlobal("fetch", mockFetchOk(MOCK_USER_AUTH_RESPONSE));
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    const result = await client.auth.users.signIn({
+      email: "user@test.com",
+      password: "pass123",
+    });
+
+    expect(result.data).toEqual(MOCK_USER_AUTH_RESPONSE);
+    expect(result.error).toBeNull();
+  });
+
+  it("stores user tokens after successful signIn", async () => {
+    const fetchMock = mockFetchOk(MOCK_USER_AUTH_RESPONSE);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    await client.auth.users.signIn({ email: "user@test.com", password: "pass123" });
+
+    // Next request should include the Bearer token
+    await client.auth.users.getUser();
+
+    const [, secondInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    const headers = secondInit.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer user-access-token");
+  });
+
+  it("returns error on invalid credentials", async () => {
+    vi.stubGlobal("fetch", mockFetchError(401, "Invalid credentials"));
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    const result = await client.auth.users.signIn({
+      email: "user@test.com",
+      password: "wrong",
+    });
+
+    expect(result.data).toBeNull();
+    expect(result.error?.code).toBe("HTTP_401");
+  });
+});
+
+describe("UserAuthClient.signOut", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("calls POST /v1/auth/users/logout with refresh token", async () => {
+    let callCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        // signIn response
+        return { ok: true, status: 200, json: async () => MOCK_USER_AUTH_RESPONSE };
+      }
+      // logout response
+      return { ok: true, status: 200, json: async () => ({ message: "Logged out successfully" }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    await client.auth.users.signIn({ email: "user@test.com", password: "pass123" });
+    await client.auth.users.signOut();
+
+    const [url, init] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(url).toBe("http://localhost:3000/v1/auth/users/logout");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      refresh_token: "user-refresh-token",
+    });
+  });
+
+  it("clears stored user tokens after signOut", async () => {
+    let callCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return { ok: true, status: 200, json: async () => MOCK_USER_AUTH_RESPONSE };
+      }
+      // logout + subsequent getUser
+      return { ok: true, status: 200, json: async () => ({ message: "ok" }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    await client.auth.users.signIn({ email: "user@test.com", password: "pass123" });
+    await client.auth.users.signOut();
+
+    // Next request should NOT include Authorization header
+    await client.auth.users.getUser();
+
+    const [, thirdInit] = fetchMock.mock.calls[2] as [string, RequestInit];
+    const headers = thirdInit.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBeUndefined();
+  });
+
+  it("returns { data, error: null } on success", async () => {
+    let callCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return { ok: true, status: 200, json: async () => MOCK_USER_AUTH_RESPONSE };
+      }
+      return { ok: true, status: 200, json: async () => ({ message: "Logged out successfully" }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    await client.auth.users.signIn({ email: "user@test.com", password: "pass123" });
+    const result = await client.auth.users.signOut();
+
+    expect(result.data).toEqual({ message: "Logged out successfully" });
+    expect(result.error).toBeNull();
+  });
+});
+
+describe("UserAuthClient.getUser", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("calls GET /v1/auth/users/me", async () => {
+    let callCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return { ok: true, status: 200, json: async () => MOCK_USER_AUTH_RESPONSE };
+      }
+      return { ok: true, status: 200, json: async () => MOCK_USER_PROFILE };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    await client.auth.users.signIn({ email: "user@test.com", password: "pass123" });
+    await client.auth.users.getUser();
+
+    const [url, init] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(url).toBe("http://localhost:3000/v1/auth/users/me");
+    expect(init.method).toBe("GET");
+  });
+
+  it("returns user profile data", async () => {
+    let callCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return { ok: true, status: 200, json: async () => MOCK_USER_AUTH_RESPONSE };
+      }
+      return { ok: true, status: 200, json: async () => MOCK_USER_PROFILE };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    await client.auth.users.signIn({ email: "user@test.com", password: "pass123" });
+    const result = await client.auth.users.getUser();
+
+    expect(result.data).toEqual(MOCK_USER_PROFILE);
+    expect(result.error).toBeNull();
+  });
+
+  it("sends Authorization header with user access token", async () => {
+    let callCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return { ok: true, status: 200, json: async () => MOCK_USER_AUTH_RESPONSE };
+      }
+      return { ok: true, status: 200, json: async () => MOCK_USER_PROFILE };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    await client.auth.users.signIn({ email: "user@test.com", password: "pass123" });
+    await client.auth.users.getUser();
+
+    const [, init] = fetchMock.mock.calls[1] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer user-access-token");
+  });
+});
+
+describe("UserAuthClient.updateUser", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("calls PUT /v1/auth/users/me with metadata", async () => {
+    const updatedProfile = { ...MOCK_USER_PROFILE, metadata: { name: "Test" } };
+    let callCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return { ok: true, status: 200, json: async () => MOCK_USER_AUTH_RESPONSE };
+      }
+      return { ok: true, status: 200, json: async () => updatedProfile };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    await client.auth.users.signIn({ email: "user@test.com", password: "pass123" });
+    await client.auth.users.updateUser({ metadata: { name: "Test" } });
+
+    const [url, init] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(url).toBe("http://localhost:3000/v1/auth/users/me");
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(init.body as string)).toEqual({ metadata: { name: "Test" } });
+  });
+
+  it("returns updated user profile", async () => {
+    const updatedProfile = { ...MOCK_USER_PROFILE, metadata: { name: "Test" } };
+    let callCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return { ok: true, status: 200, json: async () => MOCK_USER_AUTH_RESPONSE };
+      }
+      return { ok: true, status: 200, json: async () => updatedProfile };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    await client.auth.users.signIn({ email: "user@test.com", password: "pass123" });
+    const result = await client.auth.users.updateUser({ metadata: { name: "Test" } });
+
+    expect(result.data).toEqual(updatedProfile);
+    expect(result.error).toBeNull();
+  });
+});
+
+describe("User auth token auto-refresh", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("refreshes user token on 401 and retries the request", async () => {
+    let callCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      callCount++;
+      // 1: signIn — succeeds, stores user tokens
+      if (callCount === 1) {
+        return { ok: true, status: 200, json: async () => MOCK_USER_AUTH_RESPONSE };
+      }
+      // 2: getUser — 401 triggers refresh
+      if (callCount === 2) {
+        return {
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          json: async () => ({ detail: "Token expired" }),
+        };
+      }
+      // 3: refresh endpoint
+      if (callCount === 3) {
+        expect(url).toContain("/v1/auth/users/refresh");
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            access_token: "new-user-access-token",
+            token_type: "bearer",
+          }),
+        };
+      }
+      // 4: retry of getUser
+      if (callCount === 4) {
+        return { ok: true, status: 200, json: async () => MOCK_USER_PROFILE };
+      }
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    await client.auth.users.signIn({ email: "user@test.com", password: "pass123" });
+
+    // This triggers 401 -> refresh -> retry
+    const result = await client.auth.users.getUser();
+
+    // signIn(1) + fail(2) + refresh(3) + retry(4)
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(result.data).toEqual(MOCK_USER_PROFILE);
+
+    // Verify the retry used the new access token
+    const [, retryInit] = fetchMock.mock.calls[3] as [string, RequestInit];
+    const headers = retryInit.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer new-user-access-token");
+  });
+
+  it("returns error if user token refresh also fails", async () => {
+    let callCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      callCount++;
+      // 1: signIn succeeds
+      if (callCount === 1) {
+        return { ok: true, status: 200, json: async () => MOCK_USER_AUTH_RESPONSE };
+      }
+      // 2: getUser — 401
+      if (callCount === 2) {
+        return {
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          json: async () => ({ detail: "Token expired" }),
+        };
+      }
+      // 3: refresh — also fails
+      if (callCount === 3) {
+        return {
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          json: async () => ({ detail: "Refresh token expired" }),
+        };
+      }
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    await client.auth.users.signIn({ email: "user@test.com", password: "pass123" });
+
+    const result = await client.auth.users.getUser();
+
+    expect(result.data).toBeNull();
+    expect(result.error?.code).toBe("HTTP_401");
+  });
+});
+
+describe("User auth and developer auth coexistence", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("user auth state is separate from developer auth state", async () => {
+    const DEVELOPER_TOKENS = {
+      access_token: "developer-access-token",
+      refresh_token: "developer-refresh-token",
+      token_type: "bearer",
+    };
+
+    let callCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      callCount++;
+      // 1: developer signIn
+      if (callCount === 1) {
+        return { ok: true, status: 200, json: async () => DEVELOPER_TOKENS };
+      }
+      // 2: user signIn
+      if (callCount === 2) {
+        return { ok: true, status: 200, json: async () => MOCK_USER_AUTH_RESPONSE };
+      }
+      // 3: getUser (should use user token, not developer token)
+      if (callCount === 3) {
+        return { ok: true, status: 200, json: async () => MOCK_USER_PROFILE };
+      }
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+
+    // Developer signs in first
+    await client.auth.signIn({ email: "dev@test.com", password: "devpass" });
+
+    // Then user signs in
+    await client.auth.users.signIn({ email: "user@test.com", password: "pass123" });
+
+    // getUser should use user access token
+    await client.auth.users.getUser();
+
+    const [, thirdInit] = fetchMock.mock.calls[2] as [string, RequestInit];
+    const headers = thirdInit.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer user-access-token");
+  });
+
+  it("user signOut does not affect developer auth", async () => {
+    const DEVELOPER_TOKENS = {
+      access_token: "developer-access-token",
+      refresh_token: "developer-refresh-token",
+      token_type: "bearer",
+    };
+
+    let callCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      callCount++;
+      // 1: developer signIn
+      if (callCount === 1) {
+        return { ok: true, status: 200, json: async () => DEVELOPER_TOKENS };
+      }
+      // 2: user signIn
+      if (callCount === 2) {
+        return { ok: true, status: 200, json: async () => MOCK_USER_AUTH_RESPONSE };
+      }
+      // 3: user signOut
+      if (callCount === 3) {
+        return { ok: true, status: 200, json: async () => ({ message: "Logged out successfully" }) };
+      }
+      // 4: developer signIn again (should still have developer token from earlier)
+      if (callCount === 4) {
+        return { ok: true, status: 200, json: async () => DEVELOPER_TOKENS };
+      }
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+
+    await client.auth.signIn({ email: "dev@test.com", password: "devpass" });
+    await client.auth.users.signIn({ email: "user@test.com", password: "pass123" });
+    await client.auth.users.signOut();
+
+    // Developer auth should still be intact — next developer request should have developer token
+    await client.auth.signIn({ email: "dev@test.com", password: "devpass" });
+
+    const [, fourthInit] = fetchMock.mock.calls[3] as [string, RequestInit];
+    const headers = fourthInit.headers as Record<string, string>;
+    // Developer token should still be sent
+    expect(headers["Authorization"]).toBe("Bearer developer-access-token");
+  });
+});
+
+describe("User auth namespace access", () => {
+  it("client.auth.users is accessible", () => {
+    const client = createClient("http://localhost:3000", "pqdb_anon_key");
+    expect(client.auth.users).toBeDefined();
+    expect(typeof client.auth.users.signUp).toBe("function");
+    expect(typeof client.auth.users.signIn).toBe("function");
+    expect(typeof client.auth.users.signOut).toBe("function");
+    expect(typeof client.auth.users.getUser).toBe("function");
+    expect(typeof client.auth.users.updateUser).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `UserAuthClient` class (`sdk/src/client/user-auth.ts`) with `signUp`, `signIn`, `signOut`, `getUser`, `updateUser` methods
- Wire into existing `AuthClient` as `client.auth.users.*` namespace — user auth state is fully separate from developer auth
- Auto-refresh on 401: when user access token expires, SDK uses user refresh token to get a new one before retrying
- Add `skipRefresh` to `HttpRequestOptions` so user-auth 401s don't trigger developer-level refresh
- Fix `HttpClient.request()` to not override explicitly-passed `Authorization` headers (enables token coexistence)
- Add full TypeScript types: `UserProfile`, `UserAuthTokens`, `UserAuthResponse`, `UserMetadataUpdate`
- 21 new unit tests covering all methods, token storage, auto-refresh, error handling, and dev/user auth coexistence
- All 130 SDK tests pass, typecheck clean, production build succeeds

## Test plan
- [x] `client.auth.users.signUp()` calls POST `/v1/auth/users/signup`, stores tokens, returns `{ data, error }`
- [x] `client.auth.users.signIn()` calls POST `/v1/auth/users/login`, stores tokens
- [x] `client.auth.users.signOut()` calls POST `/v1/auth/users/logout` with refresh token, clears stored tokens
- [x] `client.auth.users.getUser()` calls GET `/v1/auth/users/me` with user Bearer token
- [x] `client.auth.users.updateUser()` calls PUT `/v1/auth/users/me` with metadata
- [x] Token auto-refresh on 401 works (refresh -> retry with new token)
- [x] Failed refresh returns original error
- [x] User auth state is separate from developer auth state
- [x] User signOut does not affect developer auth
- [x] TypeScript typecheck passes
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)