### PR TITLE
Fix 8 review issues from PRs #25-28

### DIFF
--- a/backend/src/pqdb_api/routes/auth_settings.py
+++ b/backend/src/pqdb_api/routes/auth_settings.py
@@ -16,10 +16,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     async_sessionmaker,
-    create_async_engine,
 )
 
 from pqdb_api.database import get_session
+from pqdb_api.middleware.api_key import _get_or_create_engine
 from pqdb_api.middleware.auth import get_current_developer_id
 from pqdb_api.models.project import Project
 from pqdb_api.services.auth_engine import (
@@ -104,14 +104,13 @@ async def get_project_auth_settings(
 
     platform_url: str = request.app.state.settings.database_url
     project_url = _build_project_db_url(platform_url, project.database_name)
-    engine = create_async_engine(project_url)
+    engine = _get_or_create_engine(
+        request.app.state, project_url, project.database_name
+    )
     factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
-    try:
-        async with factory() as project_session:
-            await ensure_auth_tables(project_session)
-            settings = await get_auth_settings(project_session)
-    finally:
-        await engine.dispose()
+    async with factory() as project_session:
+        await ensure_auth_tables(project_session)
+        settings = await get_auth_settings(project_session)
 
     return AuthSettingsResponse(**settings)
 
@@ -147,14 +146,14 @@ async def update_project_auth_settings(
 
     platform_url: str = request.app.state.settings.database_url
     project_url = _build_project_db_url(platform_url, project.database_name)
-    engine = create_async_engine(project_url)
+    engine = _get_or_create_engine(
+        request.app.state, project_url, project.database_name
+    )
     factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
     try:
         async with factory() as project_session:
             settings = await update_auth_settings(project_session, updates)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    finally:
-        await engine.dispose()
 
     return AuthSettingsResponse(**settings)

--- a/backend/src/pqdb_api/routes/user_auth.py
+++ b/backend/src/pqdb_api/routes/user_auth.py
@@ -17,6 +17,8 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+import jwt
+import pydantic
 import structlog
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PrivateKey,
@@ -25,6 +27,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import (
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, EmailStr
 from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from pqdb_api.middleware.api_key import (
@@ -55,14 +58,14 @@ class UserSignupRequest(BaseModel):
     """Request body for user signup."""
 
     email: EmailStr
-    password: str
+    password: str = pydantic.Field(max_length=1024)
 
 
 class UserLoginRequest(BaseModel):
     """Request body for user login."""
 
     email: EmailStr
-    password: str
+    password: str = pydantic.Field(max_length=1024)
 
 
 class UserLogoutRequest(BaseModel):
@@ -120,10 +123,11 @@ def _get_user_auth_service(request: Request) -> UserAuthService:
 
 
 def _get_client_ip(request: Request) -> str:
-    """Extract client IP for rate limiting."""
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
+    """Extract client IP for rate limiting.
+
+    Uses request.client.host only — does NOT trust X-Forwarded-For
+    because it can be spoofed by clients to bypass rate limiting.
+    """
     client = request.client
     if client:
         return client.host
@@ -179,7 +183,9 @@ async def _get_current_user(
 
     try:
         payload = service.decode_user_token(token, expected_type="user_access")
-    except Exception:
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+    except (jwt.PyJWTError, ValueError):
         raise HTTPException(status_code=401, detail="Invalid or expired token")
 
     # Verify project_id matches the apikey project
@@ -287,7 +293,11 @@ async def user_signup(
         },
     )
 
-    await session.commit()
+    try:
+        await session.commit()
+    except IntegrityError:
+        await session.rollback()
+        raise HTTPException(status_code=409, detail="Email already registered")
 
     logger.info(
         "user_signup",
@@ -410,8 +420,14 @@ async def user_logout(
         payload = service.decode_user_token(
             body.refresh_token, expected_type="user_refresh"
         )
-    except Exception:
+    except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Invalid refresh token")
+    except (jwt.PyJWTError, ValueError):
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+    # Verify project_id matches the apikey project
+    if payload.get("project_id") != str(context.project_id):
+        raise HTTPException(status_code=401, detail="Token does not match project")
 
     # Find and revoke matching session
     result = await session.execute(
@@ -467,8 +483,14 @@ async def user_refresh(
         payload = service.decode_user_token(
             body.refresh_token, expected_type="user_refresh"
         )
-    except Exception:
+    except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Invalid or expired refresh token")
+    except (jwt.PyJWTError, ValueError):
+        raise HTTPException(status_code=401, detail="Invalid or expired refresh token")
+
+    # Verify project_id matches the apikey project
+    if payload.get("project_id") != str(context.project_id):
+        raise HTTPException(status_code=401, detail="Token does not match project")
 
     user_id = payload["sub"]
 

--- a/backend/src/pqdb_api/services/auth_engine.py
+++ b/backend/src/pqdb_api/services/auth_engine.py
@@ -123,6 +123,10 @@ def _is_sqlite(session: AsyncSession) -> bool:
     return bind.dialect.name == "sqlite"
 
 
+class AuthEngineError(Exception):
+    """Raised when auth engine operations fail."""
+
+
 async def ensure_auth_tables(session: AsyncSession) -> None:
     """Create auth tables if they don't exist. Idempotent.
 
@@ -132,21 +136,26 @@ async def ensure_auth_tables(session: AsyncSession) -> None:
     - _pqdb_auth_settings: single-row project auth config
 
     Called lazily on first auth-related request.
+    Raises AuthEngineError if table creation fails.
     """
     sqlite = _is_sqlite(session)
 
-    if sqlite:
-        await session.execute(_SQL_CREATE_USERS_SQLITE)
-        await session.execute(_SQL_CREATE_SESSIONS_SQLITE)
-        await session.execute(_SQL_CREATE_AUTH_SETTINGS_SQLITE)
-        await session.execute(_SQL_INSERT_DEFAULT_SETTINGS_SQLITE)
-    else:
-        await session.execute(_SQL_CREATE_USERS_PG)
-        await session.execute(_SQL_CREATE_SESSIONS_PG)
-        await session.execute(_SQL_CREATE_AUTH_SETTINGS_PG)
-        await session.execute(_SQL_INSERT_DEFAULT_SETTINGS_PG)
+    try:
+        if sqlite:
+            await session.execute(_SQL_CREATE_USERS_SQLITE)
+            await session.execute(_SQL_CREATE_SESSIONS_SQLITE)
+            await session.execute(_SQL_CREATE_AUTH_SETTINGS_SQLITE)
+            await session.execute(_SQL_INSERT_DEFAULT_SETTINGS_SQLITE)
+        else:
+            await session.execute(_SQL_CREATE_USERS_PG)
+            await session.execute(_SQL_CREATE_SESSIONS_PG)
+            await session.execute(_SQL_CREATE_AUTH_SETTINGS_PG)
+            await session.execute(_SQL_INSERT_DEFAULT_SETTINGS_PG)
 
-    await session.commit()
+        await session.commit()
+    except Exception as exc:
+        logger.error("auth_tables_creation_failed", error=str(exc))
+        raise AuthEngineError(f"Failed to create auth tables: {exc}") from exc
 
     logger.info("auth_tables_ensured", dialect="sqlite" if sqlite else "postgresql")
 
@@ -168,13 +177,11 @@ async def get_auth_settings(session: AsyncSession) -> dict[str, Any]:
     )
     row = result.fetchone()
     if row is None:
-        # Should never happen after ensure_auth_tables
-        return {
-            "require_email_verification": False,
-            "magic_link_webhook": None,
-            "password_min_length": 8,
-            "mfa_enabled": False,
-        }
+        # Should never happen after ensure_auth_tables — indicates a serious bug
+        raise RuntimeError(
+            "Auth settings row missing after ensure_auth_tables. "
+            "This indicates a bug in table initialization."
+        )
 
     return {
         "require_email_verification": bool(row[0]),

--- a/backend/src/pqdb_api/services/user_auth.py
+++ b/backend/src/pqdb_api/services/user_auth.py
@@ -110,11 +110,15 @@ class UserAuthService:
             raise ValueError(f"Invalid token type: expected {expected_type}")
         return payload
 
-    def validate_password(self, password: str, *, min_length: int = 8) -> None:
-        """Validate password meets minimum length requirement.
+    def validate_password(
+        self, password: str, *, min_length: int = 8, max_length: int = 1024
+    ) -> None:
+        """Validate password meets length requirements.
 
-        Raises ValueError if password is too short.
+        Raises ValueError if password is too short or too long.
         """
+        if len(password) > max_length:
+            raise ValueError(f"Password must not exceed {max_length} characters")
         if len(password) < min_length:
             raise ValueError(f"Password must be at least {min_length} characters")
 

--- a/backend/tests/unit/test_auth_engine.py
+++ b/backend/tests/unit/test_auth_engine.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from pqdb_api.services.auth_engine import (
+    AuthEngineError,
     ensure_auth_tables,
     get_auth_settings,
     update_auth_settings,
@@ -173,6 +174,35 @@ class TestGetAuthSettings:
             settings = await get_auth_settings(session)
             assert settings is not None
             assert settings["password_min_length"] == 8
+
+    @pytest.mark.asyncio()
+    async def test_raises_runtime_error_when_row_missing(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """get_auth_settings raises RuntimeError if settings row is missing."""
+        from unittest.mock import AsyncMock, patch
+
+        async with session_factory() as session:
+            await ensure_auth_tables(session)
+            # Delete the settings row to simulate corruption
+            await session.execute(text("DELETE FROM _pqdb_auth_settings"))
+            await session.commit()
+            # Patch ensure_auth_tables to no-op so it doesn't re-insert the row
+            with patch(
+                "pqdb_api.services.auth_engine.ensure_auth_tables",
+                new_callable=AsyncMock,
+            ):
+                with pytest.raises(RuntimeError, match="Auth settings row missing"):
+                    await get_auth_settings(session)
+
+
+class TestAuthEngineError:
+    """Tests for AuthEngineError exception class."""
+
+    def test_auth_engine_error_is_exception(self) -> None:
+        err = AuthEngineError("test")
+        assert isinstance(err, Exception)
+        assert str(err) == "test"
 
 
 class TestUpdateAuthSettings:

--- a/backend/tests/unit/test_user_auth_service.py
+++ b/backend/tests/unit/test_user_auth_service.py
@@ -211,6 +211,20 @@ class TestPasswordValidation:
         with pytest.raises(ValueError, match="at least 12 characters"):
             user_auth_service.validate_password("short12345", min_length=12)
 
+    def test_password_exceeds_max_length_raises(
+        self, user_auth_service: UserAuthService
+    ) -> None:
+        long_password = "a" * 1025
+        with pytest.raises(ValueError, match="must not exceed 1024 characters"):
+            user_auth_service.validate_password(long_password, min_length=8)
+
+    def test_password_at_max_length_passes(
+        self, user_auth_service: UserAuthService
+    ) -> None:
+        password_1024 = "a" * 1024
+        # Should not raise
+        user_auth_service.validate_password(password_1024, min_length=8)
+
 
 class TestHashAndStoreRefreshToken:
     """Test that refresh tokens are hashed for storage."""


### PR DESCRIPTION
## Summary

Fixes accumulated review issues identified in PRs #25-28:

- **Security**: Replace bare `except Exception` with specific JWT exceptions (`jwt.ExpiredSignatureError`, `jwt.PyJWTError`, `ValueError`) in 3 places in `user_auth.py`
- **Security**: Fix `_get_client_ip` to use `request.client.host` only — no longer trusts `X-Forwarded-For` header (spoofable by clients to bypass rate limits)
- **Security**: Add `max_length=1024` to password Pydantic fields and `validate_password()` to prevent DoS via extremely long passwords
- **Correctness**: Add `IntegrityError` handling for duplicate email signup race condition (catch at commit time, not just SELECT check)
- **Correctness**: Add `project_id` validation in logout and refresh endpoints (matching the pattern already in `_get_current_user`)
- **Correctness**: `get_auth_settings()` now raises `RuntimeError` instead of silently returning hardcoded defaults when settings row is missing
- **Robustness**: Add error handling in `ensure_auth_tables()` with new `AuthEngineError` exception and logging
- **Performance**: `auth_settings.py` now uses pooled engines from `_get_or_create_engine()` instead of creating per-request engines

## Test plan

- [x] Added unit tests for password max_length validation (exceeds max raises, at max passes)
- [x] Added unit test for `RuntimeError` when auth settings row missing
- [x] Added unit test for `AuthEngineError` exception class
- [x] All 280 unit tests pass
- [x] All 37 user_auth + auth_settings integration tests pass
- [x] Full suite: 515 tests pass
- [x] `ruff check`, `ruff format`, `mypy --strict` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)