### PR TITLE
Fix owner column UPDATE privilege escalation

### DIFF
--- a/backend/src/pqdb_api/routes/db.py
+++ b/backend/src/pqdb_api/routes/db.py
@@ -33,6 +33,7 @@ from pqdb_api.services.crud import (
     validate_columns_for_insert,
     validate_filter_column,
     validate_owner_for_insert,
+    validate_owner_for_update,
 )
 from pqdb_api.services.schema_engine import (
     ColumnDefinition,
@@ -561,6 +562,17 @@ async def update_rows(
                 physical_updates[physical_col] = val
     except CrudError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Reject owner column changes for non-service roles
+    try:
+        validate_owner_for_update(
+            updates=body.values,
+            columns_meta=columns_meta,
+            key_role=context.key_role,
+            user_id=user.user_id if user else None,
+        )
+    except CrudError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
 
     # Parse filters
     try:

--- a/backend/src/pqdb_api/services/crud.py
+++ b/backend/src/pqdb_api/services/crud.py
@@ -390,3 +390,27 @@ def validate_owner_for_insert(
 
     if str(row[owner_col]) != str(user_id):
         raise CrudError(f"Owner column {owner_col!r} must match authenticated user")
+
+
+def validate_owner_for_update(
+    *,
+    updates: dict[str, Any],
+    columns_meta: list[dict[str, Any]],
+    key_role: str,
+    user_id: uuid.UUID | None,
+) -> None:
+    """Validate that update values do not change the owner column.
+
+    - service role: no validation (admin can reassign ownership)
+    - anon role + owner column in updates: reject unconditionally
+    - no owner column in table: no validation
+    """
+    owner_col = _find_owner_column(columns_meta)
+    if owner_col is None:
+        return
+
+    if key_role == "service":
+        return
+
+    if owner_col in updates:
+        raise CrudError("Cannot change owner column")

--- a/backend/tests/integration/test_owner_rls.py
+++ b/backend/tests/integration/test_owner_rls.py
@@ -446,6 +446,91 @@ class TestRlsUpdateDeleteIsolation:
             assert resp.json()["data"][0]["title"] == "B item"
 
 
+class TestRlsUpdateOwnerEscalation:
+    """Anon user cannot change owner column value on UPDATE."""
+
+    def test_anon_update_owner_column_to_different_user_rejected(
+        self, test_db_url: str
+    ) -> None:
+        """Anon tries to transfer row ownership to another user — must get 403."""
+        user_a = uuid.uuid4()
+        user_b = uuid.uuid4()
+        project_id = uuid.uuid4()
+
+        # Service role creates table and inserts a row for user_a
+        svc_app = _make_rls_app(test_db_url, key_role="service", project_id=project_id)
+        with TestClient(svc_app) as svc:
+            _create_owner_table(svc)
+            svc.post(
+                "/v1/db/items/insert",
+                json={"rows": [{"title": "A item", "user_id": str(user_a)}]},
+            )
+
+        # User A (anon) tries to change user_id to user_b
+        anon_app = _make_rls_app(
+            test_db_url, key_role="anon", user_id=user_a, project_id=project_id
+        )
+        with TestClient(anon_app) as anon:
+            resp = anon.post(
+                "/v1/db/items/update",
+                json={
+                    "values": {"user_id": str(user_b)},
+                    "filters": [{"column": "title", "op": "eq", "value": "A item"}],
+                },
+            )
+            assert resp.status_code == 403
+            assert "Cannot change owner column" in resp.json()["detail"]
+
+    def test_anon_update_owner_to_same_value_rejected(self, test_db_url: str) -> None:
+        """Even setting owner to the same user_id is rejected."""
+        user_a = uuid.uuid4()
+        project_id = uuid.uuid4()
+
+        svc_app = _make_rls_app(test_db_url, key_role="service", project_id=project_id)
+        with TestClient(svc_app) as svc:
+            _create_owner_table(svc)
+            svc.post(
+                "/v1/db/items/insert",
+                json={"rows": [{"title": "A item", "user_id": str(user_a)}]},
+            )
+
+        anon_app = _make_rls_app(
+            test_db_url, key_role="anon", user_id=user_a, project_id=project_id
+        )
+        with TestClient(anon_app) as anon:
+            resp = anon.post(
+                "/v1/db/items/update",
+                json={
+                    "values": {"user_id": str(user_a)},
+                    "filters": [{"column": "title", "op": "eq", "value": "A item"}],
+                },
+            )
+            assert resp.status_code == 403
+
+    def test_service_role_can_update_owner_column(self, test_db_url: str) -> None:
+        """Service role can reassign ownership (admin operation)."""
+        user_a = uuid.uuid4()
+        user_b = uuid.uuid4()
+        project_id = uuid.uuid4()
+
+        svc_app = _make_rls_app(test_db_url, key_role="service", project_id=project_id)
+        with TestClient(svc_app) as svc:
+            _create_owner_table(svc)
+            svc.post(
+                "/v1/db/items/insert",
+                json={"rows": [{"title": "A item", "user_id": str(user_a)}]},
+            )
+            resp = svc.post(
+                "/v1/db/items/update",
+                json={
+                    "values": {"user_id": str(user_b)},
+                    "filters": [{"column": "title", "op": "eq", "value": "A item"}],
+                },
+            )
+            assert resp.status_code == 200
+            assert resp.json()["data"][0]["user_id"] == str(user_b)
+
+
 class TestRlsNoUserContext:
     """Anon without user context on owner table returns 403."""
 

--- a/backend/tests/unit/test_owner_column.py
+++ b/backend/tests/unit/test_owner_column.py
@@ -21,6 +21,7 @@ from pqdb_api.services.crud import (
     build_select_sql,
     inject_rls_filters,
     validate_owner_for_insert,
+    validate_owner_for_update,
 )
 from pqdb_api.services.schema_engine import (
     ColumnDefinition,
@@ -253,6 +254,67 @@ class TestValidateOwnerForInsert:
         row = {"display_name": "Alice", "age": 30}
         validate_owner_for_insert(
             row=row,
+            columns_meta=COLUMNS_WITHOUT_OWNER,
+            key_role="anon",
+            user_id=uuid.uuid4(),
+        )
+
+
+class TestValidateOwnerForUpdate:
+    """validate_owner_for_update prevents changing owner column on non-service roles."""
+
+    def test_anon_update_with_owner_column_rejected(self) -> None:
+        """Anon user cannot include owner column in update values."""
+        user_id = uuid.uuid4()
+        updates = {"display_name": "New Name", "user_id": str(uuid.uuid4())}
+        with pytest.raises(CrudError, match="Cannot change owner column"):
+            validate_owner_for_update(
+                updates=updates,
+                columns_meta=COLUMNS_WITH_OWNER,
+                key_role="anon",
+                user_id=user_id,
+            )
+
+    def test_anon_update_owner_to_same_value_rejected(self) -> None:
+        """Even setting owner to same user_id is rejected — simplest safe policy."""
+        user_id = uuid.uuid4()
+        updates = {"user_id": str(user_id)}
+        with pytest.raises(CrudError, match="Cannot change owner column"):
+            validate_owner_for_update(
+                updates=updates,
+                columns_meta=COLUMNS_WITH_OWNER,
+                key_role="anon",
+                user_id=user_id,
+            )
+
+    def test_anon_update_without_owner_column_ok(self) -> None:
+        """Anon user can update non-owner columns freely."""
+        user_id = uuid.uuid4()
+        updates = {"display_name": "New Name", "age": 25}
+        # Should not raise
+        validate_owner_for_update(
+            updates=updates,
+            columns_meta=COLUMNS_WITH_OWNER,
+            key_role="anon",
+            user_id=user_id,
+        )
+
+    def test_service_role_can_update_owner_column(self) -> None:
+        """Service role can change owner column (admin operation)."""
+        updates = {"user_id": str(uuid.uuid4())}
+        # Should not raise
+        validate_owner_for_update(
+            updates=updates,
+            columns_meta=COLUMNS_WITH_OWNER,
+            key_role="service",
+            user_id=None,
+        )
+
+    def test_no_owner_column_no_validation(self) -> None:
+        """Tables without owner column skip validation entirely."""
+        updates = {"display_name": "Test"}
+        validate_owner_for_update(
+            updates=updates,
             columns_meta=COLUMNS_WITHOUT_OWNER,
             key_role="anon",
             user_id=uuid.uuid4(),


### PR DESCRIPTION
## Summary
- **Security fix**: Anon users could change the `owner` column value in UPDATE requests, transferring row ownership to another user
- Added `validate_owner_for_update()` in `crud.py` that rejects any UPDATE containing the owner column for non-service roles
- Called from `update_rows()` in `routes/db.py` before building SQL, returning 403 on violation
- Service role retains the ability to reassign ownership (admin operation)

## Test plan
- [x] Unit tests: 5 new tests in `tests/unit/test_owner_column.py::TestValidateOwnerForUpdate`
- [x] Integration tests: 3 new tests in `tests/integration/test_owner_rls.py::TestRlsUpdateOwnerEscalation`
- [x] Full suite: 597 tests pass
- [x] Linting, formatting, type checking all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)