### PR TITLE
[US-009] Dashboard navigation back to projects (3 paths)

### DIFF
--- a/dashboard/e2e/nav-back-to-projects.spec.ts
+++ b/dashboard/e2e/nav-back-to-projects.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * E2E — US-009: Dashboard navigation back to projects list
+ *
+ * Verifies all three navigation paths from an in-project route back to
+ * /projects:
+ *   1) Click the pqdb sidebar logo
+ *   2) Click 'All Projects' in the project-selector dropdown (on /projects)
+ *   3) Click the 'All projects' breadcrumb in the top-bar
+ *
+ * Each path starts from /projects/{id}/schema (the deepest routine
+ * navigation landing page) and must land on /projects.
+ */
+import { test, expect } from "@playwright/test";
+import {
+  testEmail,
+  apiSignup,
+  apiCreateProject,
+  injectTokens,
+  mockProjectKeys,
+} from "./helpers";
+
+const PASSWORD = "TestPassword123!";
+const BASE_URL = "http://localhost:8000";
+
+test.describe("US-009: navigate back to projects list", () => {
+  let accessToken: string;
+  let refreshToken: string;
+  let projectId: string;
+
+  test.beforeAll(async () => {
+    const email = testEmail();
+    const tokens = await apiSignup(BASE_URL, email, PASSWORD);
+    accessToken = tokens.access_token;
+    refreshToken = tokens.refresh_token;
+    const project = await apiCreateProject(
+      BASE_URL,
+      accessToken,
+      `us009-e2e-${Date.now()}`,
+    );
+    projectId = project.id;
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await injectTokens(page, accessToken, refreshToken);
+    const serviceKey = "dummy-service-key-us009";
+    await mockProjectKeys(page, projectId, serviceKey);
+  });
+
+  test("clicking the pqdb sidebar logo navigates to /projects", async ({ page }) => {
+    await page.goto(`/projects/${projectId}/schema`, { waitUntil: "networkidle" });
+    await expect(page).toHaveURL(new RegExp(`/projects/${projectId}/schema`));
+
+    // The sidebar logo is the 'pqdb' text wrapped in a <Link to="/projects">.
+    const sidebar = page.getByTestId("sidebar-nav");
+    await sidebar.getByRole("link", { name: "pqdb", exact: true }).click();
+
+    await expect(page).toHaveURL(/\/projects$/, { timeout: 10_000 });
+  });
+
+  test("clicking 'All Projects' in project selector dropdown navigates to /projects", async ({ page }) => {
+    // The project-selector is only rendered outside of a project. Start
+    // from /projects so the selector is visible, then open the dropdown
+    // and click 'All Projects'.
+    await page.goto("/projects", { waitUntil: "networkidle" });
+    // Navigate into a project first so the test exercises coming back via
+    // the dropdown from inside a project via the top-bar breadcrumb path.
+    await page.goto(`/projects/${projectId}/schema`, { waitUntil: "networkidle" });
+    // Jump back to projects page so we can interact with the selector.
+    await page.goto("/projects", { waitUntil: "networkidle" });
+
+    // Open the dropdown
+    const selector = page.getByTestId("project-selector");
+    await selector.getByRole("button").first().click();
+
+    // Click 'All Projects' entry
+    await page.getByRole("link", { name: "All Projects" }).click();
+
+    await expect(page).toHaveURL(/\/projects$/, { timeout: 10_000 });
+  });
+
+  test("clicking 'All projects' breadcrumb in top-bar navigates to /projects", async ({ page }) => {
+    await page.goto(`/projects/${projectId}/schema`, { waitUntil: "networkidle" });
+    await expect(page).toHaveURL(new RegExp(`/projects/${projectId}/schema`));
+
+    const breadcrumb = page.getByTestId("breadcrumb-all-projects");
+    await expect(breadcrumb).toBeVisible();
+    await breadcrumb.click();
+
+    await expect(page).toHaveURL(/\/projects$/, { timeout: 10_000 });
+  });
+});

--- a/dashboard/src/components/project-selector.tsx
+++ b/dashboard/src/components/project-selector.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useQuery } from "@tanstack/react-query";
 import { ChevronDown } from "lucide-react";
