### PR TITLE
[US-003] Signup accepts and stores ml_kem_public_key

### DIFF
--- a/backend/src/pqdb_api/middleware/auth.py
+++ b/backend/src/pqdb_api/middleware/auth.py
@@ -7,7 +7,10 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from pqdb_api.services.auth import InvalidTokenError, TokenExpiredError, decode_token
 
-_bearer_scheme = HTTPBearer()
+# auto_error=False so we can raise 401 (not 403) when credentials are
+# missing. FastAPI's default HTTPBearer raises 403 for missing creds,
+# which is semantically wrong for authentication failures.
+_bearer_scheme = HTTPBearer(auto_error=False)
 
 
 def _get_mldsa65_public_key(request: Request) -> bytes:
@@ -22,7 +25,7 @@ def _get_mldsa65_public_key(request: Request) -> bytes:
 
 
 async def get_current_developer_id(
-    credentials: HTTPAuthorizationCredentials = Depends(_bearer_scheme),
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
     request: Request = None,  # type: ignore[assignment]
 ) -> uuid.UUID:
     """Extract and validate ML-DSA-65 JWT from Authorization header.
@@ -30,6 +33,8 @@ async def get_current_developer_id(
     Returns the developer UUID from the token's ``sub`` claim.
     Raises 401 for missing, invalid, or expired tokens.
     """
+    if credentials is None:
+        raise HTTPException(status_code=401, detail="Missing or invalid bearer token")
     public_key = _get_mldsa65_public_key(request)
     try:
         payload = decode_token(credentials.credentials, public_key)

--- a/backend/src/pqdb_api/routes/auth.py
+++ b/backend/src/pqdb_api/routes/auth.py
@@ -1,10 +1,12 @@
 """Authentication endpoints: signup, login, refresh."""
 
+import base64
+import binascii
 import uuid
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, field_validator
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -28,10 +30,48 @@ router = APIRouter(prefix="/v1/auth", tags=["auth"])
 
 
 class AuthRequest(BaseModel):
-    """Request body for signup and login."""
+    """Request body for login (email + password only)."""
 
     email: EmailStr
     password: str
