### PR TITLE
feat(US-048): Schema browser + ERD visualizer

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -13,6 +13,7 @@
         "@tanstack/react-query": "5.91.0",
         "@tanstack/react-router": "1.167.5",
         "@tanstack/react-start": "1.166.17",
+        "@xyflow/react": "^12.10.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",
@@ -2875,6 +2876,55 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3075,6 +3125,38 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.1",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.1.tgz",
+      "integrity": "sha512-5eSWtIK/+rkldOuFbOOz44CRgQRjtS9v5nufk77DV+XBnfCGL9HAQ8PG00o2ZYKqkEU/Ak6wrKC95Tu+2zuK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.75",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.75.tgz",
+      "integrity": "sha512-iXs+AGFLi8w/VlAoc/iSxk+CxfT6o64Uw/k0CKASOPqjqz6E0rb5jFZgJtXGZCpfQI6OQpu5EnumP5fGxQheaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/accepts": {
@@ -3579,6 +3661,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -3932,6 +4020,111 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -8324,6 +8517,34 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -16,6 +16,7 @@
     "@tanstack/react-query": "5.91.0",
     "@tanstack/react-router": "1.167.5",
     "@tanstack/react-start": "1.166.17",
+    "@xyflow/react": "12.10.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",

--- a/dashboard/src/components/erd-table-node.tsx
+++ b/dashboard/src/components/erd-table-node.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { KeyRound } from "lucide-react";
+import { Badge } from "~/components/ui/badge";
+import type { IntrospectionColumn } from "~/lib/schema";
+
+export interface TableNodeData {
+  label: string;
+  columns: IntrospectionColumn[];
+  viewMode: "logical" | "physical";
+  [key: string]: unknown;
+}
+
+const sensitivityColors: Record<string, string> = {
+  plain: "bg-muted text-muted-foreground",
+  searchable: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+  private: "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
+};
+
+function getDisplayColumns(
+  columns: IntrospectionColumn[],
+  viewMode: "logical" | "physical",
+): { name: string; type: string; sensitivity: string; is_owner: boolean }[] {
+  if (viewMode === "logical") {
+    return columns.map((col) => ({
+      name: col.name,
+      type: col.type,
+      sensitivity: col.sensitivity,
+      is_owner: col.is_owner,
+    }));
+  }
+
+  // Physical view: expand shadow columns
+  const result: { name: string; type: string; sensitivity: string; is_owner: boolean }[] = [];
+  for (const col of columns) {
+    if (col.sensitivity === "searchable") {
+      result.push({ name: `${col.name}_encrypted`, type: "bytea", sensitivity: col.sensitivity, is_owner: col.is_owner });
+      result.push({ name: `${col.name}_index`, type: "text", sensitivity: col.sensitivity, is_owner: false });
+    } else if (col.sensitivity === "private") {
+      result.push({ name: `${col.name}_encrypted`, type: "bytea", sensitivity: col.sensitivity, is_owner: col.is_owner });
+    } else {
+      result.push({ name: col.name, type: col.type, sensitivity: col.sensitivity, is_owner: col.is_owner });
+    }
+  }
+  return result;
+}
+
+export function ErdTableNode({ data }: NodeProps) {
+  const { label, columns, viewMode } = data as TableNodeData;
+  const displayColumns = getDisplayColumns(columns, viewMode);
+
+  return (
+    <div
+      data-testid={`erd-table-${label}`}
+      className="rounded-lg border border-border bg-card shadow-md min-w-[220px]"
+    >
+      <Handle type="target" position={Position.Left} className="!bg-primary" />
+      <div className="rounded-t-lg border-b border-border bg-muted px-3 py-2">
+        <span className="text-sm font-semibold">{label}</span>
+      </div>
+      <div className="divide-y divide-border">
+        {displayColumns.map((col, idx) => (
+          <div
+            key={`${col.name}-${idx}`}
+            className="flex items-center gap-2 px-3 py-1.5 text-xs"
+          >
+            {col.is_owner && (
+              <KeyRound
+                className="h-3 w-3 text-amber-500 shrink-0"
+                data-testid="owner-icon"
+              />
+            )}
+            <span className="font-mono flex-1 truncate">{col.name}</span>
+            <span className="text-muted-foreground">{col.type}</span>
+            <Badge
+              data-testid={`badge-${col.sensitivity}`}
+              className={`text-[10px] px-1.5 py-0 h-4 ${sensitivityColors[col.sensitivity] ?? ""}`}
+            >
+              {col.sensitivity}
+            </Badge>
+          </div>
+        ))}
+      </div>
+      <Handle type="source" position={Position.Right} className="!bg-primary" />
+    </div>
+  );
+}

--- a/dashboard/src/components/schema-page.tsx
+++ b/dashboard/src/components/schema-page.tsx
@@ -1,0 +1,495 @@
+import * as React from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ReactFlow,
+  useNodesState,
+  useEdgesState,
+  type Node,
+  type Edge,
+  type NodeTypes,
+  Background,
+  Controls,
+  MiniMap,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { KeyRound, Plus } from "lucide-react";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "~/components/ui/dialog";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
+import { Skeleton } from "~/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
+import { ErdTableNode, type TableNodeData } from "~/components/erd-table-node";
+import {
+  fetchSchema,
+  addColumn,
+  getPhysicalColumns,
+  type IntrospectionTable,
+  type IntrospectionColumn,
+  type Sensitivity,
+} from "~/lib/schema";
+
+interface SchemaPageProps {
+  projectId: string;
+  apiKey: string;
+}
+
+const sensitivityColors: Record<string, string> = {
+  plain: "bg-muted text-muted-foreground",
+  searchable: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+  private:
+    "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
+};
+
+const nodeTypes: NodeTypes = {
+  tableNode: ErdTableNode,
+};
+
+function buildNodesAndEdges(
+  tables: IntrospectionTable[],
+  viewMode: "logical" | "physical",
+): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = tables.map((table, idx) => ({
+    id: table.name,
+    type: "tableNode",
+    position: { x: (idx % 3) * 320, y: Math.floor(idx / 3) * 400 },
+    data: {
+      label: table.name,
+      columns: table.columns,
+      viewMode,
+    } satisfies TableNodeData,
+  }));
+
+  // Build edges from foreign-key-like columns (columns ending with _id that match another table name)
+  const tableNames = new Set(tables.map((t) => t.name));
+  const edges: Edge[] = [];
+
+  for (const table of tables) {
+    for (const col of table.columns) {
+      if (col.name.endsWith("_id")) {
+        const refTable = col.name.replace(/_id$/, "") + "s"; // simple pluralization
+        if (tableNames.has(refTable) && refTable !== table.name) {
+          edges.push({
+            id: `${table.name}-${col.name}-${refTable}`,
+            source: table.name,
+            target: refTable,
+            animated: true,
+            label: col.name,
+            style: { stroke: "var(--color-primary)" },
+          });
+        }
+        // Also check singular
+        const refTableSingular = col.name.replace(/_id$/, "");
+        if (
+          tableNames.has(refTableSingular) &&
+          refTableSingular !== table.name &&
+          refTableSingular !== refTable
+        ) {
+          edges.push({
+            id: `${table.name}-${col.name}-${refTableSingular}`,
+            source: table.name,
+            target: refTableSingular,
+            animated: true,
+            label: col.name,
+            style: { stroke: "var(--color-primary)" },
+          });
+        }
+      }
+    }
+  }
+
+  return { nodes, edges };
+}
+
+function ColumnRow({
+  column,
+  viewMode,
+}: {
+  column: IntrospectionColumn;
+  viewMode: "logical" | "physical";
+}) {
+  if (viewMode === "physical") {
+    const physicalCols = getPhysicalColumns(column);
+    return (
+      <>
+        {physicalCols.map((pc, idx) => (
+          <div
+            key={`${pc.name}-${idx}`}
+            className="flex items-center gap-2 py-1"
+          >
+            {column.is_owner && idx === 0 && (
+              <KeyRound
+                className="h-3.5 w-3.5 text-amber-500 shrink-0"
+                data-testid="owner-icon"
+              />
+            )}
+            {!(column.is_owner && idx === 0) && (
+              <span className="w-3.5 shrink-0" />
+            )}
+            <span className="font-mono text-sm flex-1">{pc.name}</span>
+            <span className="text-xs text-muted-foreground">{pc.type}</span>
+            <Badge
+              data-testid={`badge-${column.sensitivity}`}
+              className={`text-[10px] ${sensitivityColors[column.sensitivity] ?? ""}`}
+            >
+              {column.sensitivity}
+            </Badge>
+          </div>
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 py-1">
+      {column.is_owner ? (
+        <KeyRound
+          className="h-3.5 w-3.5 text-amber-500 shrink-0"
+          data-testid="owner-icon"
+        />
+      ) : (
+        <span className="w-3.5 shrink-0" />
+      )}
+      <span className="font-mono text-sm flex-1">{column.name}</span>
+      <span className="text-xs text-muted-foreground">{column.type}</span>
+      <Badge
+        data-testid={`badge-${column.sensitivity}`}
+        className={`text-[10px] ${sensitivityColors[column.sensitivity] ?? ""}`}
+      >
+        {column.sensitivity}
+      </Badge>
+    </div>
+  );
+}
+
+function AddColumnDialog({
+  tableName,
+  apiKey,
+  onSuccess,
+}: {
+  tableName: string;
+  apiKey: string;
+  onSuccess: () => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const [name, setName] = React.useState("");
+  const [dataType, setDataType] = React.useState("text");
+  const [sensitivity, setSensitivity] = React.useState<Sensitivity>("plain");
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      await addColumn(
+        tableName,
+        { name, data_type: dataType, sensitivity, owner: false },
+        apiKey,
+      );
+      setOpen(false);
+      setName("");
+      setDataType("text");
+      setSensitivity("plain");
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add column");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger
+        render={
+          <Button variant="outline" size="sm">
+            <Plus className="h-3.5 w-3.5 mr-1" />
+            Add Column
+          </Button>
+        }
+      />
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Column to {tableName}</DialogTitle>
+          <DialogDescription>
+            Add a new column to the {tableName} table.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="col-name">Column Name</Label>
+            <Input
+              id="col-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="column_name"
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="col-type">Data Type</Label>
+            <Select value={dataType} onValueChange={(v) => { if (v) setDataType(v); }}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="text">text</SelectItem>
+                <SelectItem value="uuid">uuid</SelectItem>
+                <SelectItem value="integer">integer</SelectItem>
+                <SelectItem value="bigint">bigint</SelectItem>
+                <SelectItem value="boolean">boolean</SelectItem>
+                <SelectItem value="timestamp">timestamp</SelectItem>
+                <SelectItem value="jsonb">jsonb</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="col-sensitivity">Sensitivity</Label>
+            <Select
+              value={sensitivity}
+              onValueChange={(v) => { if (v) setSensitivity(v as Sensitivity); }}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="plain">Plain (queryable)</SelectItem>
+                <SelectItem value="searchable">
+                  Searchable (encrypted + blind index)
+                </SelectItem>
+                <SelectItem value="private">
+                  Private (encrypted only)
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <DialogFooter>
+            <Button type="submit" disabled={submitting || !name}>
+              {submitting ? "Adding..." : "Add Column"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ErdView({
+  tables,
+  viewMode,
+}: {
+  tables: IntrospectionTable[];
+  viewMode: "logical" | "physical";
+}) {
+  const { nodes: initialNodes, edges: initialEdges } = React.useMemo(
+    () => buildNodesAndEdges(tables, viewMode),
+    [tables, viewMode],
+  );
+
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+
+  // Update nodes when viewMode or tables change
+  React.useEffect(() => {
+    const { nodes: newNodes, edges: newEdges } = buildNodesAndEdges(
+      tables,
+      viewMode,
+    );
+    setNodes(newNodes);
+    setEdges(newEdges);
+  }, [tables, viewMode, setNodes, setEdges]);
+
+  return (
+    <div data-testid="erd-view" className="h-[600px] w-full rounded-lg border border-border">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        nodeTypes={nodeTypes}
+        fitView
+        fitViewOptions={{ padding: 0.2 }}
+        minZoom={0.1}
+        maxZoom={2}
+      >
+        <Background />
+        <Controls />
+        <MiniMap />
+      </ReactFlow>
+    </div>
+  );
+}
+
+function ListView({
+  tables,
+  viewMode,
+  apiKey,
+  onColumnAdded,
+}: {
+  tables: IntrospectionTable[];
+  viewMode: "logical" | "physical";
+  apiKey: string;
+  onColumnAdded: () => void;
+}) {
+  return (
+    <div className="space-y-4">
+      {tables.map((table) => (
+        <Card key={table.name}>
+          <CardHeader className="flex-row items-center justify-between">
+            <div>
+              <CardTitle>{table.name}</CardTitle>
+              <div className="flex gap-2 mt-1">
+                {table.sensitivity_summary.plain > 0 && (
+                  <span className="text-xs text-muted-foreground">
+                    {table.sensitivity_summary.plain} plain
+                  </span>
+                )}
+                {table.sensitivity_summary.searchable > 0 && (
+                  <span className="text-xs text-blue-600">
+                    {table.sensitivity_summary.searchable} searchable
+                  </span>
+                )}
+                {table.sensitivity_summary.private > 0 && (
+                  <span className="text-xs text-purple-600">
+                    {table.sensitivity_summary.private} private
+                  </span>
+                )}
+              </div>
+            </div>
+            <AddColumnDialog
+              tableName={table.name}
+              apiKey={apiKey}
+              onSuccess={onColumnAdded}
+            />
+          </CardHeader>
+          <CardContent>
+            <div className="divide-y divide-border">
+              {table.columns.map((col) => (
+                <ColumnRow
+                  key={col.name}
+                  column={col}
+                  viewMode={viewMode}
+                />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+export function SchemaPage({ projectId, apiKey }: SchemaPageProps) {
+  const [viewMode, setViewMode] = React.useState<"logical" | "physical">(
+    "logical",
+  );
+  const queryClient = useQueryClient();
+
+  const {
+    data: tables,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["schema", projectId, apiKey],
+    queryFn: () => fetchSchema(apiKey),
+    enabled: !!apiKey,
+  });
+
+  function handleColumnAdded() {
+    queryClient.invalidateQueries({ queryKey: ["schema", projectId, apiKey] });
+  }
+
+  if (isLoading) {
+    return (
+      <div data-testid="schema-loading" className="space-y-4">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-64 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-destructive">
+          {error instanceof Error ? error.message : "Failed to fetch schema"}
+        </p>
+      </div>
+    );
+  }
+
+  if (!tables || tables.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">
+          No tables yet. Create a table using the SDK or API to see your schema
+          here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">Schema</h2>
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">View:</span>
+          <Button
+            variant={viewMode === "logical" ? "default" : "outline"}
+            size="sm"
+            onClick={() => setViewMode("logical")}
+          >
+            Logical
+          </Button>
+          <Button
+            variant={viewMode === "physical" ? "default" : "outline"}
+            size="sm"
+            onClick={() => setViewMode("physical")}
+          >
+            Physical
+          </Button>
+        </div>
+      </div>
+
+      <Tabs defaultValue="list">
+        <TabsList>
+          <TabsTrigger value="list">List</TabsTrigger>
+          <TabsTrigger value="erd">ERD</TabsTrigger>
+        </TabsList>
+        <TabsContent value="list">
+          <ListView
+            tables={tables}
+            viewMode={viewMode}
+            apiKey={apiKey}
+            onColumnAdded={handleColumnAdded}
+          />
+        </TabsContent>
+        <TabsContent value="erd">
+          <ErdView tables={tables} viewMode={viewMode} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/dashboard/src/components/ui/tabs.tsx
+++ b/dashboard/src/components/ui/tabs.tsx
@@ -1,0 +1,80 @@
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "~/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-horizontal:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: TabsPrimitive.List.Props & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("flex-1 text-sm outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/dashboard/src/lib/schema.ts
+++ b/dashboard/src/lib/schema.ts
@@ -1,0 +1,84 @@
+/**
+ * Schema types and API functions for introspection.
+ * Calls GET /v1/db/introspect and POST /v1/db/tables/{name}/columns
+ * via the authenticated API client with project apikey header.
+ */
+
+import { api } from "./api-client";
+
+export type Sensitivity = "plain" | "searchable" | "private";
+
+export interface IntrospectionColumn {
+  name: string;
+  type: string;
+  sensitivity: Sensitivity;
+  is_owner: boolean;
+  queryable: boolean;
+  operations?: string[];
+  note?: string;
+}
+
+export interface IntrospectionTable {
+  name: string;
+  columns: IntrospectionColumn[];
+  sensitivity_summary: Record<Sensitivity, number>;
+}
+
+export interface IntrospectResponse {
+  tables: IntrospectionTable[];
+}
+
+export interface AddColumnRequest {
+  name: string;
+  data_type: string;
+  sensitivity: Sensitivity;
+  owner: boolean;
+}
+
+export async function fetchSchema(apiKey: string): Promise<IntrospectionTable[]> {
+  const result = await api.fetch("/v1/db/introspect", {
+    headers: { apikey: apiKey },
+  });
+  if (!result.ok) {
+    throw new Error("Failed to fetch schema");
+  }
+  const data = result.data as IntrospectResponse;
+  return data.tables;
+}
+
+export async function addColumn(
+  tableName: string,
+  column: AddColumnRequest,
+  apiKey: string,
+): Promise<void> {
+  const result = await api.fetch(`/v1/db/tables/${tableName}/columns`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: apiKey,
+    },
+    body: JSON.stringify(column),
+  });
+  if (!result.ok) {
+    throw new Error("Failed to add column");
+  }
+}
+
+/**
+ * Physical column name mapping.
+ * Sensitive columns have shadow columns in the physical schema.
+ */
+export function getPhysicalColumns(
+  column: IntrospectionColumn,
+): { name: string; type: string }[] {
+  if (column.sensitivity === "searchable") {
+    return [
+      { name: `${column.name}_encrypted`, type: "bytea" },
+      { name: `${column.name}_index`, type: "text" },
+    ];
+  }
+  if (column.sensitivity === "private") {
+    return [{ name: `${column.name}_encrypted`, type: "bytea" }];
+  }
+  return [{ name: column.name, type: column.type }];
+}

--- a/dashboard/src/routeTree.gen.ts
+++ b/dashboard/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
 import { Route as ProjectsIndexRouteImport } from './routes/projects/index'
 import { Route as ProjectsProjectIdRouteImport } from './routes/projects/$projectId'
+import { Route as ProjectsProjectIdSchemaRouteImport } from './routes/projects/$projectId/schema'
 
 const SignupRoute = SignupRouteImport.update({
   id: '/signup',
@@ -46,31 +47,39 @@ const ProjectsProjectIdRoute = ProjectsProjectIdRouteImport.update({
   path: '/projects/$projectId',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ProjectsProjectIdSchemaRoute = ProjectsProjectIdSchemaRouteImport.update({
+  id: '/schema',
+  path: '/schema',
+  getParentRoute: () => ProjectsProjectIdRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/signup': typeof SignupRoute
-  '/projects/$projectId': typeof ProjectsProjectIdRoute
+  '/projects/$projectId': typeof ProjectsProjectIdRouteWithChildren
   '/projects/': typeof ProjectsIndexRoute
   '/settings/': typeof SettingsIndexRoute
+  '/projects/$projectId/schema': typeof ProjectsProjectIdSchemaRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/signup': typeof SignupRoute
-  '/projects/$projectId': typeof ProjectsProjectIdRoute
+  '/projects/$projectId': typeof ProjectsProjectIdRouteWithChildren
   '/projects': typeof ProjectsIndexRoute
   '/settings': typeof SettingsIndexRoute
+  '/projects/$projectId/schema': typeof ProjectsProjectIdSchemaRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/signup': typeof SignupRoute
-  '/projects/$projectId': typeof ProjectsProjectIdRoute
+  '/projects/$projectId': typeof ProjectsProjectIdRouteWithChildren
   '/projects/': typeof ProjectsIndexRoute
   '/settings/': typeof SettingsIndexRoute
+  '/projects/$projectId/schema': typeof ProjectsProjectIdSchemaRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -81,6 +90,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId'
     | '/projects/'
     | '/settings/'
+    | '/projects/$projectId/schema'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -89,6 +99,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId'
     | '/projects'
     | '/settings'
+    | '/projects/$projectId/schema'
   id:
     | '__root__'
     | '/'
@@ -97,13 +108,14 @@ export interface FileRouteTypes {
     | '/projects/$projectId'
     | '/projects/'
     | '/settings/'
+    | '/projects/$projectId/schema'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LoginRoute: typeof LoginRoute
   SignupRoute: typeof SignupRoute
-  ProjectsProjectIdRoute: typeof ProjectsProjectIdRoute
+  ProjectsProjectIdRoute: typeof ProjectsProjectIdRouteWithChildren
   ProjectsIndexRoute: typeof ProjectsIndexRoute
   SettingsIndexRoute: typeof SettingsIndexRoute
 }
@@ -152,14 +164,32 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsProjectIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/projects/$projectId/schema': {
+      id: '/projects/$projectId/schema'
+      path: '/schema'
+      fullPath: '/projects/$projectId/schema'
+      preLoaderRoute: typeof ProjectsProjectIdSchemaRouteImport
+      parentRoute: typeof ProjectsProjectIdRoute
+    }
   }
 }
+
+interface ProjectsProjectIdRouteChildren {
+  ProjectsProjectIdSchemaRoute: typeof ProjectsProjectIdSchemaRoute
+}
+
+const ProjectsProjectIdRouteChildren: ProjectsProjectIdRouteChildren = {
+  ProjectsProjectIdSchemaRoute: ProjectsProjectIdSchemaRoute,
+}
+
+const ProjectsProjectIdRouteWithChildren =
+  ProjectsProjectIdRoute._addFileChildren(ProjectsProjectIdRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LoginRoute: LoginRoute,
   SignupRoute: SignupRoute,
-  ProjectsProjectIdRoute: ProjectsProjectIdRoute,
+  ProjectsProjectIdRoute: ProjectsProjectIdRouteWithChildren,
   ProjectsIndexRoute: ProjectsIndexRoute,
   SettingsIndexRoute: SettingsIndexRoute,
 }

--- a/dashboard/src/routes/projects/$projectId/schema.tsx
+++ b/dashboard/src/routes/projects/$projectId/schema.tsx
@@ -1,0 +1,80 @@
+import * as React from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import { AuthGuard } from "~/components/auth-guard";
+import { SchemaPage } from "~/components/schema-page";
+import { Skeleton } from "~/components/ui/skeleton";
+import { fetchProject, fetchProjectKeys, type Project, type ApiKeyInfo } from "~/lib/projects";
+
+export const Route = createFileRoute("/projects/$projectId/schema")({
+  component: SchemaRoute,
+});
+
+function SchemaRoute() {
+  const { projectId } = Route.useParams();
+  const [project, setProject] = React.useState<Project | null>(null);
+  const [apiKey, setApiKey] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    async function load() {
+      try {
+        const [proj, keys] = await Promise.all([
+          fetchProject(projectId),
+          fetchProjectKeys(projectId),
+        ]);
+        setProject(proj);
+        // Use the first available API key (prefer service_role, fall back to anon)
+        const serviceKey = keys.find((k: ApiKeyInfo) => k.role === "service_role");
+        const anonKey = keys.find((k: ApiKeyInfo) => k.role === "anon");
+        const key = serviceKey ?? anonKey;
+        if (key) {
+          setApiKey(key.key_prefix);
+        }
+      } catch {
+        // error handled by showing fallback
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [projectId]);
+
+  if (loading) {
+    return (
+      <AuthGuard>
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-64 w-full" />
+        </div>
+      </AuthGuard>
+    );
+  }
+
+  if (!project) {
+    return (
+      <AuthGuard>
+        <div className="text-center py-12">
+          <p className="text-destructive">Project not found</p>
+        </div>
+      </AuthGuard>
+    );
+  }
+
+  if (!apiKey) {
+    return (
+      <AuthGuard>
+        <div className="text-center py-12">
+          <p className="text-muted-foreground">
+            No API key found. Create an API key to view the schema.
+          </p>
+        </div>
+      </AuthGuard>
+    );
+  }
+
+  return (
+    <AuthGuard>
+      <SchemaPage projectId={projectId} apiKey={apiKey} />
+    </AuthGuard>
+  );
+}

--- a/dashboard/tests/setup.ts
+++ b/dashboard/tests/setup.ts
@@ -1,1 +1,10 @@
 import "@testing-library/jest-dom/vitest";
+
+// Polyfill ResizeObserver for jsdom (needed by @xyflow/react)
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof globalThis.ResizeObserver;
+}

--- a/dashboard/tests/unit/schema-page.test.tsx
+++ b/dashboard/tests/unit/schema-page.test.tsx
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createQueryWrapper } from "../query-wrapper";
+
+const { mockFetchSchema, mockAddColumn } = vi.hoisted(() => ({
+  mockFetchSchema: vi.fn(),
+  mockAddColumn: vi.fn(),
+}));
+
+vi.mock("~/lib/schema", () => ({
+  fetchSchema: mockFetchSchema,
+  addColumn: mockAddColumn,
+  getPhysicalColumns: (col: { name: string; type: string; sensitivity: string }) => {
+    if (col.sensitivity === "searchable") {
+      return [
+        { name: `${col.name}_encrypted`, type: "bytea" },
+        { name: `${col.name}_index`, type: "text" },
+      ];
+    }
+    if (col.sensitivity === "private") {
+      return [{ name: `${col.name}_encrypted`, type: "bytea" }];
+    }
+    return [{ name: col.name, type: col.type }];
+  },
+}));
+
+import { SchemaPage } from "~/components/schema-page";
+import type { IntrospectionTable } from "~/lib/schema";
+
+const mockTables: IntrospectionTable[] = [
+  {
+    name: "users",
+    columns: [
+      {
+        name: "id",
+        type: "uuid",
+        sensitivity: "plain",
+        is_owner: true,
+        queryable: true,
+        operations: ["eq", "gt", "lt", "gte", "lte", "in", "between"],
+      },
+      {
+        name: "email",
+        type: "text",
+        sensitivity: "searchable",
+        is_owner: false,
+        queryable: true,
+        operations: ["eq", "in"],
+      },
+      {
+        name: "ssn",
+        type: "text",
+        sensitivity: "private",
+        is_owner: false,
+        queryable: false,
+        note: "retrieve only — no server-side filtering",
+      },
+      {
+        name: "name",
+        type: "text",
+        sensitivity: "plain",
+        is_owner: false,
+        queryable: true,
+        operations: ["eq", "gt", "lt", "gte", "lte", "in", "between"],
+      },
+    ],
+    sensitivity_summary: { plain: 2, searchable: 1, private: 1 },
+  },
+  {
+    name: "posts",
+    columns: [
+      {
+        name: "id",
+        type: "uuid",
+        sensitivity: "plain",
+        is_owner: false,
+        queryable: true,
+        operations: ["eq", "gt", "lt", "gte", "lte", "in", "between"],
+      },
+      {
+        name: "user_id",
+        type: "uuid",
+        sensitivity: "plain",
+        is_owner: true,
+        queryable: true,
+        operations: ["eq", "gt", "lt", "gte", "lte", "in", "between"],
+      },
+      {
+        name: "title",
+        type: "text",
+        sensitivity: "plain",
+        is_owner: false,
+        queryable: true,
+        operations: ["eq", "gt", "lt", "gte", "lte", "in", "between"],
+      },
+    ],
+    sensitivity_summary: { plain: 3, searchable: 0, private: 0 },
+  },
+];
+
+describe("SchemaPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading skeleton while fetching", () => {
+    mockFetchSchema.mockReturnValue(new Promise(() => {}));
+    const { wrapper } = createQueryWrapper();
+    render(<SchemaPage projectId="p1" apiKey="pqdb_anon_abc" />, { wrapper });
+    expect(screen.getByTestId("schema-loading")).toBeInTheDocument();
+  });
+
+  it("shows error state on fetch failure", async () => {
+    mockFetchSchema.mockRejectedValueOnce(new Error("Failed to fetch schema"));
+    const { wrapper } = createQueryWrapper();
+    render(<SchemaPage projectId="p1" apiKey="pqdb_anon_abc" />, { wrapper });
+    expect(await screen.findByText(/failed to fetch schema/i)).toBeInTheDocument();
+  });
+
+  it("shows empty state when no tables exist", async () => {
+    mockFetchSchema.mockResolvedValueOnce([]);
+    const { wrapper } = createQueryWrapper();
+    render(<SchemaPage projectId="p1" apiKey="pqdb_anon_abc" />, { wrapper });
+    expect(await screen.findByText(/no tables/i)).toBeInTheDocument();
+  });
+
+  it("renders table list in list view", async () => {
+    mockFetchSchema.mockResolvedValueOnce(mockTables);
+    const { wrapper } = createQueryWrapper();
+    render(<SchemaPage projectId="p1" apiKey="pqdb_anon_abc" />, { wrapper });
+
+    expect(await screen.findByText("users")).toBeInTheDocument();
+    expect(screen.getByText("posts")).toBeInTheDocument();
+  });
+
+  it("renders columns for each table in list view", async () => {
+    mockFetchSchema.mockResolvedValueOnce(mockTables);
+    const { wrapper } = createQueryWrapper();
+    render(<SchemaPage projectId="p1" apiKey="pqdb_anon_abc" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("email")).toBeInTheDocument();
+    });
+    expect(screen.getByText("ssn")).toBeInTheDocument();
+    expect(screen.getByText("title")).toBeInTheDocument();
+  });
+
+  it("shows sensitivity badges with correct colors", async () => {
+    mockFetchSchema.mockResolvedValueOnce(mockTables);
+    const { wrapper } = createQueryWrapper();
+    render(<SchemaPage projectId="p1" apiKey="pqdb_anon_abc" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("email")).toBeInTheDocument();
+    });
+
+    // Find sensitivity badges
+    const searchableBadges = screen.getAllByTestId("badge-searchable");
+    const privateBadges = screen.getAllByTestId("badge-private");
+    const plainBadges = screen.getAllByTestId("badge-plain");
+
+    expect(searchableBadges.length).toBeGreaterThan(0);
+    expect(privateBadges.length).toBeGreaterThan(0);
+    expect(plainBadges.length).toBeGreaterThan(0);
+  });
+
+  it("shows owner icon for owner columns", async () => {
+    mockFetchSchema.mockResolvedValueOnce(mockTables);
+    const { wrapper } = createQueryWrapper();
+    render(<SchemaPage projectId="p1" apiKey="pqdb_anon_abc" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("email")).toBeInTheDocument();
+    });
+
+    const ownerIcons = screen.getAllByTestId("owner-icon");
+    // id in users (is_owner=true) and user_id in posts (is_owner=true)
+    expect(ownerIcons).toHaveLength(2);
+  });
+
+  it("defaults to logical view showing developer-facing column names", async () => {
+    mockFetchSchema.mockResolvedValueOnce(mockTables);
+    const { wrapper } = createQueryWrapper();
+    render(<SchemaPage projectId="p1" apiKey="pqdb_anon_abc" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("email")).toBeInTheDocument();
+    });
+
+    // In logical view, should show original names
+    expect(screen.getByText("email")).toBeInTheDocument();
+    expect(screen.getByText("ssn")).toBeInTheDocument();
+    // Should NOT show physical names
+    expect(screen.queryByText("email_encrypted")).not.toBeInTheDocument();
+    expect(screen.queryByText("email_index")).not.toBeInTheDocument();
+  });
+
+  it("switches to physical view showing Postgres column names", async () => {
+    const user = userEvent.setup();
+    mockFetchSchema.mockResolvedValueOnce(mockTables);
+    const { wrapper } = createQueryWrapper();
+    render(<SchemaPage projectId="p1" apiKey="pqdb_anon_abc" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("email")).toBeInTheDocument();
+    });
+
+    // Click the physical view toggle
+    const physicalToggle = screen.getByRole("button", { name: /physical/i });
+    await user.click(physicalToggle);
+
+    // Should show physical column names
+    await waitFor(() => {
+      expect(screen.getByText("email_encrypted")).toBeInTheDocument();
+    });
+    expect(screen.getByText("email_index")).toBeInTheDocument();
+    expect(screen.getByText("ssn_encrypted")).toBeInTheDocument();
+  });
+
+  it("has tabs for List and ERD views", async () => {
+    mockFetchSchema.mockResolvedValueOnce(mockTables);
+    const { wrapper } = createQueryWrapper();
+    render(<SchemaPage projectId="p1" apiKey="pqdb_anon_abc" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("users")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("tab", { name: /list/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /erd/i })).toBeInTheDocument();
+  });
+
+  it("switches to ERD view and renders table nodes", async () => {
+    const user = userEvent.setup();
+    mockFetchSchema.mockResolvedValueOnce(mockTables);
+    const { wrapper } = createQueryWrapper();
+    render(<SchemaPage projectId="p1" apiKey="pqdb_anon_abc" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("users")).toBeInTheDocument();
+    });
+
+    const erdTab = screen.getByRole("tab", { name: /erd/i });
+    await user.click(erdTab);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("erd-view")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("SchemaPage — Add Column", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows Add Column button for each table", async () => {
+    mockFetchSchema.mockResolvedValueOnce(mockTables);
+    const { wrapper } = createQueryWrapper();
+    render(<SchemaPage projectId="p1" apiKey="pqdb_anon_abc" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("users")).toBeInTheDocument();
+    });
+
+    const addButtons = screen.getAllByRole("button", { name: /add column/i });
+    expect(addButtons).toHaveLength(2); // one per table
+  });
+
+  it("opens add column dialog when clicking Add Column", async () => {
+    const user = userEvent.setup();
+    mockFetchSchema.mockResolvedValueOnce(mockTables);
+    const { wrapper } = createQueryWrapper();
+    render(<SchemaPage projectId="p1" apiKey="pqdb_anon_abc" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("users")).toBeInTheDocument();
+    });
+
+    const addButtons = screen.getAllByRole("button", { name: /add column/i });
+    await user.click(addButtons[0]);
+
+    expect(await screen.findByText(/add column to/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add schema browser page at `/projects/:id/schema` with two views: **List view** (table cards with columns) and **ERD view** (React Flow interactive canvas)
- Color-coded sensitivity badges: plain (gray), searchable (blue), private (purple) with key icon for owner columns
- **Logical/Physical view toggle**: logical shows developer-facing names (`email`), physical shows actual Postgres columns (`email_encrypted`, `email_index`)
- **Add Column** dialog per table calling `POST /v1/db/tables/{name}/columns`
- Data sourced from `GET /v1/db/introspect` endpoint (no backend changes needed)

## Files Changed
| File | Purpose |
|------|---------|
| `dashboard/src/components/schema-page.tsx` | Main SchemaPage with List/ERD tabs, view toggle, Add Column dialog |
| `dashboard/src/components/erd-table-node.tsx` | Custom React Flow node rendering table with columns/badges |
| `dashboard/src/lib/schema.ts` | Types + API functions (fetchSchema, addColumn, getPhysicalColumns) |
| `dashboard/src/components/ui/tabs.tsx` | shadcn Tabs component |
| `dashboard/src/routes/projects/$projectId/schema.tsx` | Route wiring |
| `dashboard/tests/unit/schema-page.test.tsx` | 13 unit tests covering all acceptance criteria |

## Test plan
- [x] 13 unit tests pass (list view, ERD view, sensitivity badges, owner icons, logical/physical toggle, add column dialog)
- [x] TypeScript typecheck passes (`tsc --noEmit`)
- [x] Production build succeeds (`vite build`)
- [x] All 114 existing tests still pass
- [ ] Verify in browser with running backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)