### PR TITLE
US-026: End-user auth middleware

### DIFF
--- a/backend/src/pqdb_api/middleware/user_auth.py
+++ b/backend/src/pqdb_api/middleware/user_auth.py
@@ -1,0 +1,131 @@
+"""End-user JWT auth middleware (FastAPI dependency).
+
+Validates user JWTs (type=user_access) from the Authorization: Bearer header
+on project-scoped requests. Provides an optional UserContext alongside the
+existing ProjectContext.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import uuid
+from typing import Any
+
+import jwt
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
+from fastapi import Depends, HTTPException, Request
+
+from pqdb_api.middleware.api_key import ProjectContext, get_project_context
+from pqdb_api.services.auth import JWT_ALGORITHM
+
+
+@dataclasses.dataclass(frozen=True)
+class UserContext:
+    """Immutable context resolved from a valid end-user JWT."""
+
+    user_id: uuid.UUID
+    project_id: uuid.UUID
+    role: str
+    email_verified: bool
+
+
+def _get_public_key(request: Request) -> Ed25519PublicKey:
+    """Extract Ed25519 public key from app state."""
+    key = request.app.state.jwt_public_key
+    if isinstance(key, Ed25519PublicKey):
+        return key
+    if isinstance(key, (str, bytes)):
+        pem = key.encode() if isinstance(key, str) else key
+        loaded = load_pem_public_key(pem)
+        if not isinstance(loaded, Ed25519PublicKey):
+            raise HTTPException(status_code=500, detail="Invalid JWT key type")
+        return loaded
+    raise HTTPException(status_code=500, detail="JWT public key not configured")
+
+
+def _validate_user_jwt(
+    token: str,
+    public_key: Ed25519PublicKey,
+    *,
+    expected_project_id: uuid.UUID,
+) -> UserContext:
+    """Decode and validate a user JWT.
+
+    Returns UserContext on success.
+    Raises ValueError with a descriptive message on any validation failure.
+    """
+    try:
+        payload: dict[str, Any] = jwt.decode(
+            token, public_key, algorithms=[JWT_ALGORITHM]
+        )
+    except jwt.ExpiredSignatureError:
+        raise ValueError("User token expired")
+    except jwt.PyJWTError:
+        raise ValueError("Invalid user token")
+
+    # Must be a user_access token
+    if payload.get("type") != "user_access":
+        raise ValueError(
+            f"Invalid token type: expected user_access, got {payload.get('type')}"
+        )
+
+    # Validate sub claim
+    sub = payload.get("sub")
+    if not sub:
+        raise ValueError("Missing sub claim in user token")
+    try:
+        user_id = uuid.UUID(sub)
+    except ValueError:
+        raise ValueError(f"Invalid user_id in token: {sub}")
+
+    # Validate project_id matches the API key's project
+    token_project = payload.get("project_id")
+    if token_project != str(expected_project_id):
+        raise ValueError(
+            f"Token project_id {token_project} does not match "
+            f"API key project {expected_project_id}"
+        )
+
+    return UserContext(
+        user_id=user_id,
+        project_id=expected_project_id,
+        role=payload.get("role", "authenticated"),
+        email_verified=bool(payload.get("email_verified", False)),
+    )
+
+
+async def get_current_user(
+    request: Request,
+    context: ProjectContext = Depends(get_project_context),
+) -> UserContext | None:
+    """FastAPI dependency: optionally validate user JWT from Authorization header.
+
+    Returns UserContext if a valid Bearer token is present.
+    Returns None if no Authorization header is provided (allows
+    unauthenticated/service-role access).
+    Raises 401 with structured error for invalid/expired tokens.
+    """
+    auth_header = request.headers.get("authorization")
+    if not auth_header or not auth_header.startswith("Bearer "):
+        return None
+
+    token = auth_header[7:]  # Strip "Bearer "
+    public_key = _get_public_key(request)
+
+    try:
+        user_ctx = _validate_user_jwt(
+            token, public_key, expected_project_id=context.project_id
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "error": {
+                    "code": "user_token_invalid",
+                    "message": str(exc),
+                }
+            },
+        )
+
+    return user_ctx

--- a/backend/tests/integration/test_user_auth_middleware.py
+++ b/backend/tests/integration/test_user_auth_middleware.py
@@ -1,0 +1,315 @@
+"""Integration tests for end-user auth middleware (US-026).
+
+Boots the real FastAPI app with real Postgres. Tests that:
+- Valid user JWT → UserContext injected
+- Invalid JWT → 401 with structured error
+- No JWT → no user context (optional dependency)
+- Project ID mismatch → 401
+- Expired token → 401
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import APIRouter, Depends, FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from pqdb_api.config import Settings
+from pqdb_api.database import get_session
+from pqdb_api.middleware.api_key import (
+    ProjectContext,
+    get_project_context,
+    get_project_session,
+)
+from pqdb_api.middleware.user_auth import UserContext, get_current_user
+from pqdb_api.routes.health import router as health_router
+from pqdb_api.routes.user_auth import router as user_auth_router
+from pqdb_api.services.auth import generate_ed25519_keypair
+from pqdb_api.services.provisioner import DatabaseProvisioner
+from pqdb_api.services.rate_limiter import RateLimiter
+from pqdb_api.services.vault import VaultClient
+
+
+def _make_middleware_test_app(
+    test_db_url: str,
+    test_db_name: str,
+    fake_project_id: uuid.UUID | None = None,
+) -> tuple[FastAPI, uuid.UUID]:
+    """Build a test app with a diagnostic endpoint that exposes UserContext."""
+    private_key, public_key = generate_ed25519_keypair()
+    project_id = fake_project_id or uuid.uuid4()
+
+    fake_context = ProjectContext(
+        project_id=project_id,
+        key_role="anon",
+        database_name=test_db_name,
+    )
+
+    mock_provisioner = AsyncMock(spec=DatabaseProvisioner)
+    mock_provisioner.superuser_dsn = "postgresql://test:test@localhost/test"
+    mock_provisioner.provision = AsyncMock(return_value=test_db_name)
+
+    mock_vault = MagicMock(spec=VaultClient)
+    mock_vault.store_hmac_key = MagicMock()
+    mock_vault.get_hmac_key = MagicMock(return_value=b"\x00" * 32)
+
+    settings = Settings(
+        database_url=test_db_url,
+        superuser_dsn="postgresql://test:test@localhost/test",
+    )
+
+    # Diagnostic router — exposes user context info
+    diag_router = APIRouter(prefix="/v1/diag", tags=["diag"])
+
+    @diag_router.get("/user-context")
+    async def user_context_endpoint(
+        user: UserContext | None = Depends(get_current_user),
+    ) -> dict[str, Any]:
+        if user is None:
+            return {"user": None}
+        return {
+            "user": {
+                "user_id": str(user.user_id),
+                "project_id": str(user.project_id),
+                "role": user.role,
+                "email_verified": user.email_verified,
+            }
+        }
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        platform_engine = create_async_engine(test_db_url)
+        platform_factory = async_sessionmaker(
+            platform_engine, class_=AsyncSession, expire_on_commit=False
+        )
+        project_engine = create_async_engine(test_db_url)
+        project_factory = async_sessionmaker(
+            project_engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+        async def _override_get_session() -> AsyncIterator[AsyncSession]:
+            async with platform_factory() as session:
+                yield session
+
+        async def _override_get_project_session() -> AsyncIterator[AsyncSession]:
+            async with project_factory() as session:
+                yield session
+
+        async def _override_get_project_context() -> ProjectContext:
+            return fake_context
+
+        app.dependency_overrides[get_session] = _override_get_session
+        app.dependency_overrides[get_project_session] = _override_get_project_session
+        app.dependency_overrides[get_project_context] = _override_get_project_context
+        app.state.jwt_private_key = private_key
+        app.state.jwt_public_key = public_key
+        app.state.provisioner = mock_provisioner
+        app.state.vault_client = mock_vault
+        app.state.hmac_rate_limiter = RateLimiter(max_requests=100, window_seconds=60)
+        app.state.settings = settings
+        yield
+        await platform_engine.dispose()
+        await project_engine.dispose()
+
+    app = FastAPI(lifespan=lifespan)
+    app.state.settings = settings
+    app.include_router(health_router)
+    app.include_router(user_auth_router)
+    app.include_router(diag_router)
+    return app, project_id
+
+
+@pytest.fixture()
+def project_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture()
+def client(
+    test_db_url: str, test_db_name: str, project_id: uuid.UUID
+) -> Iterator[TestClient]:
+    app, _ = _make_middleware_test_app(test_db_url, test_db_name, project_id)
+    with TestClient(app) as c:
+        yield c
+
+
+def _signup_user(client: TestClient, email: str = "mw@example.com") -> dict[str, Any]:
+    """Sign up a user and return the response JSON."""
+    resp = client.post(
+        "/v1/auth/users/signup",
+        json={"email": email, "password": "securepass123"},
+    )
+    assert resp.status_code == 201
+    data: dict[str, Any] = resp.json()
+    return data
+
+
+class TestGetCurrentUserOptional:
+    """Test that get_current_user is optional — no JWT means no user context."""
+
+    def test_no_auth_header_returns_null_user(self, client: TestClient) -> None:
+        resp = client.get("/v1/diag/user-context")
+        assert resp.status_code == 200
+        assert resp.json()["user"] is None
+
+    def test_empty_bearer_returns_null_user(self, client: TestClient) -> None:
+        resp = client.get(
+            "/v1/diag/user-context",
+            headers={"Authorization": "Basic abc"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["user"] is None
+
+
+class TestGetCurrentUserValid:
+    """Test that valid user JWT → UserContext injected."""
+
+    def test_valid_token_injects_user_context(self, client: TestClient) -> None:
+        signup = _signup_user(client)
+        access_token = signup["access_token"]
+
+        resp = client.get(
+            "/v1/diag/user-context",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["user"] is not None
+        assert data["user"]["user_id"] == signup["user"]["id"]
+        assert data["user"]["role"] == "authenticated"
+        assert data["user"]["email_verified"] is False
+
+    def test_user_context_project_id_matches(
+        self, client: TestClient, project_id: uuid.UUID
+    ) -> None:
+        signup = _signup_user(client, email="projcheck@example.com")
+        access_token = signup["access_token"]
+
+        resp = client.get(
+            "/v1/diag/user-context",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["user"]["project_id"] == str(project_id)
+
+
+class TestGetCurrentUserInvalid:
+    """Test that invalid JWTs return 401 with structured error."""
+
+    def test_garbage_token_returns_401(self, client: TestClient) -> None:
+        resp = client.get(
+            "/v1/diag/user-context",
+            headers={"Authorization": "Bearer garbage.token.here"},
+        )
+        assert resp.status_code == 401
+        detail = resp.json()["detail"]
+        assert detail["error"]["code"] == "user_token_invalid"
+
+    def test_expired_token_returns_401(
+        self, client: TestClient, project_id: uuid.UUID
+    ) -> None:
+        """Create an expired token manually and verify rejection."""
+        from datetime import UTC, datetime, timedelta
+
+        import jwt as pyjwt
+
+        from pqdb_api.services.auth import JWT_ALGORITHM
+
+        # Get the app's private key from the test client
+        private_key = client.app.state.jwt_private_key  # type: ignore[attr-defined]
+        now = datetime.now(UTC)
+        payload: dict[str, Any] = {
+            "sub": str(uuid.uuid4()),
+            "project_id": str(project_id),
+            "type": "user_access",
+            "role": "authenticated",
+            "email_verified": False,
+            "iat": now - timedelta(hours=1),
+            "exp": now - timedelta(minutes=30),
+        }
+        token = pyjwt.encode(payload, private_key, algorithm=JWT_ALGORITHM)
+
+        resp = client.get(
+            "/v1/diag/user-context",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 401
+        detail = resp.json()["detail"]
+        assert detail["error"]["code"] == "user_token_invalid"
+        assert "expired" in detail["error"]["message"].lower()
+
+    def test_developer_token_rejected(self, client: TestClient) -> None:
+        """Developer tokens (type=access) must be rejected."""
+        from datetime import UTC, datetime, timedelta
+
+        import jwt as pyjwt
+
+        from pqdb_api.services.auth import JWT_ALGORITHM
+
+        private_key = client.app.state.jwt_private_key  # type: ignore[attr-defined]
+        now = datetime.now(UTC)
+        payload: dict[str, Any] = {
+            "sub": str(uuid.uuid4()),
+            "type": "access",  # developer token
+            "iat": now,
+            "exp": now + timedelta(minutes=15),
+        }
+        token = pyjwt.encode(payload, private_key, algorithm=JWT_ALGORITHM)
+
+        resp = client.get(
+            "/v1/diag/user-context",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 401
+        detail = resp.json()["detail"]
+        assert detail["error"]["code"] == "user_token_invalid"
+
+    def test_project_id_mismatch_returns_401(self, client: TestClient) -> None:
+        """User JWT from project A cannot access project B."""
+        from datetime import UTC, datetime, timedelta
+
+        import jwt as pyjwt
+
+        from pqdb_api.services.auth import JWT_ALGORITHM
+
+        private_key = client.app.state.jwt_private_key  # type: ignore[attr-defined]
+        now = datetime.now(UTC)
+        different_project = uuid.uuid4()
+        payload: dict[str, Any] = {
+            "sub": str(uuid.uuid4()),
+            "project_id": str(different_project),
+            "type": "user_access",
+            "role": "authenticated",
+            "email_verified": False,
+            "iat": now,
+            "exp": now + timedelta(minutes=15),
+        }
+        token = pyjwt.encode(payload, private_key, algorithm=JWT_ALGORITHM)
+
+        resp = client.get(
+            "/v1/diag/user-context",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 401
+        detail = resp.json()["detail"]
+        assert detail["error"]["code"] == "user_token_invalid"
+        assert "project" in detail["error"]["message"].lower()
+
+
+class TestHealthCheck:
+    """Health check still works with user auth middleware."""
+
+    def test_health_returns_200(self, client: TestClient) -> None:
+        resp = client.get("/health")
+        assert resp.status_code == 200

--- a/backend/tests/unit/test_user_auth_middleware.py
+++ b/backend/tests/unit/test_user_auth_middleware.py
@@ -1,0 +1,199 @@
+"""Unit tests for end-user auth middleware (US-026).
+
+Tests JWT validation, project_id mismatch detection, optional
+dependency behavior, and structured error responses.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from pqdb_api.middleware.user_auth import UserContext, _validate_user_jwt
+from pqdb_api.services.auth import JWT_ALGORITHM, generate_ed25519_keypair
+
+
+@pytest.fixture()
+def ed25519_keys() -> tuple[Ed25519PrivateKey, Any]:
+    private_key, public_key = generate_ed25519_keypair()
+    return private_key, public_key
+
+
+def _make_user_token(
+    private_key: Ed25519PrivateKey,
+    *,
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    role: str = "authenticated",
+    email_verified: bool = False,
+    token_type: str = "user_access",
+    expired: bool = False,
+) -> str:
+    """Helper to create a user JWT for testing."""
+    now = datetime.now(UTC)
+    payload: dict[str, Any] = {
+        "sub": str(user_id or uuid.uuid4()),
+        "project_id": str(project_id or uuid.uuid4()),
+        "role": role,
+        "type": token_type,
+        "email_verified": email_verified,
+        "iat": now - timedelta(minutes=5) if expired else now,
+        "exp": now - timedelta(minutes=1) if expired else now + timedelta(minutes=15),
+    }
+    return jwt.encode(payload, private_key, algorithm=JWT_ALGORITHM)
+
+
+class TestValidateUserJwt:
+    """Test the _validate_user_jwt helper."""
+
+    def test_valid_token_returns_user_context(
+        self, ed25519_keys: tuple[Any, Any]
+    ) -> None:
+        private_key, public_key = ed25519_keys
+        user_id = uuid.uuid4()
+        project_id = uuid.uuid4()
+        token = _make_user_token(
+            private_key,
+            user_id=user_id,
+            project_id=project_id,
+            role="authenticated",
+            email_verified=True,
+        )
+        ctx = _validate_user_jwt(token, public_key, expected_project_id=project_id)
+        assert isinstance(ctx, UserContext)
+        assert ctx.user_id == user_id
+        assert ctx.project_id == project_id
+        assert ctx.role == "authenticated"
+        assert ctx.email_verified is True
+
+    def test_expired_token_raises_value_error(
+        self, ed25519_keys: tuple[Any, Any]
+    ) -> None:
+        private_key, public_key = ed25519_keys
+        project_id = uuid.uuid4()
+        token = _make_user_token(private_key, project_id=project_id, expired=True)
+        with pytest.raises(ValueError, match="expired"):
+            _validate_user_jwt(token, public_key, expected_project_id=project_id)
+
+    def test_invalid_signature_raises_value_error(
+        self, ed25519_keys: tuple[Any, Any]
+    ) -> None:
+        # Sign with a different key
+        other_priv, _ = generate_ed25519_keypair()
+        _, public_key = ed25519_keys
+        project_id = uuid.uuid4()
+        token = _make_user_token(other_priv, project_id=project_id)
+        with pytest.raises(ValueError, match="Invalid user token"):
+            _validate_user_jwt(token, public_key, expected_project_id=project_id)
+
+    def test_wrong_token_type_raises_value_error(
+        self, ed25519_keys: tuple[Any, Any]
+    ) -> None:
+        private_key, public_key = ed25519_keys
+        project_id = uuid.uuid4()
+        # Developer access token (type=access, not user_access)
+        token = _make_user_token(
+            private_key, project_id=project_id, token_type="access"
+        )
+        with pytest.raises(ValueError, match="Invalid token type"):
+            _validate_user_jwt(token, public_key, expected_project_id=project_id)
+
+    def test_project_id_mismatch_raises_value_error(
+        self, ed25519_keys: tuple[Any, Any]
+    ) -> None:
+        private_key, public_key = ed25519_keys
+        token_project = uuid.uuid4()
+        api_key_project = uuid.uuid4()
+        token = _make_user_token(private_key, project_id=token_project)
+        with pytest.raises(ValueError, match="project"):
+            _validate_user_jwt(token, public_key, expected_project_id=api_key_project)
+
+    def test_missing_sub_raises_value_error(
+        self, ed25519_keys: tuple[Any, Any]
+    ) -> None:
+        private_key, public_key = ed25519_keys
+        project_id = uuid.uuid4()
+        now = datetime.now(UTC)
+        payload: dict[str, Any] = {
+            "project_id": str(project_id),
+            "type": "user_access",
+            "role": "authenticated",
+            "email_verified": False,
+            "iat": now,
+            "exp": now + timedelta(minutes=15),
+        }
+        token = jwt.encode(payload, private_key, algorithm=JWT_ALGORITHM)
+        with pytest.raises(ValueError, match="Missing sub"):
+            _validate_user_jwt(token, public_key, expected_project_id=project_id)
+
+    def test_malformed_sub_raises_value_error(
+        self, ed25519_keys: tuple[Any, Any]
+    ) -> None:
+        private_key, public_key = ed25519_keys
+        project_id = uuid.uuid4()
+        now = datetime.now(UTC)
+        payload: dict[str, Any] = {
+            "sub": "not-a-uuid",
+            "project_id": str(project_id),
+            "type": "user_access",
+            "role": "authenticated",
+            "email_verified": False,
+            "iat": now,
+            "exp": now + timedelta(minutes=15),
+        }
+        token = jwt.encode(payload, private_key, algorithm=JWT_ALGORITHM)
+        with pytest.raises(ValueError, match="Invalid user_id"):
+            _validate_user_jwt(token, public_key, expected_project_id=project_id)
+
+    def test_garbage_token_raises_value_error(
+        self, ed25519_keys: tuple[Any, Any]
+    ) -> None:
+        _, public_key = ed25519_keys
+        with pytest.raises(ValueError, match="Invalid user token"):
+            _validate_user_jwt(
+                "garbage.token.here",
+                public_key,
+                expected_project_id=uuid.uuid4(),
+            )
+
+    def test_refresh_token_type_rejected(self, ed25519_keys: tuple[Any, Any]) -> None:
+        private_key, public_key = ed25519_keys
+        project_id = uuid.uuid4()
+        token = _make_user_token(
+            private_key, project_id=project_id, token_type="user_refresh"
+        )
+        with pytest.raises(ValueError, match="Invalid token type"):
+            _validate_user_jwt(token, public_key, expected_project_id=project_id)
+
+
+class TestUserContext:
+    """Test UserContext dataclass."""
+
+    def test_frozen_dataclass(self) -> None:
+        ctx = UserContext(
+            user_id=uuid.uuid4(),
+            project_id=uuid.uuid4(),
+            role="authenticated",
+            email_verified=False,
+        )
+        with pytest.raises(AttributeError):
+            ctx.role = "admin"  # type: ignore[misc]
+
+    def test_fields(self) -> None:
+        uid = uuid.uuid4()
+        pid = uuid.uuid4()
+        ctx = UserContext(
+            user_id=uid,
+            project_id=pid,
+            role="admin",
+            email_verified=True,
+        )
+        assert ctx.user_id == uid
+        assert ctx.project_id == pid
+        assert ctx.role == "admin"
+        assert ctx.email_verified is True


### PR DESCRIPTION
## Summary
- New `middleware/user_auth.py` with `get_current_user` FastAPI dependency that validates end-user JWTs (type=user_access) from Authorization: Bearer header
- `UserContext` dataclass (user_id, project_id, role, email_verified) injected into request state alongside existing `ProjectContext`
- Dependency is **optional** — returns `None` when no user JWT is present (service role / unauthenticated access continues to work)
- Rejects: expired tokens, invalid signatures, wrong token type (developer tokens), project_id mismatch (user from project A cannot access project B)
- Returns structured 401 error: `{ error: { code: "user_token_invalid", message: "..." } }`

## Test plan
- [x] 11 unit tests: JWT validation, project_id mismatch, optional behavior, frozen dataclass
- [x] 9 integration tests: real FastAPI + Postgres — valid JWT context injection, invalid JWT 401, no JWT null context, health check
- [x] All 499 existing tests pass (no regressions)
- [x] `ruff format` + `ruff check` clean
- [x] `mypy --strict` passes with zero errors

Generated with [Claude Code](https://claude.com/claude-code)