### PR TITLE
feat(US-047): API key management page

### DIFF
--- a/dashboard/src/components/api-keys-page.tsx
+++ b/dashboard/src/components/api-keys-page.tsx
@@ -1,0 +1,229 @@
+import * as React from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Copy, RefreshCw, AlertTriangle, Check } from "lucide-react";
+import { Button } from "~/components/ui/button";
+import { Card } from "~/components/ui/card";
+import { Badge } from "~/components/ui/badge";
+import { Skeleton } from "~/components/ui/skeleton";
+import { Separator } from "~/components/ui/separator";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "~/components/ui/dialog";
+import {
+  fetchProjectKeys,
+  rotateProjectKeys,
+  type ApiKeyInfo,
+  type ApiKeyCreated,
+} from "~/lib/projects";
+
+interface ApiKeysPageProps {
+  projectId: string;
+}
+
+function maskKey(prefix: string): string {
+  return `${prefix}****`;
+}
+
+function CopyButton({
+  text,
+  label,
+}: {
+  text: string;
+  label?: string;
+}) {
+  const [copied, setCopied] = React.useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={handleCopy}
+      aria-label={label ?? "Copy"}
+    >
+      {copied ? (
+        <Check className="h-4 w-4" />
+      ) : (
+        <Copy className="h-4 w-4" />
+      )}
+    </Button>
+  );
+}
+
+export function ApiKeysPage({ projectId }: ApiKeysPageProps) {
+  const queryClient = useQueryClient();
+  const [showConfirmDialog, setShowConfirmDialog] = React.useState(false);
+  const [showNewKeysDialog, setShowNewKeysDialog] = React.useState(false);
+  const [newKeys, setNewKeys] = React.useState<ApiKeyCreated[]>([]);
+
+  const {
+    data: keys,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ["projectKeys", projectId],
+    queryFn: () => fetchProjectKeys(projectId),
+    enabled: !!projectId,
+  });
+
+  const rotateMutation = useMutation({
+    mutationFn: () => rotateProjectKeys(projectId),
+    onSuccess: (data) => {
+      setNewKeys(data);
+      setShowConfirmDialog(false);
+      setShowNewKeysDialog(true);
+      queryClient.invalidateQueries({ queryKey: ["projectKeys", projectId] });
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div data-testid="keys-loading" className="space-y-4">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-destructive">Failed to load API keys</p>
+      </div>
+    );
+  }
+
+  const anonKey = keys?.find((k) => k.role === "anon");
+
+  const snippet = `import { createClient } from '@pqdb/client'
+
+const client = createClient('http://localhost:8000', '${anonKey ? maskKey(anonKey.key_prefix) : "pqdb_anon_..."}')`;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">API Keys</h2>
+        <Button
+          variant="destructive"
+          onClick={() => setShowConfirmDialog(true)}
+        >
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Rotate Keys
+        </Button>
+      </div>
+
+      <div className="space-y-4">
+        {keys?.map((key) => (
+          <Card key={key.id} className="p-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <Badge variant="outline">{key.role}</Badge>
+                <code className="text-sm text-muted-foreground">
+                  {maskKey(key.key_prefix)}
+                </code>
+              </div>
+              <CopyButton
+                text={maskKey(key.key_prefix)}
+                label={`Copy ${key.role} key`}
+              />
+            </div>
+          </Card>
+        ))}
+      </div>
+
+      <Separator />
+
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="text-lg font-medium">SDK Connection Snippet</h3>
+          <Button
+            variant="ghost"
+            size="sm"
+            data-testid="copy-snippet-btn"
+            onClick={() => navigator.clipboard.writeText(snippet)}
+            aria-label="Copy snippet"
+          >
+            <Copy className="h-4 w-4" />
+          </Button>
+        </div>
+        <pre
+          data-testid="sdk-snippet"
+          className="rounded-md bg-muted p-4 text-sm overflow-x-auto"
+        >
+          <code>{snippet}</code>
+        </pre>
+      </div>
+
+      {/* Confirmation Dialog */}
+      <Dialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-destructive" />
+              Rotate API Keys
+            </DialogTitle>
+            <DialogDescription>
+              This will invalidate your current API keys. Any applications using
+              the old keys will stop working immediately.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowConfirmDialog(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => rotateMutation.mutate()}
+              disabled={rotateMutation.isPending}
+            >
+              Confirm
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* New Keys One-Time Display Dialog */}
+      <Dialog open={showNewKeysDialog} onOpenChange={setShowNewKeysDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New API Keys</DialogTitle>
+            <DialogDescription className="flex items-center gap-2 text-amber-600">
+              <AlertTriangle className="h-4 w-4" />
+              Keys are shown only once. Store them securely.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            {newKeys.map((key) => (
+              <div key={key.id} className="space-y-1">
+                <Badge variant="outline">{key.role}</Badge>
+                <div className="flex items-center gap-2">
+                  <code className="flex-1 break-all text-sm bg-muted p-2 rounded">
+                    {key.key}
+                  </code>
+                  <CopyButton text={key.key} label={`Copy ${key.role} key`} />
+                </div>
+              </div>
+            ))}
+          </div>
+          <DialogFooter>
+            <Button onClick={() => setShowNewKeysDialog(false)}>Done</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/dashboard/src/lib/projects.ts
+++ b/dashboard/src/lib/projects.ts
@@ -76,3 +76,13 @@ export async function fetchProjectKeys(projectId: string): Promise<ApiKeyInfo[]>
   }
   return result.data as ApiKeyInfo[];
 }
