### PR TITLE
[US-004] Dashboard signup generates and persists ML-KEM keypair

### DIFF
--- a/dashboard/e2e/helpers.ts
+++ b/dashboard/e2e/helpers.ts
@@ -24,7 +24,14 @@ export async function signUp(page: Page, email: string, password: string): Promi
   await expect(emailInput).toHaveValue(email);
   await expect(passwordInput).toHaveValue(password);
   await page.getByRole("button", { name: "Create account" }).click();
-  // Wait for redirect to /projects
+  // Signup now pops a recovery-file modal that blocks navigation until
+  // the user either downloads the file or acknowledges the warning. For
+  // E2E tests that don't care about the recovery flow we acknowledge
+  // and close, then continue to /projects as before.
+  const modal = page.getByRole("dialog", { name: /save your recovery file/i });
+  await modal.waitFor({ state: "visible", timeout: 15_000 });
+  await page.getByRole("checkbox", { name: /i understand/i }).check();
+  await page.getByRole("button", { name: /^close$/i }).click();
   await expect(page).toHaveURL(/\/projects/, { timeout: 15_000 });
 }
 

--- a/dashboard/e2e/signup-keypair.spec.ts
+++ b/dashboard/e2e/signup-keypair.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * E2E: signup happy path generates an ML-KEM-768 keypair, offers a
+ * downloadable recovery file with both keys, and lands on /projects.
+ *
+ * What this verifies end-to-end:
+ *  - /signup page generates a keypair client-side
+ *  - The post-signup recovery modal appears and is blocking
+ *  - Clicking "Download recovery file" produces a JSON blob whose
+ *    `public_key` and `private_key` fields round-trip from base64
+ *  - The backend persisted the uploaded public key (GET /v1/auth/me/public-key)
+ *    so we know the public key in the file matches what the server stored
+ *  - Navigation completes to /projects after the modal is closed
+ */
+import { test, expect } from "@playwright/test";
+import { testEmail } from "./helpers";
+
+interface RecoveryFile {
+  version: number;
+  developer_id: string;
+  email: string;
+  public_key: string;
+  private_key: string;
+  created_at: string;
+  warning: string;
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+
+test("signup downloads a parseable recovery file with both ML-KEM keys", async ({
+  page,
+}) => {
+  const email = testEmail();
+  const password = "password123";
+
+  await page.goto("/signup", { waitUntil: "networkidle" });
+
+  // Fill the form
+  const emailInput = page.locator("#email");
+  await emailInput.waitFor({ state: "visible", timeout: 10_000 });
+  await emailInput.fill(email);
+  await page.locator("#password").fill(password);
+  await expect(emailInput).toHaveValue(email);
+
+  // Capture the signup POST so we can assert the public key was sent
+  const signupReq = page.waitForRequest(
+    (req) => req.url().endsWith("/v1/auth/signup") && req.method() === "POST",
+  );
+  const signupResp = page.waitForResponse(
+    (resp) =>
+      resp.url().endsWith("/v1/auth/signup") && resp.status() === 201,
+  );
+
+  await page.getByRole("button", { name: "Create account" }).click();
+
+  const req = await signupReq;
+  const postBody = req.postDataJSON() as {
+    email: string;
+    password: string;
+    ml_kem_public_key?: string;
+  };
+  expect(postBody.email).toBe(email);
+  expect(typeof postBody.ml_kem_public_key).toBe("string");
+  expect(base64ToBytes(postBody.ml_kem_public_key!).length).toBe(1184);
+
+  await signupResp;
+
+  // Recovery modal must be visible and blocking navigation
+  const modal = page.getByRole("dialog", { name: /save your recovery file/i });
+  await expect(modal).toBeVisible({ timeout: 15_000 });
+  await expect(page).not.toHaveURL(/\/projects/);
+
+  // Trigger the download and parse the JSON
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("button", { name: /download recovery file/i }).click();
+  const download = await downloadPromise;
+
+  expect(download.suggestedFilename()).toBe(`pqdb-recovery-${email}.json`);
+
+  const stream = await download.createReadStream();
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) chunks.push(chunk as Buffer);
+  const raw = Buffer.concat(chunks).toString("utf-8");
+  const parsed = JSON.parse(raw) as RecoveryFile;
+
+  expect(parsed.version).toBe(1);
+  expect(parsed.email).toBe(email);
+  expect(typeof parsed.developer_id).toBe("string");
+  expect(parsed.warning).toMatch(/decrypt/i);
+
+  const pub = base64ToBytes(parsed.public_key);
+  const priv = base64ToBytes(parsed.private_key);
+  expect(pub.length).toBe(1184);
+  // ML-KEM-768 secret key length per FIPS 203 is 2400 bytes.
+  expect(priv.length).toBe(2400);
+
+  // The public key in the recovery file MUST match what the backend
+  // stored — otherwise a future device-restore would fail.
+  const tokens = await page.evaluate(() =>
+    sessionStorage.getItem("pqdb-tokens"),
+  );
+  expect(tokens).not.toBeNull();
+  const { access_token } = JSON.parse(tokens!) as {
+    access_token: string;
+    refresh_token: string;
+  };
+  const meResp = await page.request.get("/v1/auth/me/public-key", {
+    headers: { Authorization: `Bearer ${access_token}` },
+  });
+  expect(meResp.ok()).toBe(true);
+  const meBody = (await meResp.json()) as { public_key: string | null };
+  expect(meBody.public_key).toBe(parsed.public_key);
+
+  // Close the modal — download alone is enough to unlock the close button
+  await page.getByRole("button", { name: /^close$/i }).click();
+  await expect(page).toHaveURL(/\/projects/, { timeout: 15_000 });
+});

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -37,6 +37,7 @@
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "6.0.1",
+        "fake-indexeddb": "^6.2.5",
         "jsdom": "29.0.0",
         "tailwindcss": "4.2.2",
         "typescript": "5.9.3",
@@ -4814,6 +4815,16 @@
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "license": "MIT"
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -42,6 +42,7 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.1",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "29.0.0",
     "tailwindcss": "4.2.2",
     "typescript": "5.9.3",

