### PR TITLE
[US-028] Owner column marker + RLS enforcement

### DIFF
--- a/backend/src/pqdb_api/routes/db.py
+++ b/backend/src/pqdb_api/routes/db.py
@@ -20,6 +20,7 @@ from pqdb_api.middleware.api_key import (
     get_project_context,
     get_project_session,
 )
+from pqdb_api.middleware.user_auth import UserContext, get_current_user
 from pqdb_api.services.crud import (
     CrudError,
     FilterOp,
@@ -27,9 +28,11 @@ from pqdb_api.services.crud import (
     build_insert_sql,
     build_select_sql,
     build_update_sql,
+    inject_rls_filters,
     resolve_physical_column,
     validate_columns_for_insert,
     validate_filter_column,
+    validate_owner_for_insert,
 )
 from pqdb_api.services.schema_engine import (
     ColumnDefinition,
@@ -60,6 +63,7 @@ class ColumnSchema(BaseModel):
     name: str
     data_type: str
     sensitivity: str = "plain"
+    owner: bool = False
 
     @field_validator("sensitivity")
     @classmethod
@@ -134,16 +138,16 @@ class DeleteRequest(BaseModel):
 
 async def _get_column_meta(
     session: AsyncSession, table_name: str
-) -> list[dict[str, str]]:
+) -> list[dict[str, Any]]:
     """Load column metadata for a table from _pqdb_columns.
 
     Raises HTTPException 404 if the table does not exist.
-    Returns list of dicts with keys: name, sensitivity, data_type.
+    Returns list of dicts with keys: name, sensitivity, data_type, is_owner.
     """
     await ensure_metadata_table(session)
     result = await session.execute(
         text(
-            "SELECT column_name, sensitivity, data_type "
+            "SELECT column_name, sensitivity, data_type, is_owner "
             "FROM _pqdb_columns WHERE table_name = :name ORDER BY id"
         ),
         {"name": table_name},
@@ -159,6 +163,7 @@ async def _get_column_meta(
             "name": r[0],
             "sensitivity": r[1],
             "data_type": r[2],
+            "is_owner": bool(r[3]),
         }
         for r in rows
     ]
@@ -269,6 +274,7 @@ async def create_table_endpoint(
                     name=c.name,
                     data_type=c.data_type,
                     sensitivity=cast(Sensitivity, c.sensitivity),
+                    is_owner=c.owner,
                 )
                 for c in body.columns
             ],