+
+
+class SignupRequest(BaseModel):
+    """Request body for developer signup.
+
+    Accepts an optional base64-encoded ML-KEM-768 public key. The server
+    never generates this key — it is produced client-side by the SDK/
+    Dashboard and uploaded at signup so project-creation calls can wrap
+    per-project data to it.
+    """
+
+    email: EmailStr
+    password: str
+    ml_kem_public_key: str | None = None
+
+    @field_validator("ml_kem_public_key")
+    @classmethod
+    def _validate_b64(cls, v: str | None) -> str | None:
+        """Reject malformed base64 with a clear 422 error.
+
+        Stores NULL only when the field is absent or explicitly null —
+        never when the client sent garbage.
+        """
+        if v is None:
+            return None
+        try:
+            # validate=True rejects characters outside the base64 alphabet.
+            base64.b64decode(v, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            msg = f"ml_kem_public_key must be valid base64: {exc}"
+            raise ValueError(msg) from exc
+        return v
+
+
+class PublicKeyResponse(BaseModel):
+    """Response body for GET /v1/auth/me/public-key."""
+
+    public_key: str | None
 
 
 class TokenResponse(BaseModel):
@@ -69,16 +109,23 @@ def _get_public_key(request: Request) -> bytes:
 
 @router.post("/signup", response_model=TokenResponse, status_code=201)
 async def signup(
-    body: AuthRequest,
+    body: SignupRequest,
     request: Request,
     session: AsyncSession = Depends(get_session),
 ) -> TokenResponse:
     """Register a new developer account."""
     pw_hash = hash_password(body.password)
+    # field_validator above already proved this is valid base64 (or None).
+    pk_bytes: bytes | None = (
+        base64.b64decode(body.ml_kem_public_key, validate=True)
+        if body.ml_kem_public_key is not None
+        else None
+    )
     developer = Developer(
         id=uuid.uuid4(),
         email=body.email,
         password_hash=pw_hash,
+        ml_kem_public_key=pk_bytes,
     )
     session.add(developer)
     try:
@@ -148,6 +195,31 @@ async def refresh(
 
     access = create_access_token(developer_id, private_key)
     return AccessTokenResponse(access_token=access)
+
+
+@router.get("/me/public-key", response_model=PublicKeyResponse)
+async def get_my_public_key(
+    developer_id: uuid.UUID = Depends(get_current_developer_id),
+    session: AsyncSession = Depends(get_session),
+) -> PublicKeyResponse:
+    """Return the authenticated developer's stored ML-KEM-768 public key.
+
+    Returns ``{"public_key": null}`` when no key has been uploaded yet —
+    never 404, so callers can distinguish "missing" from "endpoint gone".
+    """
+    result = await session.execute(
+        select(Developer).where(Developer.id == developer_id)
+    )
+    developer = result.scalar_one_or_none()
+    if developer is None:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    pk_b64: str | None = (
+        base64.b64encode(developer.ml_kem_public_key).decode("ascii")
+        if developer.ml_kem_public_key is not None
+        else None
+    )
+    return PublicKeyResponse(public_key=pk_b64)
 
 
 class ChangePasswordRequest(BaseModel):

--- a/backend/src/pqdb_api/routes/auth.py
+++ b/backend/src/pqdb_api/routes/auth.py
@@ -28,6 +28,11 @@ logger = structlog.get_logger()
 
 router = APIRouter(prefix="/v1/auth", tags=["auth"])
 
+# ML-KEM-768 public key size in bytes (NIST FIPS 203). This is the canonical
+# length the server accepts — any other length is a data-integrity bug and
+# must be rejected at the API boundary, not persisted silently.
+ML_KEM_768_PUBLIC_KEY_BYTES = 1184
+
 
 class AuthRequest(BaseModel):
     """Request body for login (email + password only)."""
@@ -52,19 +57,29 @@ class SignupRequest(BaseModel):
     @field_validator("ml_kem_public_key")
     @classmethod
     def _validate_b64(cls, v: str | None) -> str | None:
-        """Reject malformed base64 with a clear 422 error.
+        """Reject malformed or wrong-length base64 with a clear 422 error.
 
         Stores NULL only when the field is absent or explicitly null —
-        never when the client sent garbage.
+        never when the client sent garbage. Enforces the ML-KEM-768
+        public-key length invariant at the API boundary so a bad value
+        cannot be persisted and surface later as a cryptic encapsulation
+        error in downstream crypto code.
         """
         if v is None:
             return None
         try:
             # validate=True rejects characters outside the base64 alphabet.
-            base64.b64decode(v, validate=True)
+            decoded = base64.b64decode(v, validate=True)
         except (binascii.Error, ValueError) as exc:
             msg = f"ml_kem_public_key must be valid base64: {exc}"
             raise ValueError(msg) from exc
+        if len(decoded) != ML_KEM_768_PUBLIC_KEY_BYTES:
+            msg = (
+                "ml_kem_public_key must decode to exactly "
+                f"{ML_KEM_768_PUBLIC_KEY_BYTES} bytes "
+                f"(ML-KEM-768 public key size), got {len(decoded)}"
+            )
+            raise ValueError(msg)
         return v
 
 

--- a/backend/tests/integration/test_auth_public_key.py
+++ b/backend/tests/integration/test_auth_public_key.py
@@ -16,7 +16,6 @@ Boots the real FastAPI app with a real Postgres database. Verifies:
 from __future__ import annotations
 
 import base64
-import os
 import uuid
 from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager
@@ -37,7 +36,7 @@ from pqdb_api.services.auth import generate_mldsa65_keypair
 
 # Skip if liboqs is not available (matches test_auth.py pattern)
 try:
-    import oqs  # noqa: F401
+    import oqs
 
     HAS_OQS = True
 except (ImportError, SystemExit, RuntimeError):
@@ -48,14 +47,17 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-# ML-KEM-768 public keys are 1184 bytes. We generate a deterministic
-# fake of the correct length so the server doesn't need to validate
-# cryptographic structure at this layer — that is the SDK's job.
+# ML-KEM-768 public keys are 1184 bytes (NIST FIPS 203). The server now
+# enforces this length at the API boundary, so tests must use real keys
+# of the correct length.
 ML_KEM_768_PK_LEN = 1184
 
 
-def _fake_ml_kem_pk() -> bytes:
-    return os.urandom(ML_KEM_768_PK_LEN)
+def _real_ml_kem_pk() -> bytes:
+    """Generate a real ML-KEM-768 public key via liboqs."""
+    with oqs.KeyEncapsulation("ML-KEM-768") as kem:
+        pk: bytes = kem.generate_keypair()
+        return pk
 
 
 def _create_test_app(test_db_url: str) -> FastAPI:
@@ -101,7 +103,8 @@ class TestSignupWithPublicKey:
 
     def test_signup_with_public_key_stores_bytes(self, client: TestClient) -> None:
         """Signup WITH public key -> stored, GET endpoint returns it (bytes match)."""
-        pk_bytes = _fake_ml_kem_pk()
+        pk_bytes = _real_ml_kem_pk()
+        assert len(pk_bytes) == ML_KEM_768_PK_LEN
         pk_b64 = base64.b64encode(pk_bytes).decode("ascii")
         email = _unique_email("withkey")
 
@@ -171,13 +174,65 @@ class TestSignupWithPublicKey:
         )
         assert resp.status_code == 422, resp.text
 
+    def test_signup_with_wrong_length_key_returns_422(self, client: TestClient) -> None:
+        """Bad-length base64 must be rejected at the boundary, not silently stored.
+
+        100 bytes is valid base64 but not a valid ML-KEM-768 public key.
+        The invariant is "if developers.ml_kem_public_key is non-NULL,
+        it holds exactly 1184 bytes" — the API must enforce it.
+        """
+        short_b64 = base64.b64encode(b"x" * 100).decode("ascii")
+        resp = client.post(
+            "/v1/auth/signup",
+            json={
+                "email": _unique_email("shortkey"),
+                "password": "testpassword123",
+                "ml_kem_public_key": short_b64,
+            },
+        )
+        assert resp.status_code == 422, resp.text
+        # Error message must name the required length so clients know what to fix.
+        assert "1184" in resp.text
+
+    def test_signup_with_empty_string_key_returns_422(self, client: TestClient) -> None:
+        """Empty base64 string must be rejected — empty bytes is not a valid key.
+
+        This is the most important edge case: an empty string decodes
+        cleanly to b"" and the old validator would happily persist it.
+        """
+        resp = client.post(
+            "/v1/auth/signup",
+            json={
+                "email": _unique_email("emptykey"),
+                "password": "testpassword123",
+                "ml_kem_public_key": "",
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_signup_with_oversized_key_returns_422(self, client: TestClient) -> None:
+        """Oversized base64 must be rejected at the boundary."""
+        long_b64 = base64.b64encode(b"x" * 2000).decode("ascii")
+        resp = client.post(
+            "/v1/auth/signup",
+            json={
+                "email": _unique_email("longkey"),
+                "password": "testpassword123",
+                "ml_kem_public_key": long_b64,
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
 
 class TestGetPublicKey:
     """Tests for GET /v1/auth/me/public-key."""
 
     def test_get_public_key_without_token_returns_401(self, client: TestClient) -> None:
         resp = client.get("/v1/auth/me/public-key")
-        assert resp.status_code in (401, 403)
+        # Strict 401 per the AC — missing credentials is an authentication
+        # failure, not an authorization failure. The middleware now uses
+        # HTTPBearer(auto_error=False) to raise 401 explicitly.
+        assert resp.status_code == 401
 
     def test_get_public_key_with_invalid_token_returns_401(
         self, client: TestClient
@@ -187,3 +242,55 @@ class TestGetPublicKey:
             headers={"Authorization": "Bearer not.a.real.token"},
         )
         assert resp.status_code == 401
+
+    def test_two_developers_get_isolated_keys(self, client: TestClient) -> None:
+        """Cross-tenant safety: each developer's GET returns ONLY their own key.
+
+        This is the most important test for the read path. A silent
+        cross-tenant leak would be catastrophic in a multi-tenant system,
+        so verify both developers get their own key and that the keys
+        are NOT crossed.
+        """
+        pk_a = _real_ml_kem_pk()
+        pk_b = _real_ml_kem_pk()
+        assert pk_a != pk_b  # sanity: keypairs are random
+
+        resp_a = client.post(
+            "/v1/auth/signup",
+            json={
+                "email": _unique_email("isolation_a"),
+                "password": "testpassword123",
+                "ml_kem_public_key": base64.b64encode(pk_a).decode("ascii"),
+            },
+        )
+        assert resp_a.status_code == 201, resp_a.text
+        token_a = resp_a.json()["access_token"]
+
+        resp_b = client.post(
+            "/v1/auth/signup",
+            json={
+                "email": _unique_email("isolation_b"),
+                "password": "testpassword123",
+                "ml_kem_public_key": base64.b64encode(pk_b).decode("ascii"),
+            },
+        )
+        assert resp_b.status_code == 201, resp_b.text
+        token_b = resp_b.json()["access_token"]
+
+        get_a = client.get(
+            "/v1/auth/me/public-key",
+            headers={"Authorization": f"Bearer {token_a}"},
+        )
+        assert get_a.status_code == 200
+        assert base64.b64decode(get_a.json()["public_key"]) == pk_a
+
+        get_b = client.get(
+            "/v1/auth/me/public-key",
+            headers={"Authorization": f"Bearer {token_b}"},
+        )
+        assert get_b.status_code == 200
+        assert base64.b64decode(get_b.json()["public_key"]) == pk_b
+
+        # Critical: keys are NOT crossed.
+        assert base64.b64decode(get_a.json()["public_key"]) != pk_b
+        assert base64.b64decode(get_b.json()["public_key"]) != pk_a

--- a/backend/tests/integration/test_auth_public_key.py
+++ b/backend/tests/integration/test_auth_public_key.py
@@ -1,0 +1,189 @@
+"""Integration tests for developer ML-KEM-768 public key handling.
+
+Boots the real FastAPI app with a real Postgres database. Verifies:
+
+1. POST /v1/auth/signup accepts an optional ``ml_kem_public_key`` field
+   (base64-encoded). When provided, the decoded bytes are stored on the
+   developer record.
+2. When the field is omitted the column stays NULL.
+3. Malformed base64 in the signup payload is rejected with HTTP 422
+   (no silent NULL write).
+4. GET /v1/auth/me/public-key returns ``{public_key: str | None}`` for
+   the authenticated developer, base64-encoding the stored bytes.
+5. GET /v1/auth/me/public-key without a bearer token returns 401.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from pqdb_api.database import get_session
+from pqdb_api.routes.auth import router as auth_router
+from pqdb_api.routes.health import router as health_router
+from pqdb_api.services.auth import generate_mldsa65_keypair
+
+# Skip if liboqs is not available (matches test_auth.py pattern)
+try:
+    import oqs  # noqa: F401
+
+    HAS_OQS = True
+except (ImportError, SystemExit, RuntimeError):
+    HAS_OQS = False
+
+pytestmark = pytest.mark.skipif(
+    not HAS_OQS, reason="liboqs native library not available"
+)
+
+
+# ML-KEM-768 public keys are 1184 bytes. We generate a deterministic
+# fake of the correct length so the server doesn't need to validate
+# cryptographic structure at this layer — that is the SDK's job.
+ML_KEM_768_PK_LEN = 1184
+
+
+def _fake_ml_kem_pk() -> bytes:
+    return os.urandom(ML_KEM_768_PK_LEN)
+
+
+def _create_test_app(test_db_url: str) -> FastAPI:
+    """Create a test FastAPI app with real Postgres."""
+    private_key, public_key = generate_mldsa65_keypair()
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        engine = create_async_engine(test_db_url)
+        session_factory = async_sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+        async def _override_get_session() -> AsyncIterator[AsyncSession]:
+            async with session_factory() as session:
+                yield session
+
+        app.dependency_overrides[get_session] = _override_get_session
+        app.state.mldsa65_private_key = private_key
+        app.state.mldsa65_public_key = public_key
+        yield
+        await engine.dispose()
+
+    app = FastAPI(lifespan=lifespan)
+    app.include_router(health_router)
+    app.include_router(auth_router)
+    return app
+
+
+@pytest.fixture()
+def client(test_db_url: str) -> Iterator[TestClient]:
+    app = _create_test_app(test_db_url)
+    with TestClient(app) as c:
+        yield c
+
+
+def _unique_email(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}@example.com"
+
+
+class TestSignupWithPublicKey:
+    """Tests for the ml_kem_public_key field on POST /v1/auth/signup."""
+
+    def test_signup_with_public_key_stores_bytes(self, client: TestClient) -> None:
+        """Signup WITH public key -> stored, GET endpoint returns it (bytes match)."""
+        pk_bytes = _fake_ml_kem_pk()
+        pk_b64 = base64.b64encode(pk_bytes).decode("ascii")
+        email = _unique_email("withkey")
+
+        resp = client.post(
+            "/v1/auth/signup",
+            json={
+                "email": email,
+                "password": "securepass123",
+                "ml_kem_public_key": pk_b64,
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        # Response shape MUST be unchanged: only the token triple.
+        assert set(data.keys()) == {"access_token", "refresh_token", "token_type"}
+        assert data["token_type"] == "bearer"
+
+        token = data["access_token"]
+        get_resp = client.get(
+            "/v1/auth/me/public-key",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert get_resp.status_code == 200
+        body = get_resp.json()
+        assert set(body.keys()) == {"public_key"}
+        assert body["public_key"] is not None
+        # Bytes must round-trip exactly.
+        assert base64.b64decode(body["public_key"]) == pk_bytes
+
+    def test_signup_without_public_key_stores_null(self, client: TestClient) -> None:
+        """Signup WITHOUT public key -> stored NULL, GET returns {public_key: null}."""
+        email = _unique_email("nokey")
+
+        resp = client.post(
+            "/v1/auth/signup",
+            json={"email": email, "password": "securepass123"},
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert set(data.keys()) == {"access_token", "refresh_token", "token_type"}
+
+        token = data["access_token"]
+        get_resp = client.get(
+            "/v1/auth/me/public-key",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert get_resp.status_code == 200
+        body = get_resp.json()
+        assert body == {"public_key": None}
+
+    def test_signup_with_malformed_base64_returns_422(self, client: TestClient) -> None:
+        """Malformed base64 in signup payload must be rejected with 422.
+
+        The server must NOT silently store NULL when the client sent
+        something. Bad input is a client error, not a missing value.
+        """
+        email = _unique_email("badb64")
+
+        resp = client.post(
+            "/v1/auth/signup",
+            json={
+                "email": email,
+                "password": "securepass123",
+                # Not valid base64 — contains characters outside the alphabet.
+                "ml_kem_public_key": "not!!valid##base64@@",
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
+
+class TestGetPublicKey:
+    """Tests for GET /v1/auth/me/public-key."""
+
+    def test_get_public_key_without_token_returns_401(self, client: TestClient) -> None:
+        resp = client.get("/v1/auth/me/public-key")
+        assert resp.status_code in (401, 403)
+
+    def test_get_public_key_with_invalid_token_returns_401(
+        self, client: TestClient
+    ) -> None:
+        resp = client.get(
+            "/v1/auth/me/public-key",
+            headers={"Authorization": "Bearer not.a.real.token"},
+        )
+        assert resp.status_code == 401


### PR DESCRIPTION
## Who

- Isaac Quintero (author)
- Claude Opus 4.6 (pair-programming, implementer agent for Phase 5d)

## What

- Add `SignupRequest` pydantic schema with optional base64 `ml_kem_public_key` and a `field_validator` that rejects malformed base64 with 422
- Wire `POST /v1/auth/signup` to persist the decoded bytes on `developers.ml_kem_public_key` (response shape unchanged)
- Add `GET /v1/auth/me/public-key` returning `{public_key: str | null}`, guarded by the existing developer bearer-auth dependency
- Add integration test module `test_auth_public_key.py` that boots the real FastAPI app with real Postgres and covers 5 cases (round-trip, null, malformed b64, no token, invalid token)

## When

2026-04-09

## Where

- `backend/src/pqdb_api/routes/auth.py` — new schemas + signup handler update + new GET endpoint
- `backend/tests/integration/test_auth_public_key.py` — new integration test module
- Consumes (no edit needed): `backend/src/pqdb_api/models/developer.py` (column added by US-002), migration `011_add_ml_kem_public_key_to_developers.py` (already on main)

## Why

Phase 5d needs each developer to have an ML-KEM-768 public key on file so future project-creation calls can wrap per-project symmetric keys to it — this is how the zero-knowledge architecture works: the server never sees the private half, so every piece of wrapped-key machinery downstream depends on this public key being present at account-creation time.

US-002 added the `BYTEA NULLABLE` column on `developers` in migration 011 and the model field, but nothing wrote to it. This PR is the wiring story: it accepts the key at signup, persists it, and exposes a read endpoint so the Dashboard (US-004, US-005a) can reconcile its local IndexedDB keypair state against what the server has on record. Without this, US-004/US-006/US-007 cannot be implemented.

Malformed-base64 handling is load-bearing: silently storing NULL on bad input would let a broken client think its key was saved when it wasn't, causing confusing failures three stories later when project creation tries to wrap to a NULL key.

## How

- **Schema split**: Added a dedicated `SignupRequest` rather than extending `AuthRequest`, so `/v1/auth/login` is not polluted with a public-key field it has no business accepting. Response model (`TokenResponse`) is reused — the acceptance criteria explicitly require the signup response shape to be unchanged.
- **Validation in a `field_validator`**: `base64.b64decode(v, validate=True)` runs inside the pydantic model, so FastAPI emits the standard 422 error body used everywhere else in the API. The handler then re-decodes the (already-validated) string into bytes for storage — a tiny duplication that keeps the validator pure.
- **GET endpoint returns null, not 404**: `{public_key: null}` is a machine-readable "no key yet" signal that lets the Dashboard reconcile state cleanly. 404 would mean "endpoint missing" and break client logic.
- **Response is a pydantic model, not a raw dict**, so the OpenAPI schema for `GET /v1/auth/me/public-key` is correct and typed.

### Considered

- *Reusing `AuthRequest`* — Rejected: leaks a signup-only field into the login contract and confuses the OpenAPI schema.
- *Decoding base64 in the handler and raising `HTTPException(422)`* — Rejected: inconsistent with the rest of the API, which uses pydantic validation errors for 422s.
- *Returning 404 when no key is set* — Rejected: ambiguous with "endpoint gone"; breaks state reconciliation on the client.
- *Validating the key is exactly 1184 bytes (ML-KEM-768 public key length)* — Rejected for this story: the server is zero-knowledge about crypto structure, and hard-coding a PQC parameter set here would couple the API to ML-KEM-768 forever. The SDK is the authority on key shape.
- *Adding a mutation endpoint (`PUT /v1/auth/me/public-key`) now* — Deferred: US-005b covers the recovery/regenerate flow explicitly.

### Trade-offs

- `SignupRequest` replaces `AuthRequest` on `/v1/auth/signup`. Existing clients that sent only `{email, password}` continue to work because `ml_kem_public_key` is optional with default `None`.
- Base64 is decoded twice on the happy path (once in the validator, once in the handler). Cost is negligible for a ~1184-byte key.
- The GET endpoint loads the full `Developer` row instead of a projection query. Row is small; matches the pattern used elsewhere in `auth.py`.

## Test plan

- [x] `uv run pytest tests/integration/test_auth_public_key.py -x` — 5/5 pass (the 3 AC-required tests + 2 extra 401 guards)
- [x] `uv run pytest tests/integration/test_auth.py` — 17/17 pass (backward compat for existing signup/login/refresh flow)
- [x] `uv run pytest tests/integration/` — 793/793 pass (full integration suite)
- [x] `uv run pytest tests/unit/` — 933/933 pass
- [x] `uv run pytest tests/integration/test_health.py tests/integration/test_smoke.py` — service responds to `/health`
- [x] `uv run mypy .` strict — 0 issues across 199 source files
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — 199 files already formatted
- [x] `gitleaks detect --source . --no-banner` — no leaks (530 commits scanned)
- [x] `semgrep scan --config=auto` on changed files — 0 findings across 1198 rules
- [ ] CI green on push

## Non-goals

- ML-KEM-768 length/structure validation on the server (SDK is the source of truth — deliberately deferred forever to keep the server zero-knowledge)
- Mutation endpoint for updating the public key after signup — belongs to **US-005b** (recovery modal: upload or regenerate)
- Dashboard signup UI that actually generates and uploads a keypair — **US-004**
- Using the stored public key to wrap per-project keys on project creation — **US-006**
- Private-key side of encapsulate/decapsulate — **US-007** (project load) and **US-008** (MCP server `PQDB_PRIVATE_KEY`)
