### PR TITLE
[US-001] Export ML-KEM primitives from SDK

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -44,7 +44,8 @@ export { MfaClient } from "./client/mfa.js";
 
 // Crypto exports (for MCP server and other consumers that need direct access)
 export { deriveKeyPair, encrypt, decrypt } from "./crypto/encryption.js";
-export type { KeyPair } from "./crypto/pqc.js";
+export { generateKeyPair, encapsulate, decapsulate } from "./crypto/pqc.js";
+export type { KeyPair, EncapsulationResult } from "./crypto/pqc.js";
 export { computeBlindIndex } from "./crypto/blind-index.js";
 export {
   transformInsertRows,

--- a/sdk/tests/unit/pqc-export.test.ts
+++ b/sdk/tests/unit/pqc-export.test.ts
@@ -1,0 +1,50 @@
+/**
+ * US-001 — verify ML-KEM primitives are exported from the package root.
+ *
+ * Consumers (dashboard, MCP server) should be able to import generateKeyPair,
+ * encapsulate, decapsulate, and the KeyPair / EncapsulationResult types
+ * directly from '@pqdb/client' without reaching into internal paths.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  generateKeyPair,
+  encapsulate,
+  decapsulate,
+  type KeyPair,
+  type EncapsulationResult,
+} from "@pqdb/client";
+
+describe("US-001: ML-KEM primitives exported from @pqdb/client", () => {
+  it("exposes generateKeyPair, encapsulate, decapsulate as functions", () => {
+    expect(typeof generateKeyPair).toBe("function");
+    expect(typeof encapsulate).toBe("function");
+    expect(typeof decapsulate).toBe("function");
+  });
+
+  it("performs a full ML-KEM-768 round-trip with matching shared secrets", async () => {
+    const keyPair: KeyPair = await generateKeyPair();
+    expect(keyPair.publicKey).toBeInstanceOf(Uint8Array);
+    expect(keyPair.secretKey).toBeInstanceOf(Uint8Array);
+    expect(keyPair.publicKey.byteLength).toBe(1184);
+    expect(keyPair.secretKey.byteLength).toBe(2400);
+
+    const encap: EncapsulationResult = await encapsulate(keyPair.publicKey);
+    expect(encap.ciphertext).toBeInstanceOf(Uint8Array);
+    expect(encap.sharedSecret).toBeInstanceOf(Uint8Array);
+    expect(encap.ciphertext.byteLength).toBe(1088);
+    expect(encap.sharedSecret.byteLength).toBe(32);
+
+    const recovered = await decapsulate(encap.ciphertext, keyPair.secretKey);
+    expect(recovered).toBeInstanceOf(Uint8Array);
+    expect(recovered.byteLength).toBe(32);
+    expect(recovered).toEqual(encap.sharedSecret);
+  });
+
+  it("produces different shared secrets across independent encapsulations", async () => {
+    const { publicKey } = await generateKeyPair();
+    const a = await encapsulate(publicKey);
+    const b = await encapsulate(publicKey);
+    expect(a.sharedSecret).not.toEqual(b.sharedSecret);
+    expect(a.ciphertext).not.toEqual(b.ciphertext);
+  });
+});

--- a/sdk/vitest.config.ts
+++ b/sdk/vitest.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
 
 export default defineConfig({
   test: {
     exclude: ["tests/e2e/**", "node_modules/**"],
+    alias: {
+      "@pqdb/client": fileURLToPath(new URL("./src/index.ts", import.meta.url)),
+    },
   },
 });


### PR DESCRIPTION
## Who

- Isaac Quintero (author), paired with Claude (impl-US-001 agent)

## What

- Re-export `generateKeyPair`, `encapsulate`, `decapsulate` from the `@pqdb/client` package root
- Re-export `EncapsulationResult` type alongside the existing `KeyPair` type
- Add unit test verifying full ML-KEM-768 round-trip via package-root imports
- Add vitest alias so `@pqdb/client` resolves to source during tests

## When

- 2026-04-09

## Where

- `sdk/src/index.ts` — additive re-exports from `./crypto/pqc.js`
- `sdk/tests/unit/pqc-export.test.ts` — new file, 3 tests
- `sdk/vitest.config.ts` — alias `@pqdb/client` → `./src/index.ts`

## Why

Phase 5d requires the dashboard, MCP server, and any future `@pqdb/client` consumer to perform ML-KEM-768 keypair generation, encapsulation, and decapsulation for the new developer-owned encryption keypair flow. The primitives already exist in `sdk/src/crypto/pqc.ts` but were not exported from the package root, forcing downstream packages to reach into internal paths that are not part of the stable public API surface. US-001 locks these primitives in as first-class public exports so US-004 (dashboard signup), US-006 (create project encapsulate), US-007 (project-load decapsulate), and US-008 (MCP encapsulate) can all depend on a single, stable import path.

## How

Straightforward additive re-export from the existing `./crypto/pqc.js` module. No implementation was moved, duplicated, or rewritten — only the `export` surface of `src/index.ts` was expanded.

**TDD workflow followed:**
1. RED — wrote `pqc-export.test.ts` importing from `@pqdb/client`, confirmed 3 failures with `TypeError: generateKeyPair is not a function`
2. GREEN — added the three named exports + `EncapsulationResult` type to `src/index.ts`, all 3 tests pass
3. Full suite, typecheck, and build all green

**Vitest alias rationale:** the acceptance criterion requires the test to import from `@pqdb/client` (the package name). Node self-reference via `exports` points at `dist/`, which would couple TDD to a prior build. A vitest alias resolves `@pqdb/client` → `./src/index.ts` at test time, so tests run against source without a build step — this is the standard pattern for monorepo self-testing.

**Considered:**
- Reimplement ML-KEM in dashboard/MCP directly — rejected: duplicates `@noble/post-quantum` wiring, violates DRY
- Deep-import via `@pqdb/client/crypto/pqc.js` — rejected: relies on internal path outside the stable public API
- Re-export from `src/index.ts` (chosen) — zero duplication, additive, locks primitives as part of the SDK contract

**Trade-offs:**
- Expands the public API surface — once exported, the signatures are effectively locked for semver
- Vitest config now carries a self-alias; harmless for tests but adds one line of config

## Test plan

- [x] `cd sdk && npm test -- --run` — 238/238 tests pass locally (23 test files)
- [x] `npm run typecheck` — clean (`tsc --noEmit`, strict mode)
- [x] `npm run build` — ESM + CJS + DTS build succeeds via tsup
- [x] `dist/index.d.ts` inspected — contains `generateKeyPair`, `encapsulate`, `decapsulate`, `EncapsulationResult`, `KeyPair` (verified by grep)
- [x] `gitleaks detect --source . --no-banner` — no leaks found
- [x] `semgrep scan --config=auto` on changed files — 0 findings (378 rules run)
- [ ] CI passes on this PR

## Non-goals

- Dashboard signup keypair generation — deferred to US-004
- IndexedDB keypair persistence / recovery modal — deferred to US-005a/US-005b
- `encapsulate` call during project creation — deferred to US-006
- `decapsulate` call during project load — deferred to US-007
- MCP server `PQDB_PRIVATE_KEY` handling — deferred to US-008
- Backend `ml_kem_public_key` column and signup API changes — deferred to US-002/US-003
- No npm publish of `@pqdb/client` — the SDK remains consumed locally via workspace