@@ -373,6 +379,7 @@ async def add_column_endpoint(
             name=body.name,
             data_type=body.data_type,
             sensitivity=cast(Sensitivity, body.sensitivity),
+            is_owner=body.owner,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -420,11 +427,14 @@ async def insert_rows(
     table_name: str,
     body: InsertRequest,
     session: AsyncSession = Depends(get_project_session),
+    context: ProjectContext = Depends(get_project_context),
+    user: UserContext | None = Depends(get_current_user),
 ) -> dict[str, Any]:
     """Insert rows into a project table.
 
     The SDK sends data with shadow column names already applied
     (_encrypted, _index suffixes). The server validates and stores as-is.
+    RLS: anon role must set owner column to authenticated user_id.
     """
     columns_meta = await _get_column_meta(session, table_name)
 
@@ -434,6 +444,12 @@ async def insert_rows(
     try:
         inserted: list[dict[str, Any]] = []
         for row in body.rows:
+            validate_owner_for_insert(
+                row=row,
+                columns_meta=columns_meta,
+                key_role=context.key_role,
+                user_id=user.user_id if user else None,
+            )
             physical_row = validate_columns_for_insert(row, columns_meta)
             sql, params = build_insert_sql(table_name, physical_row)
             result = await session.execute(text(sql), params)
@@ -441,6 +457,8 @@ async def insert_rows(
         await session.commit()
     except CrudError as exc:
         await session.rollback()
+        if "User context required" in str(exc):
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
         await session.rollback()
@@ -460,11 +478,14 @@ async def select_rows(
     table_name: str,
     body: SelectRequest,
     session: AsyncSession = Depends(get_project_session),
+    context: ProjectContext = Depends(get_project_context),
+    user: UserContext | None = Depends(get_current_user),
 ) -> dict[str, Any]:
     """Select rows from a project table.
 
     Supports filtering by blind index (eq, in) and plain columns
     (eq, gt, lt, gte, lte, in). Private columns are not filterable.
+    RLS: anon role only sees rows where owner column matches user_id.
     """
     columns_meta = await _get_column_meta(session, table_name)
 
@@ -473,6 +494,17 @@ async def select_rows(
         filters = _parse_filters(body.filters, columns_meta)
     except HTTPException:
         raise
+
+    # Inject RLS filters
+    try:
+        filters = inject_rls_filters(
+            filters=filters,
+            columns_meta=columns_meta,
+            key_role=context.key_role,
+            user_id=user.user_id if user else None,
+        )
+    except CrudError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
 
     # Build order_by as list of tuples
     order_by: list[tuple[str, str]] | None = None
@@ -503,11 +535,14 @@ async def update_rows(
     table_name: str,
     body: UpdateRequest,
     session: AsyncSession = Depends(get_project_session),
+    context: ProjectContext = Depends(get_project_context),
+    user: UserContext | None = Depends(get_current_user),
 ) -> dict[str, Any]:
     """Update rows in a project table.
 
     Matches rows via filters (typically blind index), updates the
     specified columns. Returns updated rows.
+    RLS: anon role can only update own rows (WHERE owner_col = user_id).
     """
     columns_meta = await _get_column_meta(session, table_name)
 
@@ -532,6 +567,17 @@ async def update_rows(
         filters = _parse_filters(body.filters, columns_meta)
     except HTTPException:
         raise
+
+    # Inject RLS filters
+    try:
+        filters = inject_rls_filters(
+            filters=filters,
+            columns_meta=columns_meta,
+            key_role=context.key_role,
+            user_id=user.user_id if user else None,
+        )
+    except CrudError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
 
     try:
         sql, params = build_update_sql(
@@ -564,11 +610,14 @@ async def delete_rows(
     table_name: str,
     body: DeleteRequest,
     session: AsyncSession = Depends(get_project_session),
+    context: ProjectContext = Depends(get_project_context),
+    user: UserContext | None = Depends(get_current_user),
 ) -> dict[str, Any]:
     """Delete rows from a project table.
 
     Requires at least one filter to prevent accidental full-table deletion.
     Returns deleted rows.
+    RLS: anon role can only delete own rows (WHERE owner_col = user_id).
     """
     columns_meta = await _get_column_meta(session, table_name)
 
@@ -577,6 +626,17 @@ async def delete_rows(
         filters = _parse_filters(body.filters, columns_meta)
     except HTTPException:
         raise
+
+    # Inject RLS filters
+    try:
+        filters = inject_rls_filters(
+            filters=filters,
+            columns_meta=columns_meta,
+            key_role=context.key_role,
+            user_id=user.user_id if user else None,
+        )
+    except CrudError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
 
     try:
         sql, params = build_delete_sql(

--- a/backend/src/pqdb_api/services/crud.py
+++ b/backend/src/pqdb_api/services/crud.py
@@ -10,6 +10,7 @@ Sensitive columns are routed to their physical shadow columns:
 from __future__ import annotations
 
 import enum
+import uuid
 from typing import Any
 
 from pqdb_api.services.schema_engine import validate_table_name
@@ -313,3 +314,79 @@ def build_delete_sql(
 
     sql += " RETURNING *"
     return sql, where_params
+
+
+# --- RLS enforcement helpers ---
+
+
+def _find_owner_column(
+    columns_meta: list[dict[str, Any]],
+) -> str | None:
+    """Find the owner column name from column metadata, if any."""
+    for col in columns_meta:
+        if col.get("is_owner"):
+            return str(col["name"])
+    return None
+
+
+def inject_rls_filters(
+    *,
+    filters: list[tuple[str, FilterOp, Any]],
+    columns_meta: list[dict[str, Any]],
+    key_role: str,
+    user_id: uuid.UUID | None,
+) -> list[tuple[str, FilterOp, Any]]:
+    """Inject RLS WHERE filters based on owner column and user context.
+
+    - service role: no RLS filtering (admin access)
+    - anon role + table has owner column + user context present:
+      appends WHERE {owner_col} = user_id
+    - anon role + table has owner column + NO user context:
+      raises CrudError (403)
+    - table has no owner column: no RLS applied
+    """
+    owner_col = _find_owner_column(columns_meta)
+    if owner_col is None:
+        return list(filters)
+
+    if key_role == "service":
+        return list(filters)
+
+    # anon role with owner column
+    if user_id is None:
+        raise CrudError("User context required for tables with owner column")
+
+    result = list(filters)
+    result.append((owner_col, FilterOp.EQ, str(user_id)))
+    return result
+
+
+def validate_owner_for_insert(
+    *,
+    row: dict[str, Any],
+    columns_meta: list[dict[str, Any]],
+    key_role: str,
+    user_id: uuid.UUID | None,
+) -> None:
+    """Validate that insert rows respect owner column constraints.
+
+    - service role: no validation
+    - anon role + owner column: row must include owner column matching user_id
+    - no owner column: no validation
+    """
+    owner_col = _find_owner_column(columns_meta)
+    if owner_col is None:
+        return
+
+    if key_role == "service":
+        return
+
+    # anon role with owner column
+    if user_id is None:
+        raise CrudError("User context required for tables with owner column")
+
+    if owner_col not in row:
+        raise CrudError(f"Owner column {owner_col!r} required in insert data")
+
+    if str(row[owner_col]) != str(user_id):
+        raise CrudError(f"Owner column {owner_col!r} must match authenticated user")

--- a/backend/src/pqdb_api/services/schema_engine.py
+++ b/backend/src/pqdb_api/services/schema_engine.py
@@ -63,6 +63,7 @@ _SQL_CREATE_METADATA_PG = _SAFE(
     "  column_name text NOT NULL,"
     "  sensitivity text NOT NULL,"
     "  data_type text NOT NULL,"
+    "  is_owner boolean NOT NULL DEFAULT false,"
     "  created_at timestamptz NOT NULL DEFAULT now(),"
     "  UNIQUE(table_name, column_name)"
     ")"
@@ -75,9 +76,15 @@ _SQL_CREATE_METADATA_SQLITE = _SAFE(
     "  column_name TEXT NOT NULL,"
     "  sensitivity TEXT NOT NULL,"
     "  data_type TEXT NOT NULL,"
+    "  is_owner BOOLEAN NOT NULL DEFAULT 0,"
     "  created_at TEXT NOT NULL DEFAULT (datetime('now')),"
     "  UNIQUE(table_name, column_name)"
     ")"
+)
+
+_SQL_MIGRATE_IS_OWNER_PG = _SAFE(
+    "ALTER TABLE _pqdb_columns "
+    "ADD COLUMN IF NOT EXISTS is_owner boolean NOT NULL DEFAULT false"
 )
 
 _SQL_TABLE_EXISTS_PG = _SAFE(
@@ -96,8 +103,8 @@ _SQL_TABLE_EXISTS_SQLITE = _SAFE(
 
 _SQL_INSERT_METADATA = _SAFE(
     "INSERT INTO _pqdb_columns "
-    "(table_name, column_name, sensitivity, data_type) "
-    "VALUES (:table_name, :column_name, :sensitivity, :data_type)"
+    "(table_name, column_name, sensitivity, data_type, is_owner) "
+    "VALUES (:table_name, :column_name, :sensitivity, :data_type, :is_owner)"
 )
 
 _SQL_DISTINCT_TABLES = _SAFE(
@@ -105,7 +112,7 @@ _SQL_DISTINCT_TABLES = _SAFE(
 )
 
 _SQL_TABLE_COLUMNS = _SAFE(
-    "SELECT column_name, sensitivity, data_type "
+    "SELECT column_name, sensitivity, data_type, is_owner "
     "FROM _pqdb_columns "
     "WHERE table_name = :name ORDER BY id"
 )
@@ -198,6 +205,7 @@ class ColumnDefinition:
     name: str
     data_type: str
     sensitivity: Sensitivity = "plain"
+    is_owner: bool = False
 
     def __post_init__(self) -> None:
         if self.sensitivity not in _VALID_SENSITIVITIES:
@@ -208,6 +216,12 @@ class ColumnDefinition:
         validate_column_name(self.name)
         # Normalize and validate data_type to prevent SQL injection in DDL
         object.__setattr__(self, "data_type", validate_data_type(self.data_type))
+        # Owner column constraints
+        if self.is_owner:
+            if self.data_type != "uuid":
+                raise ValueError("Owner column must be uuid type")
+            if self.sensitivity != "plain":
+                raise ValueError("Owner column must have plain sensitivity")
 
 
 @dataclass
@@ -222,10 +236,15 @@ class TableDefinition:
         if not self.columns:
             raise ValueError("Table must have at least one column")
         seen: set[str] = set()
+        owner_count = 0
         for col in self.columns:
             if col.name in seen:
                 raise ValueError(f"Duplicate column name: {col.name!r}")
             seen.add(col.name)
+            if col.is_owner:
+                owner_count += 1
+        if owner_count > 1:
+            raise ValueError("At most one column can be marked is_owner")
 
 
 def map_sensitivity_to_physical(
@@ -329,11 +348,17 @@ def _build_create_table_sql(table_name: str, col_defs: list[str]) -> str:
 
 
 async def ensure_metadata_table(session: AsyncSession) -> None:
-    """Create the _pqdb_columns metadata table if needed."""
+    """Create the _pqdb_columns metadata table if needed.
+
+    Also runs migrations to add columns introduced in later versions
+    (e.g. is_owner) so existing project databases stay up to date.
+    """
     if _is_sqlite(session):
         await session.execute(_SQL_CREATE_METADATA_SQLITE)
     else:
         await session.execute(_SQL_CREATE_METADATA_PG)
+        # Migration: add is_owner column for existing projects
+        await session.execute(_SQL_MIGRATE_IS_OWNER_PG)
 
 
 async def create_table(
@@ -372,6 +397,7 @@ async def create_table(
                 "column_name": col.name,
                 "sensitivity": col.sensitivity,
                 "data_type": col.data_type,
+                "is_owner": col.is_owner,
             },
         )
 
@@ -420,13 +446,14 @@ async def _get_table_metadata(
     if not rows:
         return None
 
-    columns: list[dict[str, str]] = []
+    columns: list[dict[str, object]] = []
     for row in rows:
         columns.append(
             {
                 "name": row[0],
                 "sensitivity": row[1],
                 "data_type": row[2],
+                "is_owner": bool(row[3]),
             }
         )
 
@@ -449,17 +476,22 @@ _SEARCHABLE_OPERATIONS: list[str] = ["eq", "in"]
 
 
 def build_introspection_column(
-    name: str, data_type: str, sensitivity: str
+    name: str,
+    data_type: str,
+    sensitivity: str,
+    *,
+    is_owner: bool = False,
 ) -> dict[str, object]:
     """Build introspection metadata for a single column.
 
-    Returns name, type, sensitivity, queryable flag, and
+    Returns name, type, sensitivity, is_owner, queryable flag, and
     operations/note based on sensitivity level.
     """
     result: dict[str, object] = {
         "name": name,
         "type": data_type,
         "sensitivity": sensitivity,
+        "is_owner": is_owner,
     }
     if sensitivity == "plain":
         result["queryable"] = True
@@ -474,13 +506,13 @@ def build_introspection_column(
 
 
 def build_introspection_table(
-    table_name: str, columns: list[dict[str, str]]
+    table_name: str, columns: list[dict[str, object]]
 ) -> dict[str, object]:
     """Build introspection metadata for a table.
 
     Includes sensitivity_summary with counts per level.
     ``columns`` is a list of dicts with keys:
-    name, data_type, sensitivity.
+    name, data_type, sensitivity, is_owner.
     """
     introspection_columns: list[dict[str, object]] = []
     summary: dict[str, int] = {
@@ -489,13 +521,14 @@ def build_introspection_table(
         "plain": 0,
     }
     for col in columns:
-        sensitivity = col["sensitivity"]
+        sensitivity = str(col["sensitivity"])
         summary[sensitivity] = summary.get(sensitivity, 0) + 1
         introspection_columns.append(
             build_introspection_column(
-                col["name"],
-                col["data_type"],
+                str(col["name"]),
+                str(col["data_type"]),
                 sensitivity,
+                is_owner=bool(col.get("is_owner", False)),
             )
         )
     return {
@@ -521,11 +554,12 @@ async def introspect_all_tables(
             {"name": name},
         )
         rows = table_result.fetchall()
-        columns = [
+        columns: list[dict[str, object]] = [
             {
                 "name": r[0],
                 "data_type": r[2],
                 "sensitivity": r[1],
+                "is_owner": bool(r[3]),
             }
             for r in rows
         ]
@@ -549,11 +583,12 @@ async def introspect_table(
     if not rows:
         return None
 
-    columns = [
+    columns: list[dict[str, object]] = [
         {
             "name": r[0],
             "data_type": r[2],
             "sensitivity": r[1],
+            "is_owner": bool(r[3]),
         }
         for r in rows
     ]
@@ -564,13 +599,14 @@ def _build_table_response(
     table: TableDefinition,
 ) -> dict[str, object]:
     """Build the API response for a created table."""
-    columns: list[dict[str, str]] = []
+    columns: list[dict[str, object]] = []
     for col in table.columns:
         columns.append(
             {
                 "name": col.name,
                 "sensitivity": col.sensitivity,
                 "data_type": col.data_type,
+                "is_owner": col.is_owner,
             }
         )
     return {
@@ -583,7 +619,7 @@ async def add_column(
     session: AsyncSession,
     table_name: str,
     col: ColumnDefinition,
-) -> dict[str, str]:
+) -> dict[str, object]:
     """Add a column to an existing table with shadow column mapping.
 
     1. Validates table exists (via _pqdb_columns metadata)
@@ -610,6 +646,13 @@ async def add_column(
     if result.fetchone() is not None:
         raise ValueError(f"Column {col.name!r} already exists in table {table_name!r}")
 
+    # If marking as owner, check no existing owner column
+    if col.is_owner:
+        assert isinstance(table_meta["columns"], list)
+        for existing_col in table_meta["columns"]:
+            if existing_col.get("is_owner"):
+                raise ValueError(f"Table {table_name!r} already has an owner column")
+
     # Execute DDL
     for stmt in build_add_column_ddl(table_name, col):
         await session.execute(_SAFE(stmt))
@@ -622,6 +665,7 @@ async def add_column(
             "column_name": col.name,
             "sensitivity": col.sensitivity,
             "data_type": col.data_type,
+            "is_owner": col.is_owner,
         },
     )
 
@@ -632,12 +676,14 @@ async def add_column(
         table=table_name,
         column=col.name,
         sensitivity=col.sensitivity,
+        is_owner=col.is_owner,
     )
 
     return {
         "name": col.name,
         "sensitivity": col.sensitivity,
         "data_type": col.data_type,
+        "is_owner": col.is_owner,
     }
 
 

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -420,8 +420,11 @@ def _make_project_app(test_db_url: str) -> FastAPI:
     """Build a minimal test app for project-scoped endpoints.
 
     Creates its own engine inside the lifespan so it runs on
-    the TestClient's event loop.
+    the TestClient's event loop. Uses service role by default so
+    CRUD endpoints work without user auth (no RLS filtering).
     """
+    from pqdb_api.middleware.api_key import ProjectContext, get_project_context
+    from pqdb_api.middleware.user_auth import get_current_user
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -434,7 +437,19 @@ def _make_project_app(test_db_url: str) -> FastAPI:
             async with session_factory() as session:
                 yield session
 
+        async def _override_project_context() -> ProjectContext:
+            return ProjectContext(
+                project_id=uuid.uuid4(),
+                key_role="service",
+                database_name="test",
+            )
+
+        async def _override_current_user() -> None:
+            return None
+
         app.dependency_overrides[get_project_session] = _override_get_project_session
+        app.dependency_overrides[get_project_context] = _override_project_context
+        app.dependency_overrides[get_current_user] = _override_current_user
         yield
         await engine.dispose()
 

--- a/backend/tests/integration/test_owner_rls.py
+++ b/backend/tests/integration/test_owner_rls.py
@@ -1,0 +1,575 @@
+"""Integration tests for owner column + RLS enforcement (US-028).
+
+Boots the real FastAPI app with a real Postgres database.
+Tests:
+- Create table with owner column
+- Owner column in schema introspection
+- RLS: anon user sees only own rows
+- RLS: service role sees all rows
+- RLS: cross-user isolation
+- RLS: anon without user context on owner table returns 403
+- Add owner column to existing table
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from pqdb_api.middleware.api_key import (
+    ProjectContext,
+    get_project_context,
+    get_project_session,
+)
+from pqdb_api.middleware.user_auth import UserContext, get_current_user
+from pqdb_api.routes.db import router as db_router
+from pqdb_api.routes.health import router as health_router
+from pqdb_api.services.auth import generate_ed25519_keypair
+
+
+def _make_rls_app(
+    test_db_url: str,
+    *,
+    key_role: str = "anon",
+    user_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+) -> FastAPI:
+    """Build a test app with configurable ProjectContext and UserContext.
+
+    This allows testing RLS behavior with different roles and user contexts
+    without needing real API key / JWT infrastructure.
+    """
+    _project_id = project_id or uuid.uuid4()
+    _private_key, _public_key = generate_ed25519_keypair()
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        engine = create_async_engine(test_db_url)
+        session_factory = async_sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+        async def _override_project_session() -> AsyncIterator[AsyncSession]:
+            async with session_factory() as session:
+                yield session
+
+        async def _override_project_context() -> ProjectContext:
+            return ProjectContext(
+                project_id=_project_id,
+                key_role=key_role,
+                database_name="test",
+            )
+
+        async def _override_current_user() -> UserContext | None:
+            if user_id is None:
+                return None
+            return UserContext(
+                user_id=user_id,
+                project_id=_project_id,
+                role="authenticated",
+                email_verified=True,
+            )
+
+        app.dependency_overrides[get_project_session] = _override_project_session
+        app.dependency_overrides[get_project_context] = _override_project_context
+        app.dependency_overrides[get_current_user] = _override_current_user
+        app.state.jwt_public_key = _public_key
+        yield
+        await engine.dispose()
+
+    app = FastAPI(lifespan=lifespan)
+    app.include_router(health_router)
+    app.include_router(db_router)
+    return app
+
+
+class TestCreateTableWithOwner:
+    """POST /v1/db/tables with owner column."""
+
+    @pytest.fixture()
+    def client(self, test_db_url: str) -> Iterator[TestClient]:
+        app = _make_rls_app(test_db_url, key_role="service")
+        with TestClient(app) as c:
+            yield c
+
+    def test_create_table_with_owner_column(self, client: TestClient) -> None:
+        resp = client.post(
+            "/v1/db/tables",
+            json={
+                "name": "items",
+                "columns": [
+                    {"name": "title", "data_type": "text", "sensitivity": "plain"},
+                    {
+                        "name": "user_id",
+                        "data_type": "uuid",
+                        "sensitivity": "plain",
+                        "owner": True,
+                    },
+                ],
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        cols = {c["name"]: c for c in data["columns"]}
+        assert cols["user_id"]["is_owner"] is True
+        assert cols["title"]["is_owner"] is False
+
+    def test_create_table_multiple_owners_rejected(self, client: TestClient) -> None:
+        resp = client.post(
+            "/v1/db/tables",
+            json={
+                "name": "bad_table",
+                "columns": [
+                    {"name": "user_id", "data_type": "uuid", "owner": True},
+                    {"name": "owner_id", "data_type": "uuid", "owner": True},
+                ],
+            },
+        )
+        assert resp.status_code == 400
+        assert "is_owner" in resp.json()["detail"]
+
+    def test_owner_column_must_be_uuid(self, client: TestClient) -> None:
+        resp = client.post(
+            "/v1/db/tables",
+            json={
+                "name": "bad_type",
+                "columns": [
+                    {"name": "user_id", "data_type": "text", "owner": True},
+                ],
+            },
+        )
+        assert resp.status_code == 400
+        assert "uuid" in resp.json()["detail"].lower()
+
+    def test_owner_column_must_be_plain(self, client: TestClient) -> None:
+        resp = client.post(
+            "/v1/db/tables",
+            json={
+                "name": "bad_sens",
+                "columns": [
+                    {
+                        "name": "user_id",
+                        "data_type": "uuid",
+                        "sensitivity": "private",
+                        "owner": True,
+                    },
+                ],
+            },
+        )
+        assert resp.status_code == 400
+        assert "plain" in resp.json()["detail"].lower()
+
+
+class TestIntrospectionWithOwner:
+    """Schema introspection includes is_owner."""
+
+    @pytest.fixture()
+    def client(self, test_db_url: str) -> Iterator[TestClient]:
+        app = _make_rls_app(test_db_url, key_role="service")
+        with TestClient(app) as c:
+            yield c
+
+    def test_introspect_shows_is_owner(self, client: TestClient) -> None:
+        client.post(
+            "/v1/db/tables",
+            json={
+                "name": "items",
+                "columns": [
+                    {"name": "title", "data_type": "text"},
+                    {"name": "user_id", "data_type": "uuid", "owner": True},
+                ],
+            },
+        )
+        resp = client.get("/v1/db/introspect/items")
+        assert resp.status_code == 200
+        cols = {c["name"]: c for c in resp.json()["columns"]}
+        assert cols["user_id"]["is_owner"] is True
+        assert cols["title"]["is_owner"] is False
+
+    def test_get_table_shows_is_owner(self, client: TestClient) -> None:
+        client.post(
+            "/v1/db/tables",
+            json={
+                "name": "items",
+                "columns": [
+                    {"name": "title", "data_type": "text"},
+                    {"name": "user_id", "data_type": "uuid", "owner": True},
+                ],
+            },
+        )
+        resp = client.get("/v1/db/tables/items")
+        assert resp.status_code == 200
+        cols = {c["name"]: c for c in resp.json()["columns"]}
+        assert cols["user_id"]["is_owner"] is True
+
+
+def _create_owner_table(client: TestClient) -> None:
+    """Helper: create a table with an owner column."""
+    resp = client.post(
+        "/v1/db/tables",
+        json={
+            "name": "items",
+            "columns": [
+                {"name": "title", "data_type": "text", "sensitivity": "plain"},
+                {
+                    "name": "user_id",
+                    "data_type": "uuid",
+                    "sensitivity": "plain",
+                    "owner": True,
+                },
+            ],
+        },
+    )
+    assert resp.status_code == 201
+
+
+class TestRlsSelectIsolation:
+    """Anon users only see their own rows; service sees all."""
+
+    def test_anon_user_sees_only_own_rows(self, test_db_url: str) -> None:
+        user_a = uuid.uuid4()
+        user_b = uuid.uuid4()
+        project_id = uuid.uuid4()
+
+        # Service role inserts rows for both users
+        svc_app = _make_rls_app(test_db_url, key_role="service", project_id=project_id)
+        with TestClient(svc_app) as svc:
+            _create_owner_table(svc)
+            svc.post(
+                "/v1/db/items/insert",
+                json={
+                    "rows": [
+                        {"title": "A item", "user_id": str(user_a)},
+                        {"title": "B item", "user_id": str(user_b)},
+                    ]
+                },
+            )
+
+        # User A with anon role
+        anon_a_app = _make_rls_app(
+            test_db_url, key_role="anon", user_id=user_a, project_id=project_id
+        )
+        with TestClient(anon_a_app) as anon_a:
+            resp = anon_a.post("/v1/db/items/select", json={})
+            assert resp.status_code == 200
+            data = resp.json()["data"]
+            assert len(data) == 1
+            assert data[0]["title"] == "A item"
+
+        # User B with anon role
+        anon_b_app = _make_rls_app(
+            test_db_url, key_role="anon", user_id=user_b, project_id=project_id
+        )
+        with TestClient(anon_b_app) as anon_b:
+            resp = anon_b.post("/v1/db/items/select", json={})
+            assert resp.status_code == 200
+            data = resp.json()["data"]
+            assert len(data) == 1
+            assert data[0]["title"] == "B item"
+
+    def test_service_role_sees_all_rows(self, test_db_url: str) -> None:
+        user_a = uuid.uuid4()
+        user_b = uuid.uuid4()
+        project_id = uuid.uuid4()
+
+        svc_app = _make_rls_app(test_db_url, key_role="service", project_id=project_id)
+        with TestClient(svc_app) as svc:
+            _create_owner_table(svc)
+            svc.post(
+                "/v1/db/items/insert",
+                json={
+                    "rows": [
+                        {"title": "A item", "user_id": str(user_a)},
+                        {"title": "B item", "user_id": str(user_b)},
+                    ]
+                },
+            )
+            resp = svc.post("/v1/db/items/select", json={})
+            assert resp.status_code == 200
+            data = resp.json()["data"]
+            assert len(data) == 2
+
+
+class TestRlsInsertEnforcement:
+    """Anon insert must set owner column to authenticated user."""
+
+    def test_anon_insert_matching_owner_succeeds(self, test_db_url: str) -> None:
+        user_id = uuid.uuid4()
+        project_id = uuid.uuid4()
+
+        # Create table with service role
+        svc_app = _make_rls_app(test_db_url, key_role="service", project_id=project_id)
+        with TestClient(svc_app) as svc:
+            _create_owner_table(svc)
+
+        # Insert with anon role
+        anon_app = _make_rls_app(
+            test_db_url, key_role="anon", user_id=user_id, project_id=project_id
+        )
+        with TestClient(anon_app) as anon:
+            resp = anon.post(
+                "/v1/db/items/insert",
+                json={"rows": [{"title": "My item", "user_id": str(user_id)}]},
+            )
+            assert resp.status_code == 201
+
+    def test_anon_insert_mismatched_owner_rejected(self, test_db_url: str) -> None:
+        user_id = uuid.uuid4()
+        other_id = uuid.uuid4()
+        project_id = uuid.uuid4()
+
+        svc_app = _make_rls_app(test_db_url, key_role="service", project_id=project_id)
+        with TestClient(svc_app) as svc:
+            _create_owner_table(svc)
+
+        anon_app = _make_rls_app(
+            test_db_url, key_role="anon", user_id=user_id, project_id=project_id
+        )
+        with TestClient(anon_app) as anon:
+            resp = anon.post(
+                "/v1/db/items/insert",
+                json={"rows": [{"title": "Sneaky", "user_id": str(other_id)}]},
+            )
+            assert resp.status_code == 400
+            assert "must match" in resp.json()["detail"]
+
+    def test_anon_insert_missing_owner_rejected(self, test_db_url: str) -> None:
+        user_id = uuid.uuid4()
+        project_id = uuid.uuid4()
+
+        svc_app = _make_rls_app(test_db_url, key_role="service", project_id=project_id)
+        with TestClient(svc_app) as svc:
+            _create_owner_table(svc)
+
+        anon_app = _make_rls_app(
+            test_db_url, key_role="anon", user_id=user_id, project_id=project_id
+        )
+        with TestClient(anon_app) as anon:
+            resp = anon.post(
+                "/v1/db/items/insert",
+                json={"rows": [{"title": "No owner"}]},
+            )
+            assert resp.status_code == 400
+            assert "required" in resp.json()["detail"]
+
+
+class TestRlsUpdateDeleteIsolation:
+    """Anon can only update/delete own rows."""
+
+    def test_anon_update_own_row(self, test_db_url: str) -> None:
+        user_a = uuid.uuid4()
+        user_b = uuid.uuid4()
+        project_id = uuid.uuid4()
+
+        svc_app = _make_rls_app(test_db_url, key_role="service", project_id=project_id)
+        with TestClient(svc_app) as svc:
+            _create_owner_table(svc)
+            svc.post(
+                "/v1/db/items/insert",
+                json={
+                    "rows": [
+                        {"title": "A item", "user_id": str(user_a)},
+                        {"title": "B item", "user_id": str(user_b)},
+                    ]
+                },
+            )
+
+        # User A tries to update all — RLS limits to own rows
+        anon_app = _make_rls_app(
+            test_db_url, key_role="anon", user_id=user_a, project_id=project_id
+        )
+        with TestClient(anon_app) as anon:
+            resp = anon.post(
+                "/v1/db/items/update",
+                json={
+                    "values": {"title": "Updated"},
+                    "filters": [{"column": "title", "op": "eq", "value": "A item"}],
+                },
+            )
+            assert resp.status_code == 200
+            data = resp.json()["data"]
+            assert len(data) == 1
+            assert data[0]["title"] == "Updated"
+
+        # Verify B's item is untouched
+        with TestClient(svc_app) as svc:
+            resp = svc.post(
+                "/v1/db/items/select",
+                json={"filters": [{"column": "title", "op": "eq", "value": "B item"}]},
+            )
+            assert len(resp.json()["data"]) == 1
+
+    def test_anon_delete_own_row(self, test_db_url: str) -> None:
+        user_a = uuid.uuid4()
+        user_b = uuid.uuid4()
+        project_id = uuid.uuid4()
+
+        svc_app = _make_rls_app(test_db_url, key_role="service", project_id=project_id)
+        with TestClient(svc_app) as svc:
+            _create_owner_table(svc)
+            svc.post(
+                "/v1/db/items/insert",
+                json={
+                    "rows": [
+                        {"title": "A item", "user_id": str(user_a)},
+                        {"title": "B item", "user_id": str(user_b)},
+                    ]
+                },
+            )
+
+        # User A deletes — RLS limits to own rows
+        anon_app = _make_rls_app(
+            test_db_url, key_role="anon", user_id=user_a, project_id=project_id
+        )
+        with TestClient(anon_app) as anon:
+            resp = anon.post(
+                "/v1/db/items/delete",
+                json={"filters": [{"column": "title", "op": "eq", "value": "A item"}]},
+            )
+            assert resp.status_code == 200
+            assert len(resp.json()["data"]) == 1
+
+        # B's item still exists
+        with TestClient(svc_app) as svc:
+            resp = svc.post("/v1/db/items/select", json={})
+            assert len(resp.json()["data"]) == 1
+            assert resp.json()["data"][0]["title"] == "B item"
+
+
+class TestRlsNoUserContext:
+    """Anon without user context on owner table returns 403."""
+
+    def test_anon_no_user_select_returns_403(self, test_db_url: str) -> None:
+        project_id = uuid.uuid4()
+
+        svc_app = _make_rls_app(test_db_url, key_role="service", project_id=project_id)
+        with TestClient(svc_app) as svc:
+            _create_owner_table(svc)
+
+        # Anon without user context
+        anon_app = _make_rls_app(
+            test_db_url, key_role="anon", user_id=None, project_id=project_id
+        )
+        with TestClient(anon_app) as anon:
+            resp = anon.post("/v1/db/items/select", json={})
+            assert resp.status_code == 403
+
+    def test_anon_no_user_insert_returns_403(self, test_db_url: str) -> None:
+        project_id = uuid.uuid4()
+
+        svc_app = _make_rls_app(test_db_url, key_role="service", project_id=project_id)
+        with TestClient(svc_app) as svc:
+            _create_owner_table(svc)
+
+        anon_app = _make_rls_app(
+            test_db_url, key_role="anon", user_id=None, project_id=project_id
+        )
+        with TestClient(anon_app) as anon:
+            resp = anon.post(
+                "/v1/db/items/insert",
+                json={"rows": [{"title": "test", "user_id": str(uuid.uuid4())}]},
+            )
+            assert resp.status_code == 403
+
+
+class TestNoOwnerColumnNoRls:
+    """Tables without owner column have no RLS applied."""
+
+    @pytest.fixture()
+    def client(self, test_db_url: str) -> Iterator[TestClient]:
+        app = _make_rls_app(test_db_url, key_role="anon", user_id=uuid.uuid4())
+        with TestClient(app) as c:
+            yield c
+
+    def test_anon_can_freely_crud_without_owner(self, client: TestClient) -> None:
+        # Create table without owner column
+        client.post(
+            "/v1/db/tables",
+            json={
+                "name": "public_items",
+                "columns": [
+                    {"name": "title", "data_type": "text"},
+                    {"name": "age", "data_type": "integer"},
+                ],
+            },
+        )
+        # Insert
+        resp = client.post(
+            "/v1/db/public_items/insert",
+            json={"rows": [{"title": "Public", "age": 10}]},
+        )
+        assert resp.status_code == 201
+
+        # Select all
+        resp = client.post("/v1/db/public_items/select", json={})
+        assert resp.status_code == 200
+        assert len(resp.json()["data"]) == 1
+
+
+class TestAddOwnerColumn:
+    """POST /v1/db/tables/{name}/columns with owner flag."""
+
+    @pytest.fixture()
+    def client(self, test_db_url: str) -> Iterator[TestClient]:
+        app = _make_rls_app(test_db_url, key_role="service")
+        with TestClient(app) as c:
+            yield c
+
+    def test_add_owner_column_to_existing_table(self, client: TestClient) -> None:
+        # Create table without owner
+        client.post(
+            "/v1/db/tables",
+            json={
+                "name": "items",
+                "columns": [{"name": "title", "data_type": "text"}],
+            },
+        )
+        # Add owner column
+        resp = client.post(
+            "/v1/db/tables/items/columns",
+            json={"name": "user_id", "data_type": "uuid", "owner": True},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["is_owner"] is True
+
+    def test_add_second_owner_column_rejected(self, client: TestClient) -> None:
+        client.post(
+            "/v1/db/tables",
+            json={
+                "name": "items",
+                "columns": [
+                    {"name": "title", "data_type": "text"},
+                    {"name": "user_id", "data_type": "uuid", "owner": True},
+                ],
+            },
+        )
+        resp = client.post(
+            "/v1/db/tables/items/columns",
+            json={"name": "owner_id", "data_type": "uuid", "owner": True},
+        )
+        assert resp.status_code == 400
+        assert "already has an owner" in resp.json()["detail"]
+
+
+class TestHealthCheck:
+    """Health check still works."""
+
+    @pytest.fixture()
+    def client(self, test_db_url: str) -> Iterator[TestClient]:
+        app = _make_rls_app(test_db_url, key_role="service")
+        with TestClient(app) as c:
+            yield c
+
+    def test_health_returns_200(self, client: TestClient) -> None:
+        resp = client.get("/health")
+        assert resp.status_code == 200

--- a/backend/tests/unit/test_introspection.py
+++ b/backend/tests/unit/test_introspection.py
@@ -124,7 +124,7 @@ class TestBuildIntrospectionTable:
         }
 
     def test_single_plain_column(self) -> None:
-        columns = [
+        columns: list[dict[str, object]] = [
             {
                 "name": "age",
                 "data_type": "integer",
@@ -142,7 +142,7 @@ class TestBuildIntrospectionTable:
         assert cols[0]["queryable"] is True
 
     def test_mixed_sensitivity_summary(self) -> None:
-        columns = [
+        columns: list[dict[str, object]] = [
             {
                 "name": "display_name",
                 "data_type": "text",
@@ -170,7 +170,7 @@ class TestBuildIntrospectionTable:
         }
 
     def test_multiple_same_sensitivity(self) -> None:
-        columns = [
+        columns: list[dict[str, object]] = [
             {
                 "name": "name",
                 "data_type": "text",
@@ -195,7 +195,7 @@ class TestBuildIntrospectionTable:
         }
 
     def test_columns_have_correct_structure(self) -> None:
-        columns = [
+        columns: list[dict[str, object]] = [
             {
                 "name": "email",
                 "data_type": "text",

--- a/backend/tests/unit/test_owner_column.py
+++ b/backend/tests/unit/test_owner_column.py
@@ -1,0 +1,288 @@
+"""Unit tests for owner column marker + RLS enforcement (US-028).
+
+Tests:
+- ColumnDefinition accepts is_owner flag
+- Owner column must be uuid type, plain sensitivity
+- At most one owner column per table
+- RLS filter injection in CRUD SQL builders
+- Role-based RLS bypass (service role skips RLS)
+- Error cases (no user context on anon with owner table)
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from pqdb_api.services.crud import (
+    CrudError,
+    FilterOp,
+    build_select_sql,
+    inject_rls_filters,
+    validate_owner_for_insert,
+)
+from pqdb_api.services.schema_engine import (
+    ColumnDefinition,
+    TableDefinition,
+)
+
+# --- Column metadata with owner column ---
+
+COLUMNS_WITH_OWNER = [
+    {
+        "name": "display_name",
+        "sensitivity": "plain",
+        "data_type": "text",
+        "is_owner": False,
+    },
+    {"name": "user_id", "sensitivity": "plain", "data_type": "uuid", "is_owner": True},
+    {"name": "age", "sensitivity": "plain", "data_type": "integer", "is_owner": False},
+]
+
+COLUMNS_WITHOUT_OWNER = [
+    {
+        "name": "display_name",
+        "sensitivity": "plain",
+        "data_type": "text",
+        "is_owner": False,
+    },
+    {"name": "age", "sensitivity": "plain", "data_type": "integer", "is_owner": False},
+]
+
+
+class TestColumnDefinitionOwner:
+    """ColumnDefinition with is_owner flag."""
+
+    def test_owner_column_defaults_to_false(self) -> None:
+        col = ColumnDefinition(name="name", data_type="text", sensitivity="plain")
+        assert col.is_owner is False
+
+    def test_owner_column_set_to_true(self) -> None:
+        col = ColumnDefinition(
+            name="user_id", data_type="uuid", sensitivity="plain", is_owner=True
+        )
+        assert col.is_owner is True
+
+    def test_owner_column_must_be_uuid_type(self) -> None:
+        with pytest.raises(ValueError, match="Owner column must be uuid type"):
+            ColumnDefinition(
+                name="user_id", data_type="text", sensitivity="plain", is_owner=True
+            )
+
+    def test_owner_column_must_be_plain_sensitivity(self) -> None:
+        with pytest.raises(
+            ValueError, match="Owner column must have plain sensitivity"
+        ):
+            ColumnDefinition(
+                name="user_id", data_type="uuid", sensitivity="private", is_owner=True
+            )
+
+    def test_non_owner_column_any_type_ok(self) -> None:
+        """Non-owner columns can be any type."""
+        col = ColumnDefinition(name="name", data_type="text", sensitivity="plain")
+        assert col.is_owner is False
+
+
+class TestTableDefinitionOwner:
+    """TableDefinition enforces at most one owner column."""
+
+    def test_single_owner_column_allowed(self) -> None:
+        table = TableDefinition(
+            name="items",
+            columns=[
+                ColumnDefinition(name="title", data_type="text"),
+                ColumnDefinition(
+                    name="user_id", data_type="uuid", sensitivity="plain", is_owner=True
+                ),
+            ],
+        )
+        assert len(table.columns) == 2
+
+    def test_multiple_owner_columns_rejected(self) -> None:
+        with pytest.raises(ValueError, match="At most one column.*is_owner"):
+            TableDefinition(
+                name="items",
+                columns=[
+                    ColumnDefinition(
+                        name="user_id",
+                        data_type="uuid",
+                        sensitivity="plain",
+                        is_owner=True,
+                    ),
+                    ColumnDefinition(
+                        name="owner_id",
+                        data_type="uuid",
+                        sensitivity="plain",
+                        is_owner=True,
+                    ),
+                ],
+            )
+
+    def test_no_owner_column_ok(self) -> None:
+        table = TableDefinition(
+            name="items",
+            columns=[ColumnDefinition(name="title", data_type="text")],
+        )
+        assert len(table.columns) == 1
+
+
+class TestInjectRlsFilters:
+    """inject_rls_filters adds WHERE owner_col = user_id for anon role."""
+
+    def test_anon_with_user_injects_filter(self) -> None:
+        user_id = uuid.uuid4()
+        filters: list[tuple[str, FilterOp, object]] = []
+        result = inject_rls_filters(
+            filters=filters,
+            columns_meta=COLUMNS_WITH_OWNER,
+            key_role="anon",
+            user_id=user_id,
+        )
+        assert len(result) == 1
+        col, op, val = result[0]
+        assert col == "user_id"
+        assert op == FilterOp.EQ
+        assert val == str(user_id)
+
+    def test_anon_preserves_existing_filters(self) -> None:
+        user_id = uuid.uuid4()
+        existing = [("age", FilterOp.GT, 18)]
+        result = inject_rls_filters(
+            filters=existing,
+            columns_meta=COLUMNS_WITH_OWNER,
+            key_role="anon",
+            user_id=user_id,
+        )
+        assert len(result) == 2
+        # First filter preserved
+        assert result[0] == ("age", FilterOp.GT, 18)
+        # RLS filter appended
+        assert result[1][0] == "user_id"
+
+    def test_service_role_skips_rls(self) -> None:
+        user_id = uuid.uuid4()
+        filters: list[tuple[str, FilterOp, object]] = []
+        result = inject_rls_filters(
+            filters=filters,
+            columns_meta=COLUMNS_WITH_OWNER,
+            key_role="service",
+            user_id=user_id,
+        )
+        assert result == []
+
+    def test_no_owner_column_skips_rls(self) -> None:
+        user_id = uuid.uuid4()
+        filters: list[tuple[str, FilterOp, object]] = []
+        result = inject_rls_filters(
+            filters=filters,
+            columns_meta=COLUMNS_WITHOUT_OWNER,
+            key_role="anon",
+            user_id=user_id,
+        )
+        assert result == []
+
+    def test_anon_no_user_raises_on_owner_table(self) -> None:
+        with pytest.raises(CrudError, match="User context required"):
+            inject_rls_filters(
+                filters=[],
+                columns_meta=COLUMNS_WITH_OWNER,
+                key_role="anon",
+                user_id=None,
+            )
+
+    def test_anon_no_user_ok_on_no_owner_table(self) -> None:
+        result = inject_rls_filters(
+            filters=[],
+            columns_meta=COLUMNS_WITHOUT_OWNER,
+            key_role="anon",
+            user_id=None,
+        )
+        assert result == []
+
+
+class TestValidateOwnerForInsert:
+    """validate_owner_for_insert ensures owner_column matches user_id."""
+
+    def test_anon_owner_matches_user_id(self) -> None:
+        user_id = uuid.uuid4()
+        row = {"display_name": "Alice", "user_id": str(user_id), "age": 30}
+        # Should not raise
+        validate_owner_for_insert(
+            row=row,
+            columns_meta=COLUMNS_WITH_OWNER,
+            key_role="anon",
+            user_id=user_id,
+        )
+
+    def test_anon_owner_mismatch_raises(self) -> None:
+        user_id = uuid.uuid4()
+        other_id = uuid.uuid4()
+        row = {"display_name": "Alice", "user_id": str(other_id), "age": 30}
+        with pytest.raises(CrudError, match="Owner column.*must match"):
+            validate_owner_for_insert(
+                row=row,
+                columns_meta=COLUMNS_WITH_OWNER,
+                key_role="anon",
+                user_id=user_id,
+            )
+
+    def test_anon_owner_missing_raises(self) -> None:
+        user_id = uuid.uuid4()
+        row = {"display_name": "Alice", "age": 30}
+        with pytest.raises(CrudError, match="Owner column.*required"):
+            validate_owner_for_insert(
+                row=row,
+                columns_meta=COLUMNS_WITH_OWNER,
+                key_role="anon",
+                user_id=user_id,
+            )
+
+    def test_service_role_skips_validation(self) -> None:
+        other_id = uuid.uuid4()
+        row = {"display_name": "Alice", "user_id": str(other_id), "age": 30}
+        # Service role doesn't validate owner
+        validate_owner_for_insert(
+            row=row,
+            columns_meta=COLUMNS_WITH_OWNER,
+            key_role="service",
+            user_id=None,
+        )
+
+    def test_no_owner_column_skips_validation(self) -> None:
+        row = {"display_name": "Alice", "age": 30}
+        validate_owner_for_insert(
+            row=row,
+            columns_meta=COLUMNS_WITHOUT_OWNER,
+            key_role="anon",
+            user_id=uuid.uuid4(),
+        )
+
+
+class TestRlsWithSelectSql:
+    """Verify RLS filters integrate correctly with build_select_sql."""
+
+    def test_select_with_rls_filter(self) -> None:
+        user_id = uuid.uuid4()
+        rls_filters = inject_rls_filters(
+            filters=[],
+            columns_meta=COLUMNS_WITH_OWNER,
+            key_role="anon",
+            user_id=user_id,
+        )
+        sql, params = build_select_sql("items", filters=rls_filters)
+        assert "WHERE" in sql
+        assert "user_id" in sql
+        assert str(user_id) in str(params.values())
+
+    def test_select_with_existing_and_rls_filters(self) -> None:
+        user_id = uuid.uuid4()
+        existing = [("age", FilterOp.GT, 18)]
+        rls_filters = inject_rls_filters(
+            filters=existing,
+            columns_meta=COLUMNS_WITH_OWNER,
+            key_role="anon",
+            user_id=user_id,
+        )
+        sql, params = build_select_sql("items", filters=rls_filters)
+        assert "AND" in sql


### PR DESCRIPTION
## Summary

- Add `is_owner` flag to column definitions (must be uuid type, plain sensitivity, max one per table)
- `_pqdb_columns` metadata table gains `is_owner` column with automatic migration for existing projects
- `POST /v1/db/tables` and `POST /v1/db/tables/{name}/columns` accept `owner: true` in column definitions
- Schema introspection endpoints include `is_owner` in column metadata
- CRUD endpoints enforce row-level security:
  - **anon role**: SELECT/UPDATE/DELETE inject `WHERE {owner_col} = :user_id`; INSERT validates owner column matches authenticated user
  - **service role**: no RLS filtering (admin access)
  - **anon without UserContext on owner table**: returns 403
  - **tables without owner column**: no RLS applied

## Test plan

- [x] 21 unit tests: column marker validation, RLS filter injection, role-based bypass, error cases
- [x] 19 integration tests: real Postgres — cross-user isolation, service role sees all, 403 on missing context, add owner column to existing table
- [x] 549 total tests pass (unit + integration)
- [x] `ruff check` clean
- [x] `mypy --strict` clean
- [x] Health check passes

Generated with [Claude Code](https://claude.com/claude-code)