### PR TITLE
[US-002] Add ml_kem_public_key column to developers

### DIFF
--- a/backend/alembic/versions/011_add_ml_kem_public_key_to_developers.py
+++ b/backend/alembic/versions/011_add_ml_kem_public_key_to_developers.py
@@ -1,0 +1,27 @@
+"""Add ml_kem_public_key column to developers.
+
+Revision ID: 011
+Revises: 010
+Create Date: 2026-04-09
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "011"
+down_revision: str | None = "010"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "developers",
+        sa.Column("ml_kem_public_key", sa.LargeBinary(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("developers", "ml_kem_public_key")

--- a/backend/src/pqdb_api/models/developer.py
+++ b/backend/src/pqdb_api/models/developer.py
@@ -34,6 +34,7 @@ class Developer(Base):
     email_verified: Mapped[bool] = mapped_column(
         Boolean, server_default="false", nullable=False
     )
+    ml_kem_public_key: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/tests/integration/test_ml_kem_public_key_column.py
+++ b/backend/tests/integration/test_ml_kem_public_key_column.py
@@ -1,0 +1,251 @@
+"""Integration tests for US-002: ml_kem_public_key column on developers.
+
+Verifies that:
+- The FastAPI app boots and /health returns 200.
+- The developers table exposes an ml_kem_public_key column of type BYTEA
+  that is nullable, per acceptance criteria in prd.json (US-002).
+- The column round-trips None and bytes values via the SQLAlchemy model.
+- The Alembic migration 011_add_ml_kem_public_key_to_developers.py applies
+  cleanly against a fresh database and is reversible (downgrade -> upgrade).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import subprocess
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from pqdb_api.models.developer import Developer
+from tests.integration.conftest import _make_platform_app
+
+PG_HOST = "localhost"
+PG_PORT = 5432
+PG_USER = "postgres"
+PG_PASS = "postgres"
+
+
+def _pg_available() -> bool:
+    try:
+        with socket.create_connection((PG_HOST, PG_PORT), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _pg_available(),
+    reason="Integration tests require Postgres on localhost:5432",
+)
+
+
+class TestMlKemPublicKeyColumn:
+    """US-002 acceptance: developers.ml_kem_public_key is BYTEA NULLABLE."""
+
+    def test_health_endpoint_responds(self, test_db_url: str) -> None:
+        """Service responds to health check (/health returns 200)."""
+        app = _make_platform_app(test_db_url)
+        with TestClient(app) as client:
+            resp = client.get("/health")
+            assert resp.status_code == 200
+
+    def test_developers_has_ml_kem_public_key_column(self, test_db_url: str) -> None:
+        """developers table must expose ml_kem_public_key as BYTEA NULLABLE."""
+        app = _make_platform_app(test_db_url)
+        with TestClient(app):
+            # App must boot cleanly before we inspect the schema
+            pass
+
+        async def _inspect() -> tuple[str, str]:
+            engine = create_async_engine(test_db_url)
+            try:
+                async with engine.connect() as conn:
+                    row = await conn.execute(
+                        text(
+                            "SELECT data_type, is_nullable "
+                            "FROM information_schema.columns "
+                            "WHERE table_name = 'developers' "
+                            "AND column_name = 'ml_kem_public_key'"
+                        )
+                    )
+                    result = row.first()
+                    assert result is not None, (
+                        "developers.ml_kem_public_key column does not exist"
+                    )
+                    return str(result[0]), str(result[1])
+            finally:
+                await engine.dispose()
+
+        data_type, is_nullable = asyncio.run(_inspect())
+        assert data_type == "bytea", f"expected bytea, got {data_type}"
+        assert is_nullable == "YES", f"expected nullable, got {is_nullable}"
+
+    def test_model_roundtrip_none(self, test_db_url: str) -> None:
+        """Inserting a developer with ml_kem_public_key=None round-trips."""
+        app = _make_platform_app(test_db_url)
+        with TestClient(app):
+            pass
+
+        async def _run() -> None:
+            engine = create_async_engine(test_db_url)
+            session_factory = async_sessionmaker(
+                engine, class_=AsyncSession, expire_on_commit=False
+            )
+            try:
+                async with session_factory() as session:
+                    dev = Developer(
+                        id=uuid.uuid4(),
+                        email=f"none-{uuid.uuid4().hex[:8]}@test.com",
+                        password_hash="x",
+                        ml_kem_public_key=None,
+                    )
+                    session.add(dev)
+                    await session.commit()
+
+                    result = await session.execute(
+                        select(Developer).where(Developer.id == dev.id)
+                    )
+                    loaded = result.scalar_one()
+                    assert loaded.ml_kem_public_key is None
+            finally:
+                await engine.dispose()
+
+        asyncio.run(_run())
+
+    def test_model_roundtrip_bytes(self, test_db_url: str) -> None:
+        """Inserting a developer with ml_kem_public_key=bytes round-trips."""
+        app = _make_platform_app(test_db_url)
+        with TestClient(app):
+            pass
+
+        key_bytes = b"\x00\x01\x02" + b"A" * 1181  # ML-KEM-768 public key = 1184B
+
+        async def _run() -> None:
+            engine = create_async_engine(test_db_url)
+            session_factory = async_sessionmaker(
+                engine, class_=AsyncSession, expire_on_commit=False
+            )
+            try:
+                async with session_factory() as session:
+                    dev = Developer(
+                        id=uuid.uuid4(),
+                        email=f"bytes-{uuid.uuid4().hex[:8]}@test.com",
+                        password_hash="x",
+                        ml_kem_public_key=key_bytes,
+                    )
+                    session.add(dev)
+                    await session.commit()
+
+                    result = await session.execute(
+                        select(Developer).where(Developer.id == dev.id)
+                    )
+                    loaded = result.scalar_one()
+                    assert loaded.ml_kem_public_key == key_bytes
+            finally:
+                await engine.dispose()
+
+        asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Alembic migration reversibility test
+#
+# This uses a separate, throwaway database so we can exercise the real
+# alembic upgrade head / downgrade -1 / upgrade head cycle without disturbing
+# the shared integration test database.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def alembic_db() -> Iterator[str]:
+    """Create a throwaway database, yield its async URL, drop at teardown."""
+    db_name = f"pqdb_alembic_test_{uuid.uuid4().hex[:8]}"
+    env = {
+        "PGHOST": PG_HOST,
+        "PGPORT": str(PG_PORT),
+        "PGUSER": PG_USER,
+        "PGPASSWORD": PG_PASS,
+    }
+    subprocess.run(["createdb", db_name], env=env, check=True, capture_output=True)
+    try:
+        yield (
+            f"postgresql+asyncpg://{PG_USER}:{PG_PASS}@{PG_HOST}:{PG_PORT}/{db_name}"
+        )
+    finally:
+        subprocess.run(
+            ["dropdb", "--if-exists", db_name],
+            env=env,
+            check=False,
+            capture_output=True,
+        )
+
+
+class TestMigrationReversibility:
+    """Acceptance: migration applies cleanly and downgrade removes the column."""
+
+    def _run_alembic(self, db_url: str, *args: str) -> subprocess.CompletedProcess[str]:
+        """Invoke alembic CLI pointing at the throwaway database."""
+        backend_dir = Path(__file__).resolve().parents[2]
+        sync_url = db_url.replace("+asyncpg", "+psycopg2")
+        env = os.environ.copy()
+        env["PQDB_DATABASE_URL"] = sync_url
+        env["PQDB_SUPERUSER_DSN"] = (
+            f"postgresql://{PG_USER}:{PG_PASS}@{PG_HOST}:{PG_PORT}/postgres"
+        )
+        result = subprocess.run(
+            ["alembic", *args],
+            cwd=backend_dir,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return result
+
+    def _column_exists(self, db_url: str) -> bool:
+        async def _check() -> bool:
+            engine = create_async_engine(db_url)
+            try:
+                async with engine.connect() as conn:
+                    row = await conn.execute(
+                        text(
+                            "SELECT 1 FROM information_schema.columns "
+                            "WHERE table_name = 'developers' "
+                            "AND column_name = 'ml_kem_public_key'"
+                        )
+                    )
+                    return row.first() is not None
+            finally:
+                await engine.dispose()
+
+        return asyncio.run(_check())
+
+    def test_upgrade_adds_column_downgrade_removes(self, alembic_db: str) -> None:
+        """alembic upgrade head -> column present; downgrade -1 -> column gone."""
+        up1 = self._run_alembic(alembic_db, "upgrade", "head")
+        assert up1.returncode == 0, f"upgrade head failed: {up1.stderr}"
+        assert self._column_exists(alembic_db), "column missing after upgrade head"
+
+        down = self._run_alembic(alembic_db, "downgrade", "-1")
+        assert down.returncode == 0, f"downgrade -1 failed: {down.stderr}"
+        assert not self._column_exists(alembic_db), (
+            "column still present after downgrade -1"
+        )
+
+        up2 = self._run_alembic(alembic_db, "upgrade", "head")
+        assert up2.returncode == 0, f"second upgrade head failed: {up2.stderr}"
+        assert self._column_exists(alembic_db), (
+            "column missing after second upgrade head"
+        )

--- a/backend/tests/integration/test_roles_policies.py
+++ b/backend/tests/integration/test_roles_policies.py
@@ -310,7 +310,7 @@ class TestUserRoleAssignment:
                     await s.commit()
                 await engine.dispose()
 
-            asyncio.get_event_loop().run_until_complete(_setup())
+            asyncio.run(_setup())
 
             # Now assign a role via the API
             resp = client.put(

--- a/backend/tests/unit/test_developer_model.py
+++ b/backend/tests/unit/test_developer_model.py
@@ -13,8 +13,23 @@ class TestDeveloperModel:
 
     def test_columns_exist(self) -> None:
         columns = {c.name for c in Developer.__table__.columns}
-        expected = {"id", "email", "password_hash", "email_verified", "created_at"}
+        expected = {
+            "id",
+            "email",
+            "password_hash",
+            "email_verified",
+            "ml_kem_public_key",
+            "created_at",
+        }
         assert columns == expected
+
+    def test_ml_kem_public_key_column_is_nullable_bytea(self) -> None:
+        col = Developer.__table__.columns["ml_kem_public_key"]
+        assert col.nullable is True
+        # SQLAlchemy LargeBinary maps to BYTEA on Postgres
+        from sqlalchemy import LargeBinary
+
+        assert isinstance(col.type, LargeBinary)
 
     def test_id_is_primary_key(self) -> None:
         pk_cols = [c.name for c in Developer.__table__.primary_key]


### PR DESCRIPTION
## Summary

Phase 5d US-002: add an ml_kem_public_key BYTEA NULLABLE column to the developers table so the backend can persist each developer's ML-KEM-768 public key. This is the foundational schema change the rest of Phase 5d builds on (US-003 wires it into signup, US-004 generates the keypair client-side, etc.).

- New Alembic migration `011_add_ml_kem_public_key_to_developers.py` (down_revision = 010)
- `Developer` SQLAlchemy model exposes `ml_kem_public_key: Mapped[bytes | None]`
- Migration is reversible (downgrade drops the column)
- Existing rows get NULL — no data migration required

## Acceptance criteria (from prd.json US-002)

- [x] New alembic migration `backend/alembic/versions/011_add_ml_kem_public_key_to_developers.py` adds `ml_kem_public_key BYTEA NULLABLE` to developers
- [x] `Developer` model exposes the column as `ml_kem_public_key: Mapped[bytes | None]`
- [x] Migration applies cleanly against a fresh database (verified manually + in test)
- [x] Migration is reversible — downgrade removes the column without errors (test exercises upgrade -> downgrade -> upgrade cycle)
- [x] Existing developers rows have `ml_kem_public_key=NULL` after migration (column is nullable with no default)
- [x] Integration tests pass — new `test_ml_kem_public_key_column.py` (5 tests)
- [x] Service responds to health check (`/health` returns 200) — covered by `test_health_endpoint_responds`
- [x] Unit tests pass — `test_developer_model.py` updated for the new column
- [x] Typecheck (`mypy --strict`) passes
- [x] Production build / lint (`ruff check`, `ruff format`) passes

## Test plan

- [x] `uv run pytest tests/integration/test_ml_kem_public_key_column.py` — all 5 new tests pass
- [x] `uv run pytest tests/unit/test_developer_model.py` — all pass
- [x] `uv run pytest` — full suite green (1 unrelated flake in test_roles_policies, passes in isolation and on re-run)
- [x] `uv run mypy .` — 0 issues across 198 files
- [x] `uv run ruff check .` — all checks pass
- [x] `uv run ruff format --check .` — clean
- [x] Manual alembic cycle on throwaway DB: `upgrade head` -> `downgrade -1` -> `upgrade head` all succeed
- [x] `gitleaks detect --source .` — no leaks
- [x] `semgrep scan --config=auto` on changed files — 0 findings on 1198 rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)