+
+export async function rotateProjectKeys(projectId: string): Promise<ApiKeyCreated[]> {
+  const result = await api.fetch(`/v1/projects/${projectId}/keys/rotate`, {
+    method: "POST",
+  });
+  if (!result.ok) {
+    throw new Error("Failed to rotate API keys");
+  }
+  return result.data as ApiKeyCreated[];
+}

--- a/dashboard/src/routeTree.gen.ts
+++ b/dashboard/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as SettingsIndexRouteImport } from './routes/settings/index'
 import { Route as ProjectsIndexRouteImport } from './routes/projects/index'
 import { Route as ProjectsProjectIdRouteImport } from './routes/projects/$projectId'
 import { Route as ProjectsProjectIdSchemaRouteImport } from './routes/projects/$projectId/schema'
+import { Route as ProjectsProjectIdKeysRouteImport } from './routes/projects/$projectId.keys'
 
 const SignupRoute = SignupRouteImport.update({
   id: '/signup',
@@ -52,6 +53,11 @@ const ProjectsProjectIdSchemaRoute = ProjectsProjectIdSchemaRouteImport.update({
   path: '/schema',
   getParentRoute: () => ProjectsProjectIdRoute,
 } as any)
+const ProjectsProjectIdKeysRoute = ProjectsProjectIdKeysRouteImport.update({
+  id: '/keys',
+  path: '/keys',
+  getParentRoute: () => ProjectsProjectIdRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -60,6 +66,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectId': typeof ProjectsProjectIdRouteWithChildren
   '/projects/': typeof ProjectsIndexRoute
   '/settings/': typeof SettingsIndexRoute
+  '/projects/$projectId/keys': typeof ProjectsProjectIdKeysRoute
   '/projects/$projectId/schema': typeof ProjectsProjectIdSchemaRoute
 }
 export interface FileRoutesByTo {
@@ -69,6 +76,7 @@ export interface FileRoutesByTo {
   '/projects/$projectId': typeof ProjectsProjectIdRouteWithChildren
   '/projects': typeof ProjectsIndexRoute
   '/settings': typeof SettingsIndexRoute
+  '/projects/$projectId/keys': typeof ProjectsProjectIdKeysRoute
   '/projects/$projectId/schema': typeof ProjectsProjectIdSchemaRoute
 }
 export interface FileRoutesById {
@@ -79,6 +87,7 @@ export interface FileRoutesById {
   '/projects/$projectId': typeof ProjectsProjectIdRouteWithChildren
   '/projects/': typeof ProjectsIndexRoute
   '/settings/': typeof SettingsIndexRoute
+  '/projects/$projectId/keys': typeof ProjectsProjectIdKeysRoute
   '/projects/$projectId/schema': typeof ProjectsProjectIdSchemaRoute
 }
 export interface FileRouteTypes {
@@ -90,6 +99,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId'
     | '/projects/'
     | '/settings/'
+    | '/projects/$projectId/keys'
     | '/projects/$projectId/schema'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -99,6 +109,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId'
     | '/projects'
     | '/settings'
+    | '/projects/$projectId/keys'
     | '/projects/$projectId/schema'
   id:
     | '__root__'
@@ -108,6 +119,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId'
     | '/projects/'
     | '/settings/'
+    | '/projects/$projectId/keys'
     | '/projects/$projectId/schema'
   fileRoutesById: FileRoutesById
 }
@@ -171,14 +183,23 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsProjectIdSchemaRouteImport
       parentRoute: typeof ProjectsProjectIdRoute
     }
+    '/projects/$projectId/keys': {
+      id: '/projects/$projectId/keys'
+      path: '/keys'
+      fullPath: '/projects/$projectId/keys'
+      preLoaderRoute: typeof ProjectsProjectIdKeysRouteImport
+      parentRoute: typeof ProjectsProjectIdRoute
+    }
   }
 }
 
 interface ProjectsProjectIdRouteChildren {
+  ProjectsProjectIdKeysRoute: typeof ProjectsProjectIdKeysRoute
   ProjectsProjectIdSchemaRoute: typeof ProjectsProjectIdSchemaRoute
 }
 
 const ProjectsProjectIdRouteChildren: ProjectsProjectIdRouteChildren = {
+  ProjectsProjectIdKeysRoute: ProjectsProjectIdKeysRoute,
   ProjectsProjectIdSchemaRoute: ProjectsProjectIdSchemaRoute,
 }
 

--- a/dashboard/src/routes/projects/$projectId.keys.tsx
+++ b/dashboard/src/routes/projects/$projectId.keys.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { AuthGuard } from "~/components/auth-guard";
+import { ApiKeysPage } from "~/components/api-keys-page";
+
+export const Route = createFileRoute("/projects/$projectId/keys")({
+  component: ProjectKeysPage,
+});
+
+function ProjectKeysPage() {
+  const { projectId } = Route.useParams();
+
+  return (
+    <AuthGuard>
+      <ApiKeysPage projectId={projectId} />
+    </AuthGuard>
+  );
+}

--- a/dashboard/tests/unit/api-keys-page.test.tsx
+++ b/dashboard/tests/unit/api-keys-page.test.tsx
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createQueryWrapper } from "../query-wrapper";
+
+const { mockFetchProjectKeys, mockRotateProjectKeys } = vi.hoisted(() => ({
+  mockFetchProjectKeys: vi.fn(),
+  mockRotateProjectKeys: vi.fn(),
+}));
+
+vi.mock("~/lib/projects", () => ({
+  fetchProjectKeys: mockFetchProjectKeys,
+  rotateProjectKeys: mockRotateProjectKeys,
+}));
+
+import { ApiKeysPage } from "~/components/api-keys-page";
+
+const mockKeys = [
+  {
+    id: "k1",
+    role: "anon",
+    key_prefix: "pqdb_anon_abc123",
+    created_at: "2026-01-15T10:00:00Z",
+  },
+  {
+    id: "k2",
+    role: "service_role",
+    key_prefix: "pqdb_service_role_xyz789",
+    created_at: "2026-01-15T10:00:00Z",
+  },
+];
+
+const mockRotatedKeys = [
+  {
+    id: "k3",
+    role: "anon",
+    key: "pqdb_anon_newkey123456789012345678901234",
+    key_prefix: "pqdb_anon_newkey1234",
+  },
+  {
+    id: "k4",
+    role: "service_role",
+    key: "pqdb_service_role_newkey12345678901234567890",
+    key_prefix: "pqdb_service_role_newkey",
+  },
+];
+
+const mockWriteText = vi.fn().mockResolvedValue(undefined);
+
+describe("ApiKeysPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWriteText.mockClear();
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: mockWriteText },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("shows loading state while fetching keys", () => {
+    mockFetchProjectKeys.mockReturnValue(new Promise(() => {}));
+    const { wrapper } = createQueryWrapper();
+    render(<ApiKeysPage projectId="p1" />, { wrapper });
+    expect(screen.getByTestId("keys-loading")).toBeInTheDocument();
+  });
+
+  it("displays API keys in masked format", async () => {
+    mockFetchProjectKeys.mockResolvedValueOnce(mockKeys);
+    const { wrapper } = createQueryWrapper();
+    render(<ApiKeysPage projectId="p1" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("pqdb_anon_abc123****")).toBeInTheDocument();
+      expect(
+        screen.getByText("pqdb_service_role_xyz789****"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows role labels for each key", async () => {
+    mockFetchProjectKeys.mockResolvedValueOnce(mockKeys);
+    const { wrapper } = createQueryWrapper();
+    render(<ApiKeysPage projectId="p1" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("anon")).toBeInTheDocument();
+      expect(screen.getByText("service_role")).toBeInTheDocument();
+    });
+  });
+
+  it("shows SDK connection snippet", async () => {
+    mockFetchProjectKeys.mockResolvedValueOnce(mockKeys);
+    const { wrapper } = createQueryWrapper();
+    render(<ApiKeysPage projectId="p1" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("sdk-snippet")).toBeInTheDocument();
+    });
+
+    const snippet = screen.getByTestId("sdk-snippet");
+    expect(snippet.textContent).toContain("http://localhost:8000");
+    expect(snippet.textContent).toContain("pqdb_anon_abc123");
+    expect(snippet.textContent).toContain("createClient");
+  });
+
+  it("copies key to clipboard when copy button is clicked", async () => {
+    mockFetchProjectKeys.mockResolvedValueOnce(mockKeys);
+    const { wrapper } = createQueryWrapper();
+    render(<ApiKeysPage projectId="p1" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("pqdb_anon_abc123****")).toBeInTheDocument();
+    });
+
+    // Use fireEvent instead of userEvent to avoid clipboard interception
+    const anonCopyBtn = screen.getByRole("button", { name: "Copy anon key" });
+    fireEvent.click(anonCopyBtn);
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledWith("pqdb_anon_abc123****");
+    });
+  });
+
+  it("copies SDK snippet to clipboard", async () => {
+    mockFetchProjectKeys.mockResolvedValueOnce(mockKeys);
+    const { wrapper } = createQueryWrapper();
+    render(<ApiKeysPage projectId="p1" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("sdk-snippet")).toBeInTheDocument();
+    });
+
+    const snippetCopyBtn = screen.getByTestId("copy-snippet-btn");
+    fireEvent.click(snippetCopyBtn);
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledWith(
+        expect.stringContaining("createClient"),
+      );
+    });
+  });
+
+  it("opens rotation confirmation dialog when Rotate Keys is clicked", async () => {
+    mockFetchProjectKeys.mockResolvedValueOnce(mockKeys);
+    const user = userEvent.setup();
+    const { wrapper } = createQueryWrapper();
+    render(<ApiKeysPage projectId="p1" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("pqdb_anon_abc123****")).toBeInTheDocument();
+    });
+
+    const rotateBtn = screen.getByRole("button", { name: /rotate keys/i });
+    await user.click(rotateBtn);
+
+    // Confirmation dialog should appear
+    expect(
+      screen.getByText(/this will invalidate your current api keys/i),
+    ).toBeInTheDocument();
+  });
+
+  it("calls rotate endpoint and shows new keys in modal after confirmation", async () => {
+    mockFetchProjectKeys.mockResolvedValueOnce(mockKeys);
+    mockRotateProjectKeys.mockResolvedValueOnce(mockRotatedKeys);
+    const user = userEvent.setup();
+    const { wrapper } = createQueryWrapper();
+    render(<ApiKeysPage projectId="p1" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("pqdb_anon_abc123****")).toBeInTheDocument();
+    });
+
+    // Click rotate
+    await user.click(screen.getByRole("button", { name: /rotate keys/i }));
+
+    // Confirm rotation
+    const confirmBtn = screen.getByRole("button", { name: /confirm/i });
+    await user.click(confirmBtn);
+
+    // Wait for new keys to show
+    await waitFor(() => {
+      expect(mockRotateProjectKeys).toHaveBeenCalledWith("p1");
+    });
+
+    // Should show the full new keys (one-time display)
+    await waitFor(() => {
+      expect(
+        screen.getByText("pqdb_anon_newkey123456789012345678901234"),
+      ).toBeInTheDocument();
+    });
+
+    // Should show warning
+    expect(
+      screen.getByText(/keys are shown only once/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error state when fetch fails", async () => {
+    mockFetchProjectKeys.mockRejectedValueOnce(
+      new Error("Failed to fetch API keys"),
+    );
+    const { wrapper } = createQueryWrapper();
+    render(<ApiKeysPage projectId="p1" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load api keys/i)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `/projects/:id/keys` page showing API keys in masked format (`pqdb_anon_****`)
- Rotate Keys button with confirmation dialog calls `POST /v1/projects/{id}/keys/rotate`
- One-time display modal shows full new keys after rotation with "Keys are shown only once" warning
- Copy-to-clipboard for each key and SDK connection snippet (`createClient('http://localhost:8000', '...')`)
- Added `rotateProjectKeys()` to projects lib
- 9 unit tests covering masked display, copy buttons, rotation flow, and error states

## Test plan
- [x] Unit tests pass (9/9) — masked display, copy-to-clipboard, rotation flow, error state
- [x] TypeScript typecheck passes
- [x] Production build succeeds
- [ ] Browser verification (requires running backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)