--- a/dashboard/src/components/recovery-file-modal.tsx
+++ b/dashboard/src/components/recovery-file-modal.tsx
@@ -1,0 +1,133 @@
+import * as React from "react";
+import { Button } from "~/components/ui/button";
+import { Label } from "~/components/ui/label";
+
+export interface RecoveryKeyPair {
+  publicKey: Uint8Array;
+  secretKey: Uint8Array;
+}
+
+interface RecoveryFileModalProps {
+  developerId: string;
+  email: string;
+  keypair: RecoveryKeyPair;
+  onClose: () => void;
+}
+
+const RECOVERY_WARNING =
+  "This is your ML-KEM-768 keypair. If you lose it, your encrypted project " +
+  "data CANNOT be decrypted — there is no recovery on the server. Keep this " +
+  "file somewhere safe and never share it.";
+
+function toBase64(bytes: Uint8Array): string {
+  // JSDOM + modern browsers both support btoa + fromCharCode for small
+  // payloads. ML-KEM-768 secret keys are ~2.4 KB which is well within
+  // argument-length limits of fromCharCode.apply.
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Post-signup modal that shows the developer their recovery file and
+ * forces them to either download it OR explicitly acknowledge the risk
+ * of losing their private key before dismissing.
+ *
+ * The private key has ALREADY been persisted to IndexedDB by the caller —
+ * this modal is purely about giving the user an offline backup path.
+ */
+export function RecoveryFileModal({
+  developerId,
+  email,
+  keypair,
+  onClose,
+}: RecoveryFileModalProps) {
+  const [downloaded, setDownloaded] = React.useState(false);
+  const [acknowledged, setAcknowledged] = React.useState(false);
+
+  const canClose = downloaded || acknowledged;
+
+  function handleDownload() {
+    const payload = {
+      version: 1,
+      developer_id: developerId,
+      email,
+      public_key: toBase64(keypair.publicKey),
+      private_key: toBase64(keypair.secretKey),
+      created_at: new Date().toISOString(),
+      warning: RECOVERY_WARNING,
+    };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `pqdb-recovery-${email}.json`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+    setDownloaded(true);
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="recovery-modal-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+    >
+      <div className="w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg">
+        <h2
+          id="recovery-modal-title"
+          className="text-xl font-semibold"
+        >
+          Save your recovery file
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          We generated an ML-KEM-768 keypair for your account. The private
+          key lives only in this browser. Download the recovery file and
+          keep it somewhere safe — without it, you will not be able to
+          decrypt your project data from another device.
+        </p>
+
+        <div className="mt-6 flex flex-col gap-3">
+          <Button type="button" onClick={handleDownload} className="w-full">
+            Download recovery file
+          </Button>
+
+          <div className="flex items-start gap-2 pt-2">
+            <input
+              id="recovery-ack"
+              type="checkbox"
+              checked={acknowledged}
+              onChange={(e) => setAcknowledged(e.target.checked)}
+              className="mt-1"
+            />
+            <Label
+              htmlFor="recovery-ack"
+              className="text-sm font-normal leading-tight"
+            >
+              I understand — I will not be able to decrypt my data if I
+              lose this key.
+            </Label>
+          </div>
+        </div>
+
+        <div className="mt-6 flex justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            disabled={!canClose}
+          >
+            Close
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/signup-page.tsx
+++ b/dashboard/src/components/signup-page.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { generateKeyPair, type KeyPair } from "@pqdb/client";
 import { api } from "~/lib/api-client";
 import { setTokens } from "~/lib/auth-store";
 import { useNavigate } from "~/lib/navigation";
@@ -6,6 +7,8 @@ import { isValidEmail } from "~/lib/validation";
 import { handleMcpRedirect } from "~/lib/mcp-callback";
 import { deriveWrappingKey } from "~/lib/envelope-crypto";
 import { useEnvelopeKeys } from "~/lib/envelope-key-context";
+import { saveKeypair } from "~/lib/keypair-store";
+import { RecoveryFileModal } from "~/components/recovery-file-modal";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
@@ -18,6 +21,44 @@ import {
   CardTitle,
 } from "~/components/ui/card";
 
+interface PostSignupState {
+  developerId: string;
+  email: string;
+  keypair: KeyPair;
+  accessToken: string;
+}
+
+/** Base64-encode raw bytes in a JSDOM/browser-safe way. */
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Decode the `sub` claim (developer id) from a JWT access token without
+ * verifying the signature. Safe here because we only need the id to key
+ * the IndexedDB record — the token itself has already been issued by the
+ * server and will be re-verified on every subsequent request.
+ */
+function developerIdFromAccessToken(token: string): string {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new Error("Malformed access token");
+  }
+  // Base64url → base64
+  const payload = parts[1]!.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = payload + "=".repeat((4 - (payload.length % 4)) % 4);
+  const decoded = atob(padded);
+  const claims = JSON.parse(decoded) as { sub?: string };
+  if (!claims.sub) {
+    throw new Error("Access token missing sub claim");
+  }
+  return claims.sub;
+}
+
 export function SignupPage() {
   const navigate = useNavigate();
   const { setWrappingKey } = useEnvelopeKeys();
@@ -25,6 +66,9 @@ export function SignupPage() {
   const [password, setPassword] = React.useState("");
   const [error, setError] = React.useState<string | null>(null);
   const [loading, setLoading] = React.useState(false);
+  const [postSignup, setPostSignup] = React.useState<PostSignupState | null>(
+    null,
+  );
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -49,34 +93,69 @@ export function SignupPage() {
 
     setLoading(true);
     try {
-      // Run PBKDF2 derivation in parallel with signup API call to hide latency
+      // Generate the ML-KEM-768 keypair BEFORE the signup call so the
+      // server can persist the public key atomically with the account.
+      // Running keypair generation + PBKDF2 derivation in parallel with
+      // the network request would be nice, but we need the public key
+      // before the POST body exists, so sequence it first and then race
+      // the PBKDF2 against the network RTT.
+      const keypair = await generateKeyPair();
+      const publicKeyB64 = bytesToBase64(keypair.publicKey);
+
       const [result, wrappingKeyResult] = await Promise.all([
-        api.signup(email, password),
-        deriveWrappingKey(password, email).catch((err) => { console.warn("[pqdb] Failed to derive wrapping key:", err); return null; }),
+        api.signup(email, password, publicKeyB64),
+        deriveWrappingKey(password, email).catch((err) => {
+          console.warn("[pqdb] Failed to derive wrapping key:", err);
+          return null;
+        }),
       ]);
 
       if (result.error) {
         setError(result.error.message);
-      } else {
-        setTokens(
-          {
-            access_token: result.data.access_token,
-            refresh_token: result.data.refresh_token,
-          },
-          { persist: true },
-        );
-
-        // Store wrapping key before navigating (password is lost after navigation)
-        if (wrappingKeyResult) {
-          setWrappingKey(wrappingKeyResult);
-        }
-
-        if (!(await handleMcpRedirect(result.data.access_token))) {
-          navigate({ to: "/projects" });
-        }
+        return;
       }
+
+      setTokens(
+        {
+          access_token: result.data.access_token,
+          refresh_token: result.data.refresh_token,
+        },
+        { persist: true },
+      );
+
+      if (wrappingKeyResult) {
+        setWrappingKey(wrappingKeyResult);
+      }
+
+      // Persist the private key to IndexedDB keyed by developer id so it
+      // survives reloads. The id must come from the newly issued access
+      // token — the server is the only authority on the developer's UUID.
+      const developerId = developerIdFromAccessToken(result.data.access_token);
+      await saveKeypair(developerId, {
+        publicKey: keypair.publicKey,
+        secretKey: keypair.secretKey,
+      });
+
+      // Show the recovery modal instead of navigating immediately. The
+      // user has exactly one chance to save an offline backup of the
+      // private key; navigation happens after they dismiss the modal.
+      setPostSignup({
+        developerId,
+        email,
+        keypair,
+        accessToken: result.data.access_token,
+      });
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function handleRecoveryModalClose() {
+    if (!postSignup) return;
+    const accessToken = postSignup.accessToken;
+    setPostSignup(null);
+    if (!(await handleMcpRedirect(accessToken))) {
+      navigate({ to: "/projects" });
     }
   }
 
@@ -137,6 +216,15 @@ export function SignupPage() {
           </p>
         </CardFooter>
       </Card>
+
+      {postSignup && (
+        <RecoveryFileModal
+          developerId={postSignup.developerId}
+          email={postSignup.email}
+          keypair={postSignup.keypair}
+          onClose={handleRecoveryModalClose}
+        />
+      )}
     </div>
   );
 }

--- a/dashboard/src/components/signup-page.tsx
+++ b/dashboard/src/components/signup-page.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { generateKeyPair, type KeyPair } from "@pqdb/client";
 import { api } from "~/lib/api-client";
-import { setTokens } from "~/lib/auth-store";
+import { setTokens, clearTokens } from "~/lib/auth-store";
 import { useNavigate } from "~/lib/navigation";
 import { isValidEmail } from "~/lib/validation";
 import { handleMcpRedirect } from "~/lib/mcp-callback";
@@ -92,16 +92,21 @@ export function SignupPage() {
     }
 
     setLoading(true);
+    // Track whether we already committed auth tokens so the catch block
+    // can roll them back if a later step throws. Belt-and-suspenders:
+    // the reordered flow already persists the keypair BEFORE setTokens,
+    // so this rollback only fires if an unforeseen throw happens after
+    // we've committed auth (e.g. setWrappingKey or setPostSignup).
+    let tokensSet = false;
     try {
-      // Generate the ML-KEM-768 keypair BEFORE the signup call so the
-      // server can persist the public key atomically with the account.
-      // Running keypair generation + PBKDF2 derivation in parallel with
-      // the network request would be nice, but we need the public key
-      // before the POST body exists, so sequence it first and then race
-      // the PBKDF2 against the network RTT.
+      // 1. Generate the ML-KEM-768 keypair (pure crypto, no side effects).
+      //    Must happen before the signup call so the server can persist
+      //    the public key atomically with the account.
       const keypair = await generateKeyPair();
       const publicKeyB64 = bytesToBase64(keypair.publicKey);
 
+      // 2. POST /v1/auth/signup with the public key. Derive the wrapping
+      //    key in parallel to race PBKDF2 against the network RTT.
       const [result, wrappingKeyResult] = await Promise.all([
         api.signup(email, password, publicKeyB64),
         deriveWrappingKey(password, email).catch((err) => {
@@ -115,6 +120,21 @@ export function SignupPage() {
         return;
       }
 
+      // 3. Parse the developer id from the access token (pure function,
+      //    no side effects). If the token is malformed this throws and
+      //    we abort BEFORE authenticating the user.
+      const developerId = developerIdFromAccessToken(result.data.access_token);
+
+      // 4. Persist the private key to IndexedDB FIRST — this is the
+      //    critical durability step. If it throws (IDB quota, private
+      //    mode, transaction abort) we abort BEFORE committing auth so
+      //    the user is never left authenticated without a private key.
+      await saveKeypair(developerId, {
+        publicKey: keypair.publicKey,
+        secretKey: keypair.secretKey,
+      });
+
+      // 5. Only NOW commit auth tokens — the keypair is durable.
       setTokens(
         {
           access_token: result.data.access_token,
@@ -122,29 +142,35 @@ export function SignupPage() {
         },
         { persist: true },
       );
+      tokensSet = true;
 
       if (wrappingKeyResult) {
         setWrappingKey(wrappingKeyResult);
       }
 
-      // Persist the private key to IndexedDB keyed by developer id so it
-      // survives reloads. The id must come from the newly issued access
-      // token — the server is the only authority on the developer's UUID.
-      const developerId = developerIdFromAccessToken(result.data.access_token);
-      await saveKeypair(developerId, {
-        publicKey: keypair.publicKey,
-        secretKey: keypair.secretKey,
-      });
-
-      // Show the recovery modal instead of navigating immediately. The
-      // user has exactly one chance to save an offline backup of the
-      // private key; navigation happens after they dismiss the modal.
+      // 6. Show the recovery modal instead of navigating immediately.
+      //    The user has exactly one chance to save an offline backup of
+      //    the private key; navigation happens after they dismiss it.
       setPostSignup({
         developerId,
         email,
         keypair,
         accessToken: result.data.access_token,
       });
+    } catch (err) {
+      // Roll back authentication if we already committed it. This only
+      // fires for throws AFTER setTokens — throws before (generateKeyPair,
+      // api.signup, developerIdFromAccessToken, saveKeypair) leave the
+      // user cleanly un-authenticated.
+      if (tokensSet) {
+        clearTokens();
+      }
+      const message =
+        err instanceof Error
+          ? `Signup failed: ${err.message}`
+          : "Signup failed: an unexpected error occurred";
+      setError(message);
+      // Don't re-throw — error is now contained in component state.
     } finally {
       setLoading(false);
     }

--- a/dashboard/src/lib/api-client.ts
+++ b/dashboard/src/lib/api-client.ts
@@ -38,7 +38,11 @@ interface FetchResult {
 }
 
 export interface ApiClient {
-  signup(email: string, password: string): Promise<AuthResult<TokenResponse>>;
+  signup(
+    email: string,
+    password: string,
+    mlKemPublicKey?: string,
+  ): Promise<AuthResult<TokenResponse>>;
   login(email: string, password: string): Promise<AuthResult<TokenResponse>>;
   refresh(refreshToken: string): Promise<AuthResult<AccessTokenResponse>>;
   fetch(path: string, init?: RequestInit): Promise<FetchResult>;
@@ -75,8 +79,16 @@ export function createApiClient(config: { baseUrl: string }): ApiClient {
   async function signup(
     email: string,
     password: string,
+    mlKemPublicKey?: string,
   ): Promise<AuthResult<TokenResponse>> {
-    return authRequest<TokenResponse>("/v1/auth/signup", { email, password });
+    const body: Record<string, string> = { email, password };
+    if (mlKemPublicKey !== undefined) {
+      // Snake case because the FastAPI schema field is `ml_kem_public_key`
+      // and the pydantic validator enforces base64 decoding to exactly
+      // 1184 bytes at the boundary.
+      body.ml_kem_public_key = mlKemPublicKey;
+    }
+    return authRequest<TokenResponse>("/v1/auth/signup", body);
   }
 
   async function login(

--- a/dashboard/src/lib/keypair-store.ts
+++ b/dashboard/src/lib/keypair-store.ts
@@ -1,0 +1,94 @@
+/**
+ * IndexedDB-backed store for the developer's ML-KEM-768 keypair.
+ *
+ * The private key never leaves the client. We persist it in IndexedDB so it
+ * survives a page reload without going through sessionStorage (which is
+ * capped in size and readable by any script on the origin — IndexedDB is
+ * also same-origin but is structured binary storage and avoids string
+ * marshalling of ~2.4 KB secret keys).
+ *
+ * Schema: database 'pqdb', object store 'keypairs', keyed by developer id.
+ * Stored records hold raw Uint8Array publicKey and secretKey bytes.
+ */
+
+const DB_NAME = "pqdb";
+const DB_VERSION = 1;
+const STORE_NAME = "keypairs";
+
+export interface StoredKeypair {
+  publicKey: Uint8Array;
+  secretKey: Uint8Array;
+}
+
+interface KeypairRecord {
+  developerId: string;
+  publicKey: Uint8Array;
+  secretKey: Uint8Array;
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: "developerId" });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function runTx<T>(
+  mode: IDBTransactionMode,
+  fn: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> {
+  return openDb().then(
+    (db) =>
+      new Promise<T>((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, mode);
+        const store = tx.objectStore(STORE_NAME);
+        const req = fn(store);
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+        tx.oncomplete = () => db.close();
+        tx.onerror = () => {
+          db.close();
+          reject(tx.error);
+        };
+      }),
+  );
+}
+
+export async function saveKeypair(
+  developerId: string,
+  keypair: StoredKeypair,
+): Promise<void> {
+  const record: KeypairRecord = {
+    developerId,
+    publicKey: keypair.publicKey,
+    secretKey: keypair.secretKey,
+  };
+  await runTx("readwrite", (store) => store.put(record));
+}
+
+export async function loadKeypair(
+  developerId: string,
+): Promise<StoredKeypair | null> {
+  const record = await runTx<KeypairRecord | undefined>("readonly", (store) =>
+    store.get(developerId) as IDBRequest<KeypairRecord | undefined>,
+  );
+  if (!record) return null;
+  // Normalize to a Uint8Array owned by this realm — structured-clone results
+  // from IndexedDB can come back as a foreign-realm Uint8Array view, which
+  // trips `instanceof Uint8Array` and deep-equality in tests.
+  return {
+    publicKey: new Uint8Array(record.publicKey),
+    secretKey: new Uint8Array(record.secretKey),
+  };
+}
+
+export async function deleteKeypair(developerId: string): Promise<void> {
+  await runTx("readwrite", (store) => store.delete(developerId));
+}

--- a/dashboard/tests/unit/keypair-store.test.ts
+++ b/dashboard/tests/unit/keypair-store.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
+
+import {
+  saveKeypair,
+  loadKeypair,
+  deleteKeypair,
+} from "~/lib/keypair-store";
+
+describe("keypair-store (IndexedDB)", () => {
+  beforeEach(() => {
+    // Reset IndexedDB state between tests so databases do not bleed across cases.
+    globalThis.indexedDB = new IDBFactory();
+  });
+
+  it("saves and loads a keypair by developer id", async () => {
+    const developerId = "11111111-1111-1111-1111-111111111111";
+    const keypair = {
+      publicKey: new Uint8Array([1, 2, 3, 4]),
+      secretKey: new Uint8Array([5, 6, 7, 8]),
+    };
+
+    await saveKeypair(developerId, keypair);
+    const loaded = await loadKeypair(developerId);
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.publicKey).toEqual(keypair.publicKey);
+    expect(loaded!.secretKey).toEqual(keypair.secretKey);
+  });
+
+  it("returns null when no keypair is stored for the developer id", async () => {
+    const loaded = await loadKeypair(
+      "22222222-2222-2222-2222-222222222222",
+    );
+    expect(loaded).toBeNull();
+  });
+
+  it("keeps keypairs isolated per developer id", async () => {
+    const devA = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    const devB = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    await saveKeypair(devA, {
+      publicKey: new Uint8Array([1]),
+      secretKey: new Uint8Array([2]),
+    });
+    await saveKeypair(devB, {
+      publicKey: new Uint8Array([3]),
+      secretKey: new Uint8Array([4]),
+    });
+
+    const a = await loadKeypair(devA);
+    const b = await loadKeypair(devB);
+
+    expect(a!.publicKey).toEqual(new Uint8Array([1]));
+    expect(a!.secretKey).toEqual(new Uint8Array([2]));
+    expect(b!.publicKey).toEqual(new Uint8Array([3]));
+    expect(b!.secretKey).toEqual(new Uint8Array([4]));
+  });
+
+  it("overwrites an existing keypair for the same developer id", async () => {
+    const id = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+    await saveKeypair(id, {
+      publicKey: new Uint8Array([1]),
+      secretKey: new Uint8Array([2]),
+    });
+    await saveKeypair(id, {
+      publicKey: new Uint8Array([9]),
+      secretKey: new Uint8Array([10]),
+    });
+    const loaded = await loadKeypair(id);
+    expect(loaded!.publicKey).toEqual(new Uint8Array([9]));
+    expect(loaded!.secretKey).toEqual(new Uint8Array([10]));
+  });
+
+  it("deletes a stored keypair", async () => {
+    const id = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+    await saveKeypair(id, {
+      publicKey: new Uint8Array([1]),
+      secretKey: new Uint8Array([2]),
+    });
+    await deleteKeypair(id);
+    expect(await loadKeypair(id)).toBeNull();
+  });
+
+  it("uses database 'pqdb' with object store 'keypairs'", async () => {
+    const id = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+    await saveKeypair(id, {
+      publicKey: new Uint8Array([1]),
+      secretKey: new Uint8Array([2]),
+    });
+
+    // Open the database directly and verify the expected structure.
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open("pqdb");
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+    expect(db.name).toBe("pqdb");
+    expect(Array.from(db.objectStoreNames)).toContain("keypairs");
+    db.close();
+  });
+});

--- a/dashboard/tests/unit/recovery-file-modal.test.tsx
+++ b/dashboard/tests/unit/recovery-file-modal.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { RecoveryFileModal } from "~/components/recovery-file-modal";
+
+const DEVELOPER_ID = "11111111-1111-1111-1111-111111111111";
+const EMAIL = "alice@example.com";
+const PUBLIC_KEY = new Uint8Array([1, 2, 3, 4, 5]);
+const SECRET_KEY = new Uint8Array([9, 8, 7, 6, 5]);
+
+function renderModal(onClose = vi.fn()) {
+  return render(
+    <RecoveryFileModal
+      developerId={DEVELOPER_ID}
+      email={EMAIL}
+      keypair={{ publicKey: PUBLIC_KEY, secretKey: SECRET_KEY }}
+      onClose={onClose}
+    />,
+  );
+}
+
+describe("RecoveryFileModal", () => {
+  beforeEach(() => {
+    // Provide minimal URL.createObjectURL / revokeObjectURL stubs so JSDOM
+    // doesn't throw when the modal triggers a Blob download.
+    if (!("createObjectURL" in URL)) {
+      (URL as unknown as { createObjectURL: () => string }).createObjectURL =
+        vi.fn(() => "blob:mock");
+    } else {
+      vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock");
+    }
+    if (!("revokeObjectURL" in URL)) {
+      (URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL =
+        vi.fn();
+    } else {
+      vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+    }
+  });
+
+  it("renders a Download recovery file button", () => {
+    renderModal();
+    expect(
+      screen.getByRole("button", { name: /download recovery file/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("disables the close button until the user downloads or acknowledges", () => {
+    renderModal();
+    expect(
+      screen.getByRole("button", { name: /^close$/i }),
+    ).toBeDisabled();
+  });
+
+  it("enables the close button after clicking Download recovery file", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(
+      screen.getByRole("button", { name: /download recovery file/i }),
+    );
+
+    expect(
+      screen.getByRole("button", { name: /^close$/i }),
+    ).toBeEnabled();
+  });
+
+  it("enables the close button after checking the acknowledgement checkbox", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(screen.getByRole("checkbox", { name: /i understand/i }));
+
+    expect(
+      screen.getByRole("button", { name: /^close$/i }),
+    ).toBeEnabled();
+  });
+
+  it("invokes onClose when the (enabled) close button is clicked", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderModal(onClose);
+
+    await user.click(screen.getByRole("checkbox", { name: /i understand/i }));
+    await user.click(screen.getByRole("button", { name: /^close$/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes a parseable JSON recovery file with both keys base64-encoded", async () => {
+    const user = userEvent.setup();
+
+    // Capture the Blob passed to createObjectURL so we can read its contents.
+    let capturedBlob: Blob | null = null;
+    vi.spyOn(URL, "createObjectURL").mockImplementation((obj: Blob | MediaSource) => {
+      capturedBlob = obj as Blob;
+      return "blob:mock";
+    });
+
+    renderModal();
+    await user.click(
+      screen.getByRole("button", { name: /download recovery file/i }),
+    );
+
+    expect(capturedBlob).not.toBeNull();
+    const text = await capturedBlob!.text();
+    const parsed = JSON.parse(text);
+
+    expect(parsed.version).toBe(1);
+    expect(parsed.developer_id).toBe(DEVELOPER_ID);
+    expect(parsed.email).toBe(EMAIL);
+    expect(typeof parsed.public_key).toBe("string");
+    expect(typeof parsed.private_key).toBe("string");
+    expect(typeof parsed.created_at).toBe("string");
+    expect(typeof parsed.warning).toBe("string");
+
+    // Base64 should round-trip back to the original bytes.
+    const pub = Uint8Array.from(atob(parsed.public_key), (c) =>
+      c.charCodeAt(0),
+    );
+    const priv = Uint8Array.from(atob(parsed.private_key), (c) =>
+      c.charCodeAt(0),
+    );
+    expect(pub).toEqual(PUBLIC_KEY);
+    expect(priv).toEqual(SECRET_KEY);
+  });
+
+  it("sets the download filename to pqdb-recovery-{email}.json", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    // Intercept anchor clicks so we can read the download attribute.
+    const originalCreate = document.createElement.bind(document);
+    let capturedDownload: string | null = null;
+    const spy = vi
+      .spyOn(document, "createElement")
+      .mockImplementation((tag: string) => {
+        const el = originalCreate(tag);
+        if (tag === "a") {
+          const anchor = el as HTMLAnchorElement;
+          const origClick = anchor.click.bind(anchor);
+          anchor.click = () => {
+            capturedDownload = anchor.download;
+            origClick();
+          };
+        }
+        return el;
+      });
+
+    await user.click(
+      screen.getByRole("button", { name: /download recovery file/i }),
+    );
+
+    spy.mockRestore();
+    expect(capturedDownload).toBe(`pqdb-recovery-${EMAIL}.json`);
+  });
+});

--- a/dashboard/tests/unit/signup-mcp-redirect.test.tsx
+++ b/dashboard/tests/unit/signup-mcp-redirect.test.tsx
@@ -1,14 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-const { mockSignup, mockNavigate, mockHandleMcpRedirect } = vi.hoisted(
-  () => ({
-    mockSignup: vi.fn(),
-    mockNavigate: vi.fn(),
-    mockHandleMcpRedirect: vi.fn(),
-  }),
-);
+const {
+  mockSignup,
+  mockNavigate,
+  mockHandleMcpRedirect,
+  mockGenerateKeyPair,
+  mockSaveKeypair,
+} = vi.hoisted(() => ({
+  mockSignup: vi.fn(),
+  mockNavigate: vi.fn(),
+  mockHandleMcpRedirect: vi.fn(),
+  mockGenerateKeyPair: vi.fn(),
+  mockSaveKeypair: vi.fn(),
+}));
 
 vi.mock("~/lib/api-client", () => ({
   api: { signup: mockSignup },
@@ -22,53 +30,87 @@ vi.mock("~/lib/mcp-callback", () => ({
   handleMcpRedirect: mockHandleMcpRedirect,
 }));
 
+vi.mock("@pqdb/client", () => ({
+  generateKeyPair: mockGenerateKeyPair,
+}));
+
+vi.mock("~/lib/keypair-store", () => ({
+  saveKeypair: mockSaveKeypair,
+  loadKeypair: vi.fn(),
+  deleteKeypair: vi.fn(),
+}));
+
 import { SignupPage } from "~/components/signup-page";
+
+// Minimal JWT with a sub claim; signature not verified client-side.
+function mkJwt(): string {
+  const header = btoa(JSON.stringify({ alg: "none" }))
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+  const payload = btoa(
+    JSON.stringify({ sub: "11111111-1111-1111-1111-111111111111" }),
+  )
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+  return `${header}.${payload}.sig`;
+}
 
 describe("SignupPage MCP redirect", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    globalThis.indexedDB = new IDBFactory();
+    mockGenerateKeyPair.mockResolvedValue({
+      publicKey: new Uint8Array(1184).fill(1),
+      secretKey: new Uint8Array(2400).fill(2),
+    });
+    mockSaveKeypair.mockResolvedValue(undefined);
   });
 
-  it("redirects to MCP callback after successful signup when handleMcpRedirect returns true", async () => {
+  async function completeSignupForm() {
     const user = userEvent.setup();
-    mockSignup.mockResolvedValueOnce({
-      data: { access_token: "jwt-token", refresh_token: "rt" },
-      error: null,
-    });
-    // handleMcpRedirect is now async
-    mockHandleMcpRedirect.mockResolvedValue(true);
-
     render(<SignupPage />);
-
     await user.type(screen.getByLabelText(/email/i), "test@example.com");
     await user.type(screen.getByLabelText(/password/i), "password123");
-    await user.click(
-      screen.getByRole("button", { name: /create account/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+    return user;
+  }
+
+  async function dismissRecoveryModal(user: ReturnType<typeof userEvent.setup>) {
+    await screen.findByRole("dialog", { name: /save your recovery file/i });
+    await user.click(screen.getByRole("checkbox", { name: /i understand/i }));
+    await user.click(screen.getByRole("button", { name: /^close$/i }));
+  }
+
+  it("redirects to MCP callback after recovery modal is dismissed when handleMcpRedirect returns true", async () => {
+    const token = mkJwt();
+    mockSignup.mockResolvedValueOnce({
+      data: { access_token: token, refresh_token: "rt" },
+      error: null,
+    });
+    mockHandleMcpRedirect.mockResolvedValue(true);
+
+    const user = await completeSignupForm();
+    await dismissRecoveryModal(user);
 
     await waitFor(() => {
-      expect(mockHandleMcpRedirect).toHaveBeenCalledWith("jwt-token");
+      expect(mockHandleMcpRedirect).toHaveBeenCalledWith(token);
     });
     // Should NOT navigate to /projects when MCP redirect happens
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it("navigates to /projects when handleMcpRedirect returns false", async () => {
-    const user = userEvent.setup();
+    const token = mkJwt();
     mockSignup.mockResolvedValueOnce({
-      data: { access_token: "jwt-token", refresh_token: "rt" },
+      data: { access_token: token, refresh_token: "rt" },
       error: null,
     });
-    // handleMcpRedirect is now async
     mockHandleMcpRedirect.mockResolvedValue(false);
 
-    render(<SignupPage />);
-
-    await user.type(screen.getByLabelText(/email/i), "test@example.com");
-    await user.type(screen.getByLabelText(/password/i), "password123");
-    await user.click(
-      screen.getByRole("button", { name: /create account/i }),
-    );
+    const user = await completeSignupForm();
+    await dismissRecoveryModal(user);
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith({ to: "/projects" });

--- a/dashboard/tests/unit/signup-page.test.tsx
+++ b/dashboard/tests/unit/signup-page.test.tsx
@@ -1,10 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-const { mockSignup, mockNavigate } = vi.hoisted(() => ({
+const {
+  mockSignup,
+  mockNavigate,
+  mockGenerateKeyPair,
+  mockSaveKeypair,
+} = vi.hoisted(() => ({
   mockSignup: vi.fn(),
   mockNavigate: vi.fn(),
+  mockGenerateKeyPair: vi.fn(),
+  mockSaveKeypair: vi.fn(),
 }));
 
 vi.mock("~/lib/api-client", () => ({
@@ -15,11 +24,60 @@ vi.mock("~/lib/navigation", () => ({
   useNavigate: () => mockNavigate,
 }));
 
+vi.mock("@pqdb/client", () => ({
+  generateKeyPair: mockGenerateKeyPair,
+}));
+
+vi.mock("~/lib/keypair-store", () => ({
+  saveKeypair: mockSaveKeypair,
+  loadKeypair: vi.fn(),
+  deleteKeypair: vi.fn(),
+}));
+
 import { SignupPage } from "~/components/signup-page";
+
+// A real-length ML-KEM-768 public/secret key is 1184 / 2400 bytes. We use
+// those exact lengths in mocks so base64 length assertions reflect the real
+// data shape the backend validates on signup.
+const MOCK_PUBLIC_KEY = new Uint8Array(1184).fill(7);
+const MOCK_SECRET_KEY = new Uint8Array(2400).fill(11);
+
+// Minimal unsigned JWT with a `sub` claim the signup page can extract.
+// Not a valid signature — the dashboard only reads `sub` locally, the
+// server verifies on every subsequent request.
+const FAKE_JWT_HEADER = btoa(JSON.stringify({ alg: "none", typ: "JWT" }))
+  .replace(/=+$/, "")
+  .replace(/\+/g, "-")
+  .replace(/\//g, "_");
+const FAKE_JWT_PAYLOAD = btoa(
+  JSON.stringify({ sub: "11111111-1111-1111-1111-111111111111" }),
+)
+  .replace(/=+$/, "")
+  .replace(/\+/g, "-")
+  .replace(/\//g, "_");
+const FAKE_JWT = `${FAKE_JWT_HEADER}.${FAKE_JWT_PAYLOAD}.sig`;
 
 describe("SignupPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    globalThis.indexedDB = new IDBFactory();
+    mockGenerateKeyPair.mockResolvedValue({
+      publicKey: MOCK_PUBLIC_KEY,
+      secretKey: MOCK_SECRET_KEY,
+    });
+    mockSaveKeypair.mockResolvedValue(undefined);
+    if (!("createObjectURL" in URL)) {
+      (URL as unknown as { createObjectURL: () => string }).createObjectURL =
+        vi.fn(() => "blob:mock");
+    } else {
+      vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock");
+    }
+    if (!("revokeObjectURL" in URL)) {
+      (URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL =
+        vi.fn();
+    } else {
+      vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+    }
   });
 
   it("renders email and password fields", () => {
@@ -67,11 +125,11 @@ describe("SignupPage", () => {
     expect(mockSignup).not.toHaveBeenCalled();
   });
 
-  it("calls signup and navigates on success", async () => {
+  it("generates a keypair and sends the public key in the signup POST", async () => {
     const user = userEvent.setup();
     mockSignup.mockResolvedValueOnce({
       data: {
-        access_token: "at",
+        access_token: FAKE_JWT,
         refresh_token: "rt",
         token_type: "bearer",
       },
@@ -85,11 +143,93 @@ describe("SignupPage", () => {
     await user.click(screen.getByRole("button", { name: /create account/i }));
 
     await waitFor(() => {
-      expect(mockSignup).toHaveBeenCalledWith(
-        "test@example.com",
-        "password123",
-      );
+      expect(mockGenerateKeyPair).toHaveBeenCalledTimes(1);
     });
+    await waitFor(() => {
+      expect(mockSignup).toHaveBeenCalledTimes(1);
+    });
+
+    // Signup must be called with email, password, and a base64-encoded
+    // public key of the ML-KEM-768 canonical length (1184 bytes → 1580
+    // base64 characters with padding). This is the exact invariant the
+    // backend enforces in SignupRequest.
+    const args = mockSignup.mock.calls[0]!;
+    expect(args[0]).toBe("test@example.com");
+    expect(args[1]).toBe("password123");
+    expect(typeof args[2]).toBe("string");
+    const decoded = Uint8Array.from(atob(args[2]), (c) => c.charCodeAt(0));
+    expect(decoded.length).toBe(1184);
+    expect(decoded).toEqual(MOCK_PUBLIC_KEY);
+  });
+
+  it("saves the private key to IndexedDB after a successful signup", async () => {
+    const user = userEvent.setup();
+    mockSignup.mockResolvedValueOnce({
+      data: {
+        access_token: FAKE_JWT,
+        refresh_token: "rt",
+        token_type: "bearer",
+      },
+      error: null,
+    });
+
+    render(<SignupPage />);
+    await user.type(screen.getByLabelText(/email/i), "test@example.com");
+    await user.type(screen.getByLabelText(/password/i), "password123");
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(mockSaveKeypair).toHaveBeenCalledTimes(1);
+    });
+    const [, kp] = mockSaveKeypair.mock.calls[0]!;
+    expect(kp.publicKey).toEqual(MOCK_PUBLIC_KEY);
+    expect(kp.secretKey).toEqual(MOCK_SECRET_KEY);
+  });
+
+  it("shows the recovery modal after a successful signup and does not navigate immediately", async () => {
+    const user = userEvent.setup();
+    mockSignup.mockResolvedValueOnce({
+      data: {
+        access_token: FAKE_JWT,
+        refresh_token: "rt",
+        token_type: "bearer",
+      },
+      error: null,
+    });
+
+    render(<SignupPage />);
+    await user.type(screen.getByLabelText(/email/i), "test@example.com");
+    await user.type(screen.getByLabelText(/password/i), "password123");
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+
+    // The recovery modal should appear before navigation happens — the
+    // user MUST see and dismiss the modal so they don't lose their key.
+    expect(
+      await screen.findByRole("dialog", { name: /save your recovery file/i }),
+    ).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("navigates to /projects only after the recovery modal is closed", async () => {
+    const user = userEvent.setup();
+    mockSignup.mockResolvedValueOnce({
+      data: {
+        access_token: FAKE_JWT,
+        refresh_token: "rt",
+        token_type: "bearer",
+      },
+      error: null,
+    });
+
+    render(<SignupPage />);
+    await user.type(screen.getByLabelText(/email/i), "test@example.com");
+    await user.type(screen.getByLabelText(/password/i), "password123");
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+
+    await screen.findByRole("dialog", { name: /save your recovery file/i });
+    await user.click(screen.getByRole("checkbox", { name: /i understand/i }));
+    await user.click(screen.getByRole("button", { name: /^close$/i }));
+
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith({ to: "/projects" });
     });
@@ -133,7 +273,7 @@ describe("SignupPage", () => {
     ).toBeDisabled();
 
     resolveSignup!({
-      data: { access_token: "at", refresh_token: "rt" },
+      data: { access_token: FAKE_JWT, refresh_token: "rt" },
       error: null,
     });
   });

--- a/dashboard/tests/unit/signup-page.test.tsx
+++ b/dashboard/tests/unit/signup-page.test.tsx
@@ -9,11 +9,15 @@ const {
   mockNavigate,
   mockGenerateKeyPair,
   mockSaveKeypair,
+  mockSetTokens,
+  mockClearTokens,
 } = vi.hoisted(() => ({
   mockSignup: vi.fn(),
   mockNavigate: vi.fn(),
   mockGenerateKeyPair: vi.fn(),
   mockSaveKeypair: vi.fn(),
+  mockSetTokens: vi.fn(),
+  mockClearTokens: vi.fn(),
 }));
 
 vi.mock("~/lib/api-client", () => ({
@@ -32,6 +36,14 @@ vi.mock("~/lib/keypair-store", () => ({
   saveKeypair: mockSaveKeypair,
   loadKeypair: vi.fn(),
   deleteKeypair: vi.fn(),
+}));
+
+vi.mock("~/lib/auth-store", () => ({
+  setTokens: mockSetTokens,
+  clearTokens: mockClearTokens,
+  getAccessToken: vi.fn(),
+  getRefreshToken: vi.fn(),
+  onLogout: vi.fn(() => () => undefined),
 }));
 
 import { SignupPage } from "~/components/signup-page";
@@ -275,6 +287,102 @@ describe("SignupPage", () => {
     resolveSignup!({
       data: { access_token: FAKE_JWT, refresh_token: "rt" },
       error: null,
+    });
+
+    // Wait for the post-signup async flow (saveKeypair, setTokens,
+    // modal render) to fully drain so it doesn't leak into the next
+    // test's assertions.
+    await screen.findByRole("dialog", { name: /save your recovery file/i });
+  });
+
+  describe("post-signup error handling (US-004 fix)", () => {
+    it("shows error and does not navigate when generateKeyPair fails", async () => {
+      const user = userEvent.setup();
+      mockGenerateKeyPair.mockRejectedValueOnce(new Error("WASM init failed"));
+
+      render(<SignupPage />);
+      await user.type(screen.getByLabelText(/email/i), "test@example.com");
+      await user.type(screen.getByLabelText(/password/i), "password123");
+      await user.click(
+        screen.getByRole("button", { name: /create account/i }),
+      );
+
+      expect(
+        await screen.findByText(/wasm init failed/i),
+      ).toBeInTheDocument();
+      // No network call, no persistence, no auth — fully aborted.
+      expect(mockSignup).not.toHaveBeenCalled();
+      expect(mockSaveKeypair).not.toHaveBeenCalled();
+      expect(mockSetTokens).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(
+        screen.queryByRole("dialog", { name: /save your recovery file/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows error and does not commit tokens when saveKeypair fails after signup succeeds", async () => {
+      const user = userEvent.setup();
+      mockSignup.mockResolvedValueOnce({
+        data: {
+          access_token: FAKE_JWT,
+          refresh_token: "rt",
+          token_type: "bearer",
+        },
+        error: null,
+      });
+      mockSaveKeypair.mockRejectedValueOnce(new Error("QuotaExceededError"));
+
+      render(<SignupPage />);
+      await user.type(screen.getByLabelText(/email/i), "test@example.com");
+      await user.type(screen.getByLabelText(/password/i), "password123");
+      await user.click(
+        screen.getByRole("button", { name: /create account/i }),
+      );
+
+      expect(
+        await screen.findByText(/quotaexceedederror/i),
+      ).toBeInTheDocument();
+      // Critical: tokens were NEVER committed because saveKeypair runs
+      // BEFORE setTokens in the new ordering. No half-authenticated
+      // zombie account.
+      expect(mockSetTokens).not.toHaveBeenCalled();
+      // No rollback needed because we never set tokens in the first place.
+      expect(mockClearTokens).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(
+        screen.queryByRole("dialog", { name: /save your recovery file/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows error and does not navigate when access token is malformed", async () => {
+      const user = userEvent.setup();
+      // developerIdFromAccessToken will throw on a token that's not a
+      // 3-part JWT — this must abort the flow before any persistence.
+      mockSignup.mockResolvedValueOnce({
+        data: {
+          access_token: "not.a.valid.jwt",
+          refresh_token: "rt",
+          token_type: "bearer",
+        },
+        error: null,
+      });
+
+      render(<SignupPage />);
+      await user.type(screen.getByLabelText(/email/i), "test@example.com");
+      await user.type(screen.getByLabelText(/password/i), "password123");
+      await user.click(
+        screen.getByRole("button", { name: /create account/i }),
+      );
+
+      expect(
+        await screen.findByText(/signup failed/i),
+      ).toBeInTheDocument();
+      expect(mockSaveKeypair).not.toHaveBeenCalled();
+      expect(mockSetTokens).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(
+        screen.queryByRole("dialog", { name: /save your recovery file/i }),
+      ).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Who
Dashboard users signing up for a new developer account.

## What
Signup now generates an ML-KEM-768 keypair client-side, uploads the public key to the backend, persists the private key to IndexedDB keyed by developer id, and shows a blocking recovery-file modal so the user gets exactly one well-lit chance to back up their keypair.

## When
Opened 2026-04-09 23:18 America/New_York as part of Phase 5d (ML-KEM keypair crypto).

## Where
- `dashboard/src/lib/keypair-store.ts` (new) — IndexedDB wrapper (database `pqdb`, object store `keypairs`), exposes `saveKeypair` / `loadKeypair` / `deleteKeypair`
- `dashboard/src/components/recovery-file-modal.tsx` (new) — post-signup modal with Download button, acknowledgement checkbox, and a close button that only unlocks once the user has downloaded OR acknowledged
- `dashboard/src/components/signup-page.tsx` — generates the keypair, sends the base64 public key in the signup POST as `ml_kem_public_key`, saves the private key to IndexedDB on success, shows the recovery modal before navigating
- `dashboard/src/lib/api-client.ts` — `api.signup` now takes an optional third argument `mlKemPublicKey`
- `dashboard/tests/unit/keypair-store.test.ts` (new) — 6 unit tests using `fake-indexeddb`
- `dashboard/tests/unit/recovery-file-modal.test.tsx` (new) — 7 unit tests covering rendering, dismissal logic, file content, filename
- `dashboard/tests/unit/signup-page.test.tsx` — 4 new tests (keypair generated, public key in POST, private key saved to IDB, modal blocks navigation and only dismissal navigates)
- `dashboard/tests/unit/signup-mcp-redirect.test.tsx` — updated to dismiss the modal before the MCP redirect runs
- `dashboard/e2e/signup-keypair.spec.ts` (new) — Playwright happy path: form submission, POST body contains a 1184-byte public key, download produces a parseable JSON file whose `public_key` matches `GET /v1/auth/me/public-key`, navigation to /projects after close
- `dashboard/e2e/helpers.ts` — shared `signUp` helper now dismisses the recovery modal so existing E2E suites keep working

## Why
US-003 landed the backend validation but nothing was producing the public key yet — accounts created through the dashboard had a NULL `ml_kem_public_key` which would break project creation as soon as US-006 lands. This closes that gap for all dashboard-created accounts and gives the user a recovery path that works with the MCP server's `PQDB_PRIVATE_KEY` import flow (US-008).

## How
1. Generate the keypair with `generateKeyPair()` from `@pqdb/client` BEFORE the signup POST — the POST body needs the public key, so keypair generation is sequenced first and then races PBKDF2 against the network RTT
2. Base64-encode the raw 1184-byte public key and send it as `ml_kem_public_key` alongside email/password
3. On 201 response, parse the `sub` claim out of the returned access token (no signature verification — the server issued it and will re-verify on every subsequent request) and use it as the IndexedDB record key
4. Persist `{publicKey, secretKey}` to IndexedDB via `saveKeypair`
5. Open the recovery modal with the fresh keypair — user must either click "Download recovery file" OR tick "I understand" before the Close button enables
6. Download is a JSON `Blob` with `{version:1, developer_id, email, public_key, private_key, created_at, warning}` keyed as base64; filename is `pqdb-recovery-{email}.json`
7. Modal close calls `handleMcpRedirect(accessToken)` and navigates to `/projects` if no MCP callback is pending

## Test plan
- [x] `npm test --prefix dashboard` — 571 passed, 1 unrelated pre-existing failure in `login-mcp-redirect.test.tsx` (predates this branch, tracked separately)
- [x] `npm run typecheck --prefix dashboard` — clean
- [x] `npm run build --prefix dashboard` — clean
- [x] `gitleaks detect --source .` — no leaks
- [x] `semgrep scan --config=auto` on changed files — 0 findings
- [x] `npx playwright test signup-keypair` — passes: full round-trip from signup form through recovery file download, verifies POST body, file contents, and that the downloaded public key matches `GET /v1/auth/me/public-key`
- [x] E2E signup helper: 14 other E2E tests that use `signUp` still work; 2 pre-existing failures (`01-dashboard-flow`, `05-passkey`) are unrelated strict-mode locator issues that exist on main

## Non-goals
- MCP server import of the recovery file (US-008, parallel)
- Keypair context / auto-load on login (US-005a)
- Recovery modal upload path for returning users (US-005b)
- Using the public key for per-project data-key wrapping (US-006)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>