### PR TITLE
feat(US-054): Encryption key management UX

### DIFF
--- a/dashboard/src/components/encryption-settings.tsx
+++ b/dashboard/src/components/encryption-settings.tsx
@@ -1,0 +1,107 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "~/components/ui/card";
+import { Badge } from "~/components/ui/badge";
+
+/**
+ * Encryption section for project settings page.
+ * Explains the zero-knowledge model, key type, and backup best practices.
+ */
+export function EncryptionSettings() {
+  return (
+    <div className="space-y-6">
+      <h2 className="text-xl font-semibold">Encryption</h2>
+
+      {/* Zero-Knowledge Model */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Zero-Knowledge Architecture</CardTitle>
+          <CardDescription>
+            Your encryption key is never sent to the server. All sensitive data
+            is encrypted client-side before transmission.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <h4 className="text-sm font-medium mb-2">Key Type</h4>
+            <p className="text-sm text-muted-foreground">
+              <Badge variant="outline" className="mr-2">ML-KEM-768</Badge>
+              NIST-standardized post-quantum key encapsulation mechanism
+            </p>
+          </div>
+
+          <div>
+            <h4 className="text-sm font-medium mb-2">What It Protects</h4>
+            <p className="text-sm text-muted-foreground">
+              Columns marked as <Badge variant="outline" className="mx-1">searchable</Badge>
+              or <Badge variant="outline" className="mx-1">private</Badge> are
+              encrypted with your key before being stored. Plain columns are
+              stored unencrypted.
+            </p>
+          </div>
+
+          <div>
+            <h4 className="text-sm font-medium mb-2">What Happens If You Lose Your Key</h4>
+            <p className="text-sm text-destructive">
+              If you lose your encryption key, your encrypted data is
+              permanently unrecoverable. The server cannot decrypt your data
+              because it never holds your key.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Backup Recommendations */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Key Backup Recommendations</CardTitle>
+          <CardDescription>
+            Follow these best practices to ensure you never lose access to your
+            encrypted data.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ul className="space-y-3 text-sm">
+            <li className="flex gap-3">
+              <span className="font-medium text-muted-foreground shrink-0">1.</span>
+              <div>
+                <p className="font-medium">Password manager</p>
+                <p className="text-muted-foreground">
+                  Store your encryption key in a reputable password manager
+                  (e.g., 1Password, Bitwarden). This is the most convenient
+                  option for daily use.
+                </p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="font-medium text-muted-foreground shrink-0">2.</span>
+              <div>
+                <p className="font-medium">Secure vault</p>
+                <p className="text-muted-foreground">
+                  Keep a copy in your organization&apos;s secret management system
+                  (e.g., HashiCorp Vault, AWS Secrets Manager) for team access
+                  and disaster recovery.
+                </p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="font-medium text-muted-foreground shrink-0">3.</span>
+              <div>
+                <p className="font-medium">Offline backup</p>
+                <p className="text-muted-foreground">
+                  Write the key on paper or store it on an encrypted USB drive.
+                  Keep it in a physically secure location separate from your
+                  primary backup.
+                </p>
+              </div>
+            </li>
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/dashboard/src/components/table-data-viewer.tsx
+++ b/dashboard/src/components/table-data-viewer.tsx
@@ -325,6 +325,7 @@ export function TableDataViewer({
 function UnlockDialog({ onUnlock }: { onUnlock: (key: string) => void }) {
   const [open, setOpen] = React.useState(false);
   const [key, setKey] = React.useState("");
+  const [warningDismissed, setWarningDismissed] = React.useState(false);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -336,7 +337,10 @@ function UnlockDialog({ onUnlock }: { onUnlock: (key: string) => void }) {
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={(next) => {
+      setOpen(next);
+      if (!next) setWarningDismissed(false);
+    }}>
       <DialogTrigger
         render={
           <Button variant="outline" size="sm">
@@ -353,6 +357,27 @@ function UnlockDialog({ onUnlock }: { onUnlock: (key: string) => void }) {
             held in memory only and never sent to the server.
           </DialogDescription>
         </DialogHeader>
+        {!warningDismissed && (
+          <div
+            data-testid="encryption-key-warning"
+            className="rounded-md border border-yellow-500/50 bg-yellow-50 dark:bg-yellow-950/30 p-3 text-sm text-yellow-800 dark:text-yellow-200"
+          >
+            <p className="font-medium mb-1">Important</p>
+            <p>
+              Your encryption key is never sent to the server. If you lose this
+              key, your encrypted data is permanently unrecoverable. Store it
+              securely.
+            </p>
+            <button
+              type="button"
+              className="mt-2 text-xs underline hover:no-underline"
+              onClick={() => setWarningDismissed(true)}
+              aria-label="Dismiss"
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
             <Label htmlFor="encryption-key">Encryption Key</Label>

--- a/dashboard/src/routeTree.gen.ts
+++ b/dashboard/src/routeTree.gen.ts
@@ -16,6 +16,8 @@ import { Route as SettingsIndexRouteImport } from './routes/settings/index'
 import { Route as ProjectsIndexRouteImport } from './routes/projects/index'
 import { Route as ProjectsProjectIdRouteImport } from './routes/projects/$projectId'
 import { Route as ProjectsProjectIdIndexRouteImport } from './routes/projects/$projectId/index'
+import { Route as ProjectsProjectIdSqlRouteImport } from './routes/projects/$projectId/sql'
+import { Route as ProjectsProjectIdSettingsRouteImport } from './routes/projects/$projectId/settings'
 import { Route as ProjectsProjectIdSchemaRouteImport } from './routes/projects/$projectId/schema'
 import { Route as ProjectsProjectIdLogsRouteImport } from './routes/projects/$projectId/logs'
 import { Route as ProjectsProjectIdKeysRouteImport } from './routes/projects/$projectId.keys'
@@ -58,6 +60,17 @@ const ProjectsProjectIdIndexRoute = ProjectsProjectIdIndexRouteImport.update({
   path: '/',
   getParentRoute: () => ProjectsProjectIdRoute,
 } as any)
+const ProjectsProjectIdSqlRoute = ProjectsProjectIdSqlRouteImport.update({
+  id: '/sql',
+  path: '/sql',
+  getParentRoute: () => ProjectsProjectIdRoute,
+} as any)
+const ProjectsProjectIdSettingsRoute =
+  ProjectsProjectIdSettingsRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => ProjectsProjectIdRoute,
+  } as any)
 const ProjectsProjectIdSchemaRoute = ProjectsProjectIdSchemaRouteImport.update({
   id: '/schema',
   path: '/schema',
@@ -102,6 +115,8 @@ export interface FileRoutesByFullPath {
   '/projects/$projectId/keys': typeof ProjectsProjectIdKeysRoute
   '/projects/$projectId/logs': typeof ProjectsProjectIdLogsRoute
   '/projects/$projectId/schema': typeof ProjectsProjectIdSchemaRoute
+  '/projects/$projectId/settings': typeof ProjectsProjectIdSettingsRoute
+  '/projects/$projectId/sql': typeof ProjectsProjectIdSqlRoute
   '/projects/$projectId/': typeof ProjectsProjectIdIndexRoute
   '/projects/$projectId/tables/$tableName': typeof ProjectsProjectIdTablesTableNameRoute
   '/projects/$projectId/tables/': typeof ProjectsProjectIdTablesIndexRoute
@@ -116,6 +131,8 @@ export interface FileRoutesByTo {
   '/projects/$projectId/keys': typeof ProjectsProjectIdKeysRoute
   '/projects/$projectId/logs': typeof ProjectsProjectIdLogsRoute
   '/projects/$projectId/schema': typeof ProjectsProjectIdSchemaRoute
+  '/projects/$projectId/settings': typeof ProjectsProjectIdSettingsRoute
+  '/projects/$projectId/sql': typeof ProjectsProjectIdSqlRoute
   '/projects/$projectId': typeof ProjectsProjectIdIndexRoute
   '/projects/$projectId/tables/$tableName': typeof ProjectsProjectIdTablesTableNameRoute
   '/projects/$projectId/tables': typeof ProjectsProjectIdTablesIndexRoute
@@ -132,6 +149,8 @@ export interface FileRoutesById {
   '/projects/$projectId/keys': typeof ProjectsProjectIdKeysRoute
   '/projects/$projectId/logs': typeof ProjectsProjectIdLogsRoute
   '/projects/$projectId/schema': typeof ProjectsProjectIdSchemaRoute
+  '/projects/$projectId/settings': typeof ProjectsProjectIdSettingsRoute
+  '/projects/$projectId/sql': typeof ProjectsProjectIdSqlRoute
   '/projects/$projectId/': typeof ProjectsProjectIdIndexRoute
   '/projects/$projectId/tables/$tableName': typeof ProjectsProjectIdTablesTableNameRoute
   '/projects/$projectId/tables/': typeof ProjectsProjectIdTablesIndexRoute
@@ -149,6 +168,8 @@ export interface FileRouteTypes {
     | '/projects/$projectId/keys'
     | '/projects/$projectId/logs'
     | '/projects/$projectId/schema'
+    | '/projects/$projectId/settings'
+    | '/projects/$projectId/sql'
     | '/projects/$projectId/'
     | '/projects/$projectId/tables/$tableName'
     | '/projects/$projectId/tables/'
@@ -163,6 +184,8 @@ export interface FileRouteTypes {
     | '/projects/$projectId/keys'
     | '/projects/$projectId/logs'
     | '/projects/$projectId/schema'
+    | '/projects/$projectId/settings'
+    | '/projects/$projectId/sql'
     | '/projects/$projectId'
     | '/projects/$projectId/tables/$tableName'
     | '/projects/$projectId/tables'
@@ -178,6 +201,8 @@ export interface FileRouteTypes {
     | '/projects/$projectId/keys'
     | '/projects/$projectId/logs'
     | '/projects/$projectId/schema'
+    | '/projects/$projectId/settings'
+    | '/projects/$projectId/sql'
     | '/projects/$projectId/'
     | '/projects/$projectId/tables/$tableName'
     | '/projects/$projectId/tables/'
@@ -243,6 +268,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsProjectIdIndexRouteImport
       parentRoute: typeof ProjectsProjectIdRoute
     }
+    '/projects/$projectId/sql': {
+      id: '/projects/$projectId/sql'
+      path: '/sql'
+      fullPath: '/projects/$projectId/sql'
+      preLoaderRoute: typeof ProjectsProjectIdSqlRouteImport
+      parentRoute: typeof ProjectsProjectIdRoute
+    }
+    '/projects/$projectId/settings': {
+      id: '/projects/$projectId/settings'
+      path: '/settings'
+      fullPath: '/projects/$projectId/settings'
+      preLoaderRoute: typeof ProjectsProjectIdSettingsRouteImport
+      parentRoute: typeof ProjectsProjectIdRoute
+    }
     '/projects/$projectId/schema': {
       id: '/projects/$projectId/schema'
       path: '/schema'
@@ -293,6 +332,8 @@ interface ProjectsProjectIdRouteChildren {
   ProjectsProjectIdKeysRoute: typeof ProjectsProjectIdKeysRoute
   ProjectsProjectIdLogsRoute: typeof ProjectsProjectIdLogsRoute
   ProjectsProjectIdSchemaRoute: typeof ProjectsProjectIdSchemaRoute
+  ProjectsProjectIdSettingsRoute: typeof ProjectsProjectIdSettingsRoute
+  ProjectsProjectIdSqlRoute: typeof ProjectsProjectIdSqlRoute
   ProjectsProjectIdIndexRoute: typeof ProjectsProjectIdIndexRoute
   ProjectsProjectIdTablesTableNameRoute: typeof ProjectsProjectIdTablesTableNameRoute
   ProjectsProjectIdTablesIndexRoute: typeof ProjectsProjectIdTablesIndexRoute
@@ -303,6 +344,8 @@ const ProjectsProjectIdRouteChildren: ProjectsProjectIdRouteChildren = {
   ProjectsProjectIdKeysRoute: ProjectsProjectIdKeysRoute,
   ProjectsProjectIdLogsRoute: ProjectsProjectIdLogsRoute,
   ProjectsProjectIdSchemaRoute: ProjectsProjectIdSchemaRoute,
+  ProjectsProjectIdSettingsRoute: ProjectsProjectIdSettingsRoute,
+  ProjectsProjectIdSqlRoute: ProjectsProjectIdSqlRoute,
   ProjectsProjectIdIndexRoute: ProjectsProjectIdIndexRoute,
   ProjectsProjectIdTablesTableNameRoute: ProjectsProjectIdTablesTableNameRoute,
   ProjectsProjectIdTablesIndexRoute: ProjectsProjectIdTablesIndexRoute,

--- a/dashboard/src/routes/projects/$projectId/settings.tsx
+++ b/dashboard/src/routes/projects/$projectId/settings.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { EncryptionSettings } from "~/components/encryption-settings";
+
+export const Route = createFileRoute("/projects/$projectId/settings")({
+  component: ProjectSettingsRoute,
+});
+
+function ProjectSettingsRoute() {
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold">Project Settings</h1>
+      <EncryptionSettings />
+    </div>
+  );
+}

--- a/dashboard/tests/unit/encryption-settings.test.tsx
+++ b/dashboard/tests/unit/encryption-settings.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+import { EncryptionSettings } from "~/components/encryption-settings";
+
+describe("EncryptionSettings", () => {
+  it("renders the Encryption section heading", () => {
+    render(<EncryptionSettings />);
+    expect(screen.getByText("Encryption")).toBeInTheDocument();
+  });
+
+  it("shows the zero-knowledge model explanation", () => {
+    render(<EncryptionSettings />);
+    expect(
+      screen.getByText(/zero-knowledge/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/never sent to the server/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the key type (ML-KEM-768)", () => {
+    render(<EncryptionSettings />);
+    expect(screen.getByText(/ML-KEM-768/)).toBeInTheDocument();
+  });
+
+  it("explains what the key protects", () => {
+    render(<EncryptionSettings />);
+    expect(screen.getByText("searchable")).toBeInTheDocument();
+    expect(screen.getByText("private")).toBeInTheDocument();
+    expect(screen.getByText(/encrypted with your key/i)).toBeInTheDocument();
+  });
+
+  it("explains what happens if the key is lost", () => {
+    render(<EncryptionSettings />);
+    expect(
+      screen.getByText(/permanently unrecoverable/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows backup recommendations", () => {
+    render(<EncryptionSettings />);
+    expect(screen.getAllByText(/password manager/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/secure vault/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/offline backup/i).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/dashboard/tests/unit/table-data-viewer.test.tsx
+++ b/dashboard/tests/unit/table-data-viewer.test.tsx
@@ -176,6 +176,51 @@ describe("TableDataViewer", () => {
     expect(await screen.findByText(/enter.*encryption key/i)).toBeInTheDocument();
   });
 
+  it("shows zero-knowledge warning in the unlock dialog", async () => {
+    const user = userEvent.setup();
+    mockFetchTableRows.mockResolvedValueOnce(mockRowsData);
+    mockFetchSchema.mockResolvedValueOnce(mockSchemaData);
+    render(
+      <Wrapper>
+        <TableDataViewer projectId="p1" tableName="users" apiKey="pqdb_service_abc" />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /unlock/i }));
+    const warning = await screen.findByTestId("encryption-key-warning");
+    expect(warning).toBeInTheDocument();
+    expect(warning.textContent).toMatch(/never sent to the server/i);
+    expect(warning.textContent).toMatch(/permanently unrecoverable/i);
+    expect(warning.textContent).toMatch(/store it securely/i);
+  });
+
+  it("allows dismissing the unlock dialog warning", async () => {
+    const user = userEvent.setup();
+    mockFetchTableRows.mockResolvedValueOnce(mockRowsData);
+    mockFetchSchema.mockResolvedValueOnce(mockSchemaData);
+    render(
+      <Wrapper>
+        <TableDataViewer projectId="p1" tableName="users" apiKey="pqdb_service_abc" />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /unlock/i }));
+    const warning = await screen.findByTestId("encryption-key-warning");
+    expect(warning).toBeInTheDocument();
+
+    const dismissBtn = screen.getByRole("button", { name: /dismiss/i });
+    await user.click(dismissBtn);
+    expect(screen.queryByTestId("encryption-key-warning")).not.toBeInTheDocument();
+  });
+
   it("shows insert row button", async () => {
     mockFetchTableRows.mockResolvedValueOnce(mockRowsData);
     mockFetchSchema.mockResolvedValueOnce(mockSchemaData);

--- a/sdk/src/client/index.ts
+++ b/sdk/src/client/index.ts
@@ -105,6 +105,15 @@ export function createClient(
   const http = new HttpClient(projectUrl, apiKey);
   const auth = new AuthClient(http, options?.projectId);
 
+  // One-time warning about encryption key backup responsibility
+  if (options?.encryptionKey) {
+    console.warn(
+      "[pqdb] Your encryption key is never sent to the server. " +
+      "If you lose this key, your encrypted data is permanently unrecoverable. " +
+      "Store it securely (password manager, secure vault, or offline backup).",
+    );
+  }
+
   // Crypto state — lazily initialized
   let resolvedCryptoCtx: CryptoContext | null = null;
   let cryptoCtxPromise: Promise<CryptoContext> | null = null;

--- a/sdk/tests/unit/encryption-warning.test.ts
+++ b/sdk/tests/unit/encryption-warning.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createClient } from "../../src/client/index.js";
+
+describe("createClient encryption key warning", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("logs a warning when encryptionKey is provided", () => {
+    createClient("http://localhost:3000", "pqdb_anon_abc123", {
+      encryptionKey: "my-secret-key",
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("encryption key"),
+    );
+  });
+
+  it("warning includes backup responsibility message", () => {
+    createClient("http://localhost:3000", "pqdb_anon_abc123", {
+      encryptionKey: "my-secret-key",
+    });
+
+    const message = warnSpy.mock.calls[0][0] as string;
+    expect(message).toMatch(/never sent to the server/i);
+    expect(message).toMatch(/unrecoverable/i);
+    expect(message).toMatch(/store.*securely/i);
+  });
+
+  it("does NOT log a warning when no encryptionKey is provided", () => {
+    createClient("http://localhost:3000", "pqdb_anon_abc123");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("only logs warning once per client instance, not on every from() call", () => {
+    const client = createClient("http://localhost:3000", "pqdb_anon_abc123", {
+      encryptionKey: "my-secret-key",
+    });
+
+    // The warning fires at creation time, not on from() calls
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    // Multiple defineTable/from calls should not trigger additional warnings
+    const schema = client.defineTable("test", {
+      id: { type: "plain" },
+    });
+    client.from(schema);
+    client.from(schema);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- **Unlock dialog warning**: Added a dismissable warning in the table editor's Unlock dialog reminding developers that their encryption key is never sent to the server and that lost keys mean permanently unrecoverable data
- **Project settings Encryption section**: New `/projects/:id/settings` route with cards explaining the zero-knowledge model, ML-KEM-768 key type, what it protects, what happens if lost, and backup recommendations (password manager, secure vault, offline backup)
- **SDK console.warn**: `createClient()` now logs a one-time `console.warn` when an `encryptionKey` is provided, warning about backup responsibility

## Test plan
- [x] Dashboard: Unlock dialog warning renders and is dismissable (2 new tests in table-data-viewer.test.tsx)
- [x] Dashboard: Encryption settings component renders all required content (6 new tests in encryption-settings.test.tsx)
- [x] SDK: console.warn fires once when encryptionKey provided, not without it, not on subsequent from() calls (4 new tests in encryption-warning.test.ts)
- [x] Dashboard typecheck passes (`tsc --noEmit` zero errors)
- [x] SDK typecheck passes
- [x] Dashboard build succeeds
- [x] SDK build succeeds
- [x] All existing tests still pass

Generated with [Claude Code](https://claude.com/claude-code)