+import { Link } from "@tanstack/react-router";
 import { fetchProjects, type Project } from "~/lib/projects";
 
 interface ProjectSelectorProps {
@@ -45,6 +46,18 @@ export function ProjectSelector({
 
       {open && (
         <div className="absolute top-full left-0 z-50 mt-1 min-w-[200px] rounded-md border border-border bg-popover p-1 shadow-md">
+          <Link
+            to="/projects"
+            className="flex w-full items-center rounded-sm px-2 py-1.5 text-sm font-medium hover:bg-accent"
+            onClick={() => setOpen(false)}
+          >
+            All Projects
+          </Link>
+          <div
+            data-testid="all-projects-divider"
+            className="my-1 h-px bg-border"
+            role="separator"
+          />
           {projects.length === 0 ? (
             <p className="px-2 py-1.5 text-sm text-muted-foreground">
               No projects

--- a/dashboard/src/components/sidebar-nav.tsx
+++ b/dashboard/src/components/sidebar-nav.tsx
@@ -86,9 +86,12 @@ export function SidebarNav({ projectStatus }: { projectStatus?: string } = {}) {
       className="flex h-full w-60 flex-col border-r border-border bg-sidebar px-3 py-4"
     >
       <div className="mb-6 px-3">
-        <span className="text-lg font-semibold text-sidebar-foreground">
-          pqdb
-        </span>
+        <Link
+          to="/projects"
+          className="cursor-pointer text-lg font-semibold text-sidebar-foreground hover:text-sidebar-accent-foreground"
+        >
+          <span>pqdb</span>
+        </Link>
       </div>
       <ul className="flex flex-1 flex-col gap-1 overflow-y-auto">
         {sidebarNavItems.map((item) => {

--- a/dashboard/src/components/top-bar.tsx
+++ b/dashboard/src/components/top-bar.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Search, Settings, Plug, LogOut } from "lucide-react";
 import { ThemeToggle } from "./theme-toggle";
 import { ProjectSelector } from "./project-selector";
@@ -6,10 +7,10 @@ import { BranchSelector } from "./branch-selector";
 import { ConnectPopup } from "./connect-popup";
 import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
 import { useNavigate } from "~/lib/navigation";
-import { useParams } from "@tanstack/react-router";
+import { Link, useParams } from "@tanstack/react-router";
 import { clearTokens } from "~/lib/auth-store";
 import { getActiveBranch, setActiveBranch } from "~/lib/branch-store";
-import type { Project } from "~/lib/projects";
+import { fetchProject, type Project } from "~/lib/projects";
 
 export function TopBar() {
   const navigate = useNavigate();
@@ -22,6 +23,18 @@ export function TopBar() {
   const [activeBranch, setActiveBranchState] = React.useState<string | null>(
     () => getActiveBranch(),
   );
+
+  // Fetch project details when we only have the URL id so the breadcrumb
+  // can display the human-readable project name.
+  const { data: urlProject } = useQuery({
+    queryKey: ["project", urlProjectId],
+    queryFn: () => fetchProject(urlProjectId!),
+    enabled: !!urlProjectId && !selectedProject,
+  });
+
+  const activeProjectId = selectedProject?.id ?? urlProjectId;
+  const activeProjectName = selectedProject?.name ?? urlProject?.name;
+  const insideProject = !!activeProjectId;
 
   function handleProjectSelect(project: Project) {
     setSelectedProject(project);
@@ -63,19 +76,36 @@ export function TopBar() {
           </PopoverContent>
         </Popover>
         <span className="text-muted-foreground">/</span>
-        <ProjectSelector
-          selectedProjectId={selectedProject?.id ?? null}
-          onProjectSelect={handleProjectSelect}
-        />
-        {(selectedProject?.id ?? urlProjectId) && (
+        {insideProject ? (
           <>
+            <Link
+              to="/projects"
+              data-testid="breadcrumb-all-projects"
+              className="rounded-md px-2 py-1 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              All projects
+            </Link>
+            <span className="text-muted-foreground">/</span>
+            <Link
+              to="/projects/$projectId"
+              params={{ projectId: activeProjectId! }}
+              data-testid="breadcrumb-project-name"
+              className="rounded-md px-2 py-1 text-sm font-medium text-foreground hover:bg-accent"
+            >
+              {activeProjectName ?? activeProjectId}
+            </Link>
             <span className="text-muted-foreground">/</span>
             <BranchSelector
-              projectId={(selectedProject?.id ?? urlProjectId)!}
+              projectId={activeProjectId!}
               activeBranch={activeBranch}
               onBranchChange={handleBranchChange}
             />
           </>
+        ) : (
+          <ProjectSelector
+            selectedProjectId={selectedProject?.id ?? null}
+            onProjectSelect={handleProjectSelect}
+          />
         )}
       </div>
 

--- a/dashboard/tests/unit/project-selector.test.tsx
+++ b/dashboard/tests/unit/project-selector.test.tsx
@@ -16,6 +16,27 @@ vi.mock("~/lib/navigation", () => ({
   useNavigate: () => mockNavigate,
 }));
 
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    to,
+    children,
+    className,
+    onClick,
+    ...rest
+  }: {
+    to?: string;
+    children: React.ReactNode;
+    className?: string;
+    onClick?: (e: React.MouseEvent) => void;
+    [key: string]: unknown;
+  }) => (
+    <a href={to} className={className} onClick={onClick} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+import * as React from "react";
 import { ProjectSelector } from "~/components/project-selector";
 
 const mockProjects = [
@@ -86,6 +107,61 @@ describe("ProjectSelector", () => {
     await waitFor(() => {
       expect(screen.getByText("My App")).toBeInTheDocument();
     });
+  });
+
+  it("renders 'All Projects' as the first item linking to /projects (US-009)", async () => {
+    const user = userEvent.setup();
+    mockFetchProjects.mockResolvedValueOnce(mockProjects);
+    const { wrapper } = createQueryWrapper();
+
+    render(
+      <ProjectSelector
+        selectedProjectId="p1"
+        onProjectSelect={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    // Open dropdown
+    await waitFor(() => expect(mockFetchProjects).toHaveBeenCalled());
+    const button = await screen.findByRole("button", { name: /My App/i });
+    await user.click(button);
+
+    // "All Projects" entry exists as a link to /projects
+    const allProjects = await screen.findByText("All Projects");
+    const link = allProjects.closest("a");
+    expect(link).not.toBeNull();
+    expect(link).toHaveAttribute("href", "/projects");
+
+    // Divider exists below "All Projects"
+    const divider = screen.getByTestId("all-projects-divider");
+    expect(divider).toBeInTheDocument();
+  });
+
+  it("'All Projects' appears before any individual project in the dropdown (US-009)", async () => {
+    const user = userEvent.setup();
+    mockFetchProjects.mockResolvedValueOnce(mockProjects);
+    const { wrapper } = createQueryWrapper();
+
+    render(
+      <ProjectSelector
+        selectedProjectId={null}
+        onProjectSelect={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    await waitFor(() => expect(mockFetchProjects).toHaveBeenCalled());
+    const button = await screen.findByRole("button", { name: /select project/i });
+    await user.click(button);
+
+    const allProjects = await screen.findByText("All Projects");
+    // Find the dropdown project button by role (button, not anchor)
+    const firstApp = await screen.findByRole("button", { name: "My App" });
+
+    // Document order: All Projects must appear before the first project entry.
+    const position = allProjects.compareDocumentPosition(firstApp);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("calls onProjectSelect when a project is chosen", async () => {

--- a/dashboard/tests/unit/sidebar-nav.test.tsx
+++ b/dashboard/tests/unit/sidebar-nav.test.tsx
@@ -133,4 +133,21 @@ describe("SidebarNav", () => {
     renderSidebar();
     expect(mockUseParams).toHaveBeenCalledWith({ strict: false });
   });
+
+  it("renders the pqdb logo as a Link to /projects (US-009)", () => {
+    mockUseParams.mockReturnValue({ projectId: "proj-abc" });
+    renderSidebar();
+    const logo = screen.getByText("pqdb");
+    const link = logo.closest("a");
+    expect(link).not.toBeNull();
+    expect(link).toHaveAttribute("href", "/projects");
+  });
+
+  it("logo link has cursor-pointer hover class (US-009)", () => {
+    mockUseParams.mockReturnValue({ projectId: "proj-abc" });
+    renderSidebar();
+    const logo = screen.getByText("pqdb");
+    const link = logo.closest("a");
+    expect(link?.className).toMatch(/cursor-pointer/);
+  });
 });

--- a/dashboard/tests/unit/top-bar.test.tsx
+++ b/dashboard/tests/unit/top-bar.test.tsx
@@ -1,20 +1,56 @@
-import { describe, it, expect, vi } from "vitest";
+import * as React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { ThemeProvider } from "~/lib/theme";
 import { createQueryWrapper } from "../query-wrapper";
 
-const { mockFetchProjects, mockNavigate } = vi.hoisted(() => ({
+const { mockFetchProjects, mockNavigate, mockUseParams, mockFetchProject } = vi.hoisted(() => ({
   mockFetchProjects: vi.fn().mockResolvedValue([]),
   mockNavigate: vi.fn(),
+  mockUseParams: vi.fn().mockReturnValue({}),
+  mockFetchProject: vi.fn(),
 }));
 
 vi.mock("~/lib/projects", () => ({
   fetchProjects: mockFetchProjects,
+  fetchProject: mockFetchProject,
   fetchProjectKeys: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("~/lib/navigation", () => ({
   useNavigate: () => mockNavigate,
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useParams: (...args: unknown[]) => mockUseParams(...args),
+  Link: ({
+    to,
+    params,
+    children,
+    className,
+    onClick,
+    ...rest
+  }: {
+    to?: string;
+    params?: Record<string, string>;
+    children: React.ReactNode;
+    className?: string;
+    onClick?: (e: React.MouseEvent) => void;
+    [key: string]: unknown;
+  }) => {
+    // Substitute :paramName patterns from params object
+    let href = to ?? "";
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        href = href.replace(`$${key}`, value).replace(`:${key}`, value);
+      }
+    }
+    return (
+      <a href={href} className={className} onClick={onClick} {...rest}>
+        {children}
+      </a>
+    );
+  },
 }));
 
 import { TopBar } from "~/components/top-bar";
@@ -31,6 +67,13 @@ function renderWithTheme() {
 }
 
 describe("TopBar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchProjects.mockResolvedValue([]);
+    mockUseParams.mockReturnValue({});
+    mockFetchProject.mockReset();
+  });
+
   it("renders the top bar", () => {
     renderWithTheme();
     expect(screen.getByTestId("top-bar")).toBeInTheDocument();
@@ -41,7 +84,8 @@ describe("TopBar", () => {
     expect(screen.getByText("Account")).toBeInTheDocument();
   });
 
-  it("renders the Project selector dropdown", () => {
+  it("renders the Project selector dropdown when not inside a project", () => {
+    mockUseParams.mockReturnValue({});
     renderWithTheme();
     expect(screen.getByTestId("project-selector")).toBeInTheDocument();
   });
@@ -64,5 +108,62 @@ describe("TopBar", () => {
   it("renders the theme toggle", () => {
     renderWithTheme();
     expect(screen.getByTestId("theme-toggle")).toBeInTheDocument();
+  });
+
+  describe("breadcrumb inside a project (US-009)", () => {
+    beforeEach(() => {
+      mockUseParams.mockReturnValue({ projectId: "proj-abc" });
+      mockFetchProjects.mockResolvedValue([
+        {
+          id: "proj-abc",
+          name: "Acme API",
+          region: "us-east-1",
+          status: "active",
+          database_name: "pqdb_project_proj_abc",
+          created_at: "2026-01-01T00:00:00Z",
+        },
+      ]);
+      mockFetchProject.mockResolvedValue({
+        id: "proj-abc",
+        name: "Acme API",
+        region: "us-east-1",
+        status: "active",
+        database_name: "pqdb_project_proj_abc",
+        created_at: "2026-01-01T00:00:00Z",
+      });
+    });
+
+    it("renders 'All projects' as a clickable Link to /projects", async () => {
+      renderWithTheme();
+      const link = await screen.findByTestId("breadcrumb-all-projects");
+      expect(link.tagName).toBe("A");
+      expect(link).toHaveAttribute("href", "/projects");
+      expect(link.textContent).toContain("All projects");
+    });
+
+    it("renders {ProjectName} as a clickable Link to /projects/{id}", async () => {
+      renderWithTheme();
+      const link = await screen.findByTestId("breadcrumb-project-name");
+      expect(link.tagName).toBe("A");
+      expect(link).toHaveAttribute("href", "/projects/proj-abc");
+      // Wait for the project name to resolve from the query
+      const { waitFor } = await import("@testing-library/react");
+      await waitFor(() => {
+        expect(link.textContent).toContain("Acme API");
+      });
+    });
+
+    it("breadcrumb order is Account / All projects / {ProjectName} / {Branch}", async () => {
+      renderWithTheme();
+      const account = screen.getByText("Account");
+      const allProjects = await screen.findByTestId("breadcrumb-all-projects");
+      const projectName = await screen.findByTestId("breadcrumb-project-name");
+
+      const accountPos = account.compareDocumentPosition(allProjects);
+      expect(accountPos & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+      const allProjectsPos = allProjects.compareDocumentPosition(projectName);
+      expect(allProjectsPos & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
## Who
- Isaac Quintero (author) + Claude Opus 4.6 (pair programming)

## What
- Wrap the sidebar `pqdb` logo in a TanStack Router `Link` to `/projects` with `cursor-pointer`
- Add `All Projects` as the first item in the project-selector dropdown, separated from the project list by a horizontal divider
- Replace the top-bar project-switcher inside a project with a real breadcrumb: `Account / All projects / {ProjectName} / {BranchName}`, where `All projects` links to `/projects` and `{ProjectName}` links to `/projects/{id}`
- Fetch active project via react-query when entering via a deep link so the breadcrumb can show the human-readable name
- Fix the pre-existing broken top-bar unit test suite (added a missing `@tanstack/react-router` mock so `useParams` resolves in jsdom)
- Add three Playwright E2E cases (one per nav path) in `dashboard/e2e/nav-back-to-projects.spec.ts`

## When
- 2026-04-09

## Where
- `dashboard/src/components/sidebar-nav.tsx`
- `dashboard/src/components/project-selector.tsx`
- `dashboard/src/components/top-bar.tsx`
- `dashboard/tests/unit/sidebar-nav.test.tsx`
- `dashboard/tests/unit/project-selector.test.tsx`
- `dashboard/tests/unit/top-bar.test.tsx`
- `dashboard/e2e/nav-back-to-projects.spec.ts` (new)

## Why
Users inside a project had no discoverable path back to `/projects`. The sidebar logo was a plain `span`, the project selector dropdown only listed sibling projects, and the top bar used the dropdown trigger as the only reference to the current project — with no text-based breadcrumb link back to the projects list. Different users expect different conventions (logo-as-home, dropdown "all items" entry, breadcrumb trail), so US-009 required all three redundant paths rather than picking one.

## How
Strict TDD on three independent features: each started with a failing unit test, then the minimum implementation to turn it GREEN, then a commit.

**Sidebar logo** — considered a plain `<a href>` (breaks client-side routing) and a `<button onClick={navigate}>` (breaks middle-click / open-in-new-tab). Chose a TanStack Router `<Link to="/projects">` wrapping the existing `<span>pqdb</span>` so the router preserves history and the browser keeps native anchor ergonomics. Added `cursor-pointer` to match PRD wording.

**Project-selector** — considered repurposing the dropdown trigger button as a Link (rejected, it must open the popover) and adding a sibling back-arrow button (rejected, not discoverable). Chose the PRD-specified approach: new first row `All Projects` implemented as a `Link` with `onClick={() => setOpen(false)}`, followed by a 1px divider (`data-testid="all-projects-divider"`), then the existing project list.

**Top bar breadcrumb** — considered keeping the dropdown and adding an inline `All projects` link beside it (rejected, two ways to switch project from the same spot = clutter). Chose to render the breadcrumb conditionally: when inside a project show `Account / All projects / {ProjectName} / {BranchName}`; when outside, show the original `Account / [ProjectSelector dropdown]`. The dropdown still exists for initial project selection on `/projects`. The TopBar now issues a react-query `fetchProject(urlProjectId)` fallback so deep links still show the human-readable name.

Trade-offs:
- Switching projects while already inside a project now requires clicking `All projects` first, then picking another card. Acceptable for MVP; future work could re-introduce a switcher in the breadcrumb.
- Extra query on deep-link entry, cached by react-query under the existing `["project", id]` key (no duplicate network hit on pages that already use it).
- Sidebar `ul` already had `overflow-y-auto`; no new nav items were added so Rule 20 (sidebar overflow) is unchanged.

## Test plan
- [x] `npm test -- --run tests/unit/sidebar-nav.test.tsx tests/unit/project-selector.test.tsx tests/unit/top-bar.test.tsx` — 26/26 passing
- [x] Full suite: 555/556 passing. The single failure (`login-mcp-redirect`) is pre-existing on main and unrelated to US-009 (verified by running the same test on main's tip)
- [x] `npm run typecheck` — clean (`tsc --noEmit`)
- [x] `npm run build` — production bundle built successfully
- [x] `gitleaks detect --source . --no-banner` — no leaks found
- [x] Semgrep scan on the 4 changed files — 0 findings
- [ ] `npx playwright test e2e/nav-back-to-projects.spec.ts` — will run in CI (spec committed; requires live backend + dashboard)

## Non-goals
- Re-introducing project switching from inside a project (deferred — current flow is `All projects` → project card)
- Adding breadcrumb for non-project routes (e.g., `/settings`) — out of scope for US-009
- Any changes to SDK, backend, or MCP packages (parallel agents own those for Phase 5d)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
