### PR TITLE
[US-008] MCP server PQDB_PRIVATE_KEY + encapsulate

### DIFF
--- a/mcp/src/auth-state.ts
+++ b/mcp/src/auth-state.ts
@@ -12,6 +12,20 @@ let _projectId: string | undefined;
 let _refreshToken: string | undefined;
 let _projectUrl: string | undefined;
 
+/**
+ * ML-KEM-768 private key loaded from PQDB_PRIVATE_KEY. Used to unwrap
+ * per-project encryption keys during pqdb_select_project. Kept in
+ * process memory only — never serialized into tool responses or logs.
+ */
+let _privateKey: Uint8Array | undefined;
+
+/**
+ * Current active per-project shared secret, recovered via decapsulate
+ * in pqdb_select_project or produced via encapsulate in pqdb_create_project.
+ * Used by subsequent CRUD tools to encrypt/decrypt sensitive columns.
+ */
+let _sharedSecret: Uint8Array | undefined;
+
 /** Whether the dev token has been refreshed at least once. */
 let _tokenRefreshed = false;
 
@@ -45,6 +59,44 @@ export function getProjectId(): string | undefined {
 /** Switch the active project at runtime (used by pqdb_select_project). */
 export function setCurrentProjectId(projectId: string): void {
   _projectId = projectId;
+}
+
+/**
+ * Store the developer's ML-KEM-768 private key in memory.
+ * The raw bytes never leave process memory and must never be
+ * serialized into tool responses or logs.
+ */
+export function setCurrentPrivateKey(key: Uint8Array): void {
+  _privateKey = key;
+}
+
+/** Return the in-memory ML-KEM private key, or undefined if none configured. */
+export function getCurrentPrivateKey(): Uint8Array | undefined {
+  return _privateKey;
+}
+
+/** Clear the in-memory private key (primarily for tests). */
+export function clearCurrentPrivateKey(): void {
+  _privateKey = undefined;
+}
+
+/**
+ * Store the active per-project shared secret (32 bytes for ML-KEM-768).
+ * Populated by pqdb_create_project (encapsulate) and pqdb_select_project
+ * (decapsulate).
+ */
+export function setCurrentSharedSecret(secret: Uint8Array): void {
+  _sharedSecret = secret;
+}
+
+/** Return the current active shared secret, if any. */
+export function getCurrentSharedSecret(): Uint8Array | undefined {
+  return _sharedSecret;
+}
+
+/** Clear the active shared secret (e.g. when selecting a plaintext project). */
+export function clearCurrentSharedSecret(): void {
+  _sharedSecret = undefined;
 }
 
 /** Build auth headers — uses apikey if available, otherwise developer JWT + project ID. */

--- a/mcp/src/auth-state.ts
+++ b/mcp/src/auth-state.ts
@@ -99,6 +99,30 @@ export function clearCurrentSharedSecret(): void {
   _sharedSecret = undefined;
 }
 
+/**
+ * Return the current active shared secret encoded as a base64url string
+ * (no padding), suitable for passing to the SDK's `deriveKeyPair(string)`.
+ * Returns `null` when no shared secret is set.
+ *
+ * This is the bridge between the per-project shared secret recovered in
+ * `pqdb_create_project` / `pqdb_select_project` and the CRUD-tool key
+ * derivation path, which consumes a string.
+ */
+export function getCurrentEncryptionKeyString(): string | null {
+  if (!_sharedSecret) return null;
+  return bytesToBase64UrlNoPad(_sharedSecret);
+}
+
+/** Encode bytes to base64url without padding. */
+function bytesToBase64UrlNoPad(bytes: Uint8Array): string {
+  // Buffer is available in Node (MCP server runtime); use it for correctness.
+  return Buffer.from(bytes)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
 /** Build auth headers — uses apikey if available, otherwise developer JWT + project ID. */
 export function buildAuthHeaders(apiKey: string): Record<string, string> {
   if (apiKey) {

--- a/mcp/src/config.ts
+++ b/mcp/src/config.ts
@@ -4,6 +4,9 @@
 
 export type Transport = "stdio" | "sse" | "http";
 
+/** Expected length (bytes) of an ML-KEM-768 private (secret) key (FIPS 203). */
+export const ML_KEM_768_SECRET_KEY_BYTES = 2400;
+
 export interface ServerConfig {
   /** Base URL of the pqdb API server. */
   projectUrl: string;
@@ -19,6 +22,13 @@ export interface ServerConfig {
   devToken: string | undefined;
   /** Optional project ID resolved during OAuth (for JWT auth on /v1/db/* endpoints). */
   projectId: string | undefined;
+  /**
+   * Optional ML-KEM-768 private key (2400 bytes) decoded from the
+   * PQDB_PRIVATE_KEY environment variable. When set, the MCP server
+   * wraps per-project encryption keys using the developer's public
+   * key and unwraps them on project selection.
+   */
+  privateKey: Uint8Array | undefined;
 }
 
 export interface ParsedArgs {
@@ -58,6 +68,67 @@ export function parseArgs(argv: string[]): ParsedArgs {
 }
 
 /**
+ * Decode a base64 or base64url encoded string to bytes, normalizing
+ * base64url (- _) into standard base64 (+ /) and re-padding.
+ *
+ * Throws if the string contains characters that are not valid in
+ * either encoding, or if the length is not a multiple of 4 after padding.
+ */
+function decodeBase64Flexible(input: string): Uint8Array {
+  // Strip whitespace
+  const trimmed = input.replace(/\s+/g, "");
+  // Reject characters that are not valid in base64 or base64url
+  if (!/^[A-Za-z0-9+/_=-]*$/.test(trimmed)) {
+    throw new Error(
+      "PQDB_PRIVATE_KEY contains characters that are not valid base64 or base64url.",
+    );
+  }
+  // Normalize base64url -> base64 and re-pad
+  const normalized = trimmed.replace(/-/g, "+").replace(/_/g, "/");
+  const padded =
+    normalized.length % 4 === 0
+      ? normalized
+      : normalized + "=".repeat(4 - (normalized.length % 4));
+  const buf = Buffer.from(padded, "base64");
+  // Round-trip check: re-encoding must match the padded input (minus trailing padding).
+  // This catches strings like "!!!" that slip through the character regex by accident.
+  const reEncoded = buf.toString("base64");
+  if (
+    reEncoded.replace(/=+$/, "") !== padded.replace(/=+$/, "") &&
+    reEncoded !== padded
+  ) {
+    throw new Error("PQDB_PRIVATE_KEY failed base64 round-trip decoding.");
+  }
+  return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+}
+
+/**
+ * Parse and validate PQDB_PRIVATE_KEY.
+ *
+ * Accepts base64 or base64url encoding. Decoded length MUST match
+ * ML_KEM_768_SECRET_KEY_BYTES (2400). Fails fast with a clear error
+ * on any mismatch so misconfiguration cannot silently create broken
+ * encrypted projects.
+ */
+export function parsePrivateKey(raw: string): Uint8Array {
+  let decoded: Uint8Array;
+  try {
+    decoded = decodeBase64Flexible(raw);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `PQDB_PRIVATE_KEY is not valid base64/base64url: ${msg}`,
+    );
+  }
+  if (decoded.length !== ML_KEM_768_SECRET_KEY_BYTES) {
+    throw new Error(
+      `PQDB_PRIVATE_KEY has wrong length: expected ${ML_KEM_768_SECRET_KEY_BYTES} bytes (ML-KEM-768 secret key), got ${decoded.length}.`,
+    );
+  }
+  return decoded;
+}
+
+/**
  * Build a complete ServerConfig from CLI args + environment variables.
  */
 export function buildConfig(args: ParsedArgs): ServerConfig {
@@ -74,6 +145,12 @@ export function buildConfig(args: ParsedArgs): ServerConfig {
     );
   }
 
+  const rawPrivateKey = process.env.PQDB_PRIVATE_KEY;
+  const privateKey =
+    rawPrivateKey && rawPrivateKey.length > 0
+      ? parsePrivateKey(rawPrivateKey)
+      : undefined;
+
   return {
     projectUrl,
     transport: args.transport,
@@ -82,5 +159,6 @@ export function buildConfig(args: ParsedArgs): ServerConfig {
     encryptionKey: process.env.PQDB_ENCRYPTION_KEY || undefined,
     devToken: process.env.PQDB_DEV_TOKEN || undefined,
     projectId: undefined,
+    privateKey,
   };
 }

--- a/mcp/src/crud-tools.ts
+++ b/mcp/src/crud-tools.ts
@@ -49,7 +49,11 @@ interface IntrospectTable {
   columns: IntrospectColumn[];
 }
 
-import { authFetch as pqdbGet, authPost as pqdbPost } from "./auth-state.js";
+import {
+  authFetch as pqdbGet,
+  authPost as pqdbPost,
+  getCurrentEncryptionKeyString,
+} from "./auth-state.js";
 
 /**
  * Replace values in _encrypted columns with "[encrypted]" when
@@ -113,24 +117,62 @@ export function registerCrudTools(
   _devToken?: string,
   _projectId?: string,
 ): void {
-  // Lazy crypto state — derived on first encrypted operation
+  // Lazy crypto state — cached ONLY for the legacy static-encryptionKey
+  // path. When the dynamic per-project shared secret (US-008) is active,
+  // we derive fresh on every call so `pqdb_select_project` can switch
+  // projects without leaking stale crypto state across them.
   let cryptoState: CryptoState | null = null;
 
-  async function getCryptoState(): Promise<CryptoState> {
-    if (cryptoState) return cryptoState;
-    if (!encryptionKey) throw new Error("Encryption key not available");
+  /**
+   * Whether encryption is currently available from any source:
+   * the dynamic per-project shared secret (US-008) or the legacy
+   * PQDB_ENCRYPTION_KEY env var. Must be evaluated dynamically because
+   * the shared secret can be populated AFTER server construction by
+   * `pqdb_create_project` / `pqdb_select_project`.
+   */
+  function isEncryptionAvailable(): boolean {
+    if (getCurrentEncryptionKeyString() !== null) return true;
+    return encryptionEnabled;
+  }
 
-    const keyPair = await deriveKeyPair(encryptionKey);
-
-    // Fetch HMAC key for blind indexes
+  /** Fetch the current HMAC key from the backend for blind-index computation. */
+  async function fetchHmacKey(): Promise<Uint8Array> {
     const hmacResponse = await pqdbGet<{
       current_version: number;
       keys: Record<string, string>;
     }>(projectUrl, apiKey, "/v1/db/hmac-key");
 
     const currentKey = hmacResponse.keys[String(hmacResponse.current_version)];
-    const hmacKey = hexToBytes(currentKey);
+    return hexToBytes(currentKey);
+  }
 
+  async function getCryptoState(): Promise<CryptoState> {
+    // Prefer the dynamic per-project shared secret (US-008) over the static
+    // legacy encryptionKey. When it's set, we MUST NOT use the cache: the
+    // shared secret can change between `pqdb_select_project` calls when the
+    // user switches projects, and a cached keypair from the previous project
+    // would silently corrupt data.
+    const dynamicKey = getCurrentEncryptionKeyString();
+    if (dynamicKey !== null) {
+      const keyPair = await deriveKeyPair(dynamicKey);
+      const hmacKey = await fetchHmacKey();
+      return { keyPair, hmacKey };
+    }
+
+    // Legacy static-key path — cache is safe because encryptionKey is
+    // immutable for the lifetime of the server instance.
+    if (cryptoState) return cryptoState;
+    if (!encryptionKey) {
+      throw new Error(
+        "Encryption key not available. Either set PQDB_PRIVATE_KEY and call " +
+          "pqdb_create_project or pqdb_select_project to derive a per-project " +
+          "key, or set PQDB_ENCRYPTION_KEY in the environment for the legacy " +
+          "path.",
+      );
+    }
+
+    const keyPair = await deriveKeyPair(encryptionKey);
+    const hmacKey = await fetchHmacKey();
     cryptoState = { keyPair, hmacKey };
     return cryptoState;
   }
@@ -228,7 +270,7 @@ export function registerCrudTools(
           branchHeaders,
         );
 
-        if (!encryptionEnabled) {
+        if (!isEncryptionAvailable()) {
           return successResult({ data: maskEncryptedValues(result.data), error: null });
         }
 
@@ -273,7 +315,7 @@ export function registerCrudTools(
       try {
         let transformedRows = rows;
 
-        if (encryptionEnabled) {
+        if (isEncryptionAvailable()) {
           const schema = await getTableSchema(table);
           if (tableHasEncryptedColumns(schema)) {
             const { keyPair, hmacKey } = await getCryptoState();
@@ -340,7 +382,7 @@ export function registerCrudTools(
       try {
         let transformedValues = values;
 
-        if (encryptionEnabled) {
+        if (isEncryptionAvailable()) {
           const schema = await getTableSchema(table);
           if (tableHasEncryptedColumns(schema)) {
             const { keyPair, hmacKey } = await getCryptoState();

--- a/mcp/src/crud-tools.ts
+++ b/mcp/src/crud-tools.ts
@@ -19,10 +19,11 @@ import {
   deriveKeyPair,
   transformInsertRows,
   transformSelectResponse,
+  transformFilters,
   defineTableSchema,
   ColumnDef,
 } from "@pqdb/client";
-import type { KeyPair, SchemaColumns, TableSchema } from "@pqdb/client";
+import type { FilterClause, KeyPair, SchemaColumns, TableSchema } from "@pqdb/client";
 
 /** Filter schema matching the backend's FilterSchema. */
 const FilterZod = z.object({
@@ -246,9 +247,27 @@ export function registerCrudTools(
     },
     async ({ table, columns, filters, limit, offset, order_by, order_dir, similar_to, branch }) => {
       try {
+        // When encryption is available and the table has encrypted
+        // columns, rewrite filters targeting searchable columns so the
+        // values become blind-index HMAC digests. Without this, the
+        // backend's WHERE {col}_index = '<plaintext>' never matches the
+        // hex digests stored by transformInsertRows at write time.
+        let outgoingFilters: FilterClause[] = (filters ?? []) as FilterClause[];
+        let schemaForDecrypt: TableSchema | null = null;
+        if (isEncryptionAvailable()) {
+          const schema = await getTableSchema(table);
+          if (tableHasEncryptedColumns(schema)) {
+            schemaForDecrypt = schema;
+            if (outgoingFilters.length > 0) {
+              const { hmacKey } = await getCryptoState();
+              outgoingFilters = transformFilters(outgoingFilters, schema, hmacKey);
+            }
+          }
+        }
+
         const body: Record<string, unknown> = {
           columns: columns ?? ["*"],
-          filters: filters ?? [],
+          filters: outgoingFilters,
           modifiers: {
             limit: limit ?? null,
             offset: offset ?? null,
@@ -275,12 +294,11 @@ export function registerCrudTools(
         }
 
         // Decrypt encrypted columns
-        const schema = await getTableSchema(table);
-        if (tableHasEncryptedColumns(schema)) {
+        if (schemaForDecrypt) {
           const { keyPair } = await getCryptoState();
           const decrypted = await transformSelectResponse(
             result.data,
-            schema,
+            schemaForDecrypt,
             keyPair.secretKey,
           );
           return successResult({ data: decrypted, error: null });
@@ -381,6 +399,7 @@ export function registerCrudTools(
     async ({ table, values, filters, branch }) => {
       try {
         let transformedValues = values;
+        let outgoingFilters: FilterClause[] = (filters ?? []) as FilterClause[];
 
         if (isEncryptionAvailable()) {
           const schema = await getTableSchema(table);
@@ -394,6 +413,10 @@ export function registerCrudTools(
               hmacKey,
             );
             transformedValues = transformed;
+            // Rewrite filters targeting searchable columns into blind-index lookups.
+            if (outgoingFilters.length > 0) {
+              outgoingFilters = transformFilters(outgoingFilters, schema, hmacKey);
+            }
           }
         } else {
           const schema = await getTableSchema(table);
@@ -416,7 +439,7 @@ export function registerCrudTools(
           projectUrl,
           apiKey,
           `/v1/db/${encodeURIComponent(table)}/update`,
-          { values: transformedValues, filters: filters ?? [] },
+          { values: transformedValues, filters: outgoingFilters },
           branchHeaders,
         );
 
@@ -447,12 +470,25 @@ export function registerCrudTools(
     },
     async ({ table, filters, branch }) => {
       try {
+        // Rewrite filters targeting searchable columns into blind-index
+        // lookups when encryption is active; otherwise rows inserted via
+        // the encrypted path (hex HMAC digests in {col}_index) would
+        // never be matched by raw plaintext filter values.
+        let outgoingFilters: FilterClause[] = filters as FilterClause[];
+        if (isEncryptionAvailable() && outgoingFilters.length > 0) {
+          const schema = await getTableSchema(table);
+          if (tableHasEncryptedColumns(schema)) {
+            const { hmacKey } = await getCryptoState();
+            outgoingFilters = transformFilters(outgoingFilters, schema, hmacKey);
+          }
+        }
+
         const branchHeaders = branch ? { "x-branch": branch } : undefined;
         const result = await pqdbPost<{ data: unknown[] }>(
           projectUrl,
           apiKey,
           `/v1/db/${encodeURIComponent(table)}/delete`,
-          { filters },
+          { filters: outgoingFilters },
           branchHeaders,
         );
 

--- a/mcp/src/http-app.ts
+++ b/mcp/src/http-app.ts
@@ -261,6 +261,7 @@ export function createMcpHttpApp(options: HttpAppOptions): Express {
           encryptionKey: resolvedEncryptionKey,
           devToken: devJwt,
           projectId,
+          privateKey: undefined,
         };
 
         const { mcpServer } = createPqdbMcpServer(config);

--- a/mcp/src/nl-query.ts
+++ b/mcp/src/nl-query.ts
@@ -356,7 +356,11 @@ export function translateNaturalLanguage(
   };
 }
 
-import { authFetch as pqdbFetch, authPost as pqdbPost } from "./auth-state.js";
+import {
+  authFetch as pqdbFetch,
+  authPost as pqdbPost,
+  getCurrentEncryptionKeyString,
+} from "./auth-state.js";
 /**
  * Register the natural language query tool on the MCP server.
  */
@@ -368,6 +372,16 @@ export function registerNlQueryTool(
   devToken?: string,
   projectId?: string,
 ): void {
+  // Evaluate encryption availability dynamically at tool-invocation
+  // time: the per-project shared secret (US-008) can be populated AFTER
+  // server construction by `pqdb_create_project` / `pqdb_select_project`,
+  // so capturing `encryptionEnabled` at construction would make NL
+  // queries permanently mask encrypted columns even after a project is
+  // selected with a working key.
+  function isEncryptionAvailable(): boolean {
+    if (getCurrentEncryptionKeyString() !== null) return true;
+    return encryptionEnabled;
+  }
   mcpServer.tool(
     "pqdb_natural_language_query",
     "Execute a natural language query against the database. Translates to a pqdb query using schema metadata, respecting column sensitivity constraints. Examples: 'show all users', 'get posts where title = Hello', 'first 10 users'",
@@ -435,8 +449,11 @@ export function registerNlQueryTool(
           body,
         );
 
-        // Mask encrypted values if no encryption key
-        const data = encryptionEnabled
+        // Mask encrypted values if no encryption key available. Checked
+        // dynamically so the per-project shared secret populated by
+        // pqdb_create_project/pqdb_select_project takes effect without
+        // server restart.
+        const data = isEncryptionAvailable()
           ? result.data
           : result.data.map((row) => {
               const masked: Record<string, unknown> = {};

--- a/mcp/src/project-tools.ts
+++ b/mcp/src/project-tools.ts
@@ -320,6 +320,11 @@ export function registerProjectTools(
         // Always reset any prior shared secret before creating a new project.
         clearCurrentSharedSecret();
 
+        // Hold the freshly-encapsulated shared secret locally until the
+        // create POST succeeds. If devPost throws, we must NOT leave a
+        // stale shared secret pointing at a project that doesn't exist.
+        let pendingSharedSecret: Uint8Array | null = null;
+
         if (privKey) {
           // Fetch the developer's stored ML-KEM public key.
           const pkResp = await devGet<{ public_key: string | null }>(
@@ -342,10 +347,8 @@ export function registerProjectTools(
           // Send the wrapped encryption key in the create body.
           body.wrapped_encryption_key = bytesToBase64(ciphertext);
 
-          // Store the shared secret in process memory only — never
-          // serialize it into the tool response.
-          setCurrentSharedSecret(sharedSecret);
-          wrappedEncryptionKeyPresent = true;
+          // Defer committing the shared secret until AFTER the POST succeeds.
+          pendingSharedSecret = sharedSecret;
         } else {
           warning =
             "No PQDB_PRIVATE_KEY set — project created without encryption. " +
@@ -357,6 +360,13 @@ export function registerProjectTools(
           name: string;
           wrapped_encryption_key?: string | null;
         }>(projectUrl, devToken!, "/v1/projects", body);
+
+        // POST succeeded — now commit the shared secret to auth-state so
+        // subsequent CRUD tools can derive per-project encryption keys.
+        if (pendingSharedSecret) {
+          setCurrentSharedSecret(pendingSharedSecret);
+          wrappedEncryptionKeyPresent = true;
+        }
 
         // Auto-select the newly created project
         setCurrentProjectId(project.id);

--- a/mcp/src/project-tools.ts
+++ b/mcp/src/project-tools.ts
@@ -17,7 +17,13 @@
  */
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { setCurrentProjectId } from "./auth-state.js";
+import { encapsulate, decapsulate } from "@pqdb/client";
+import {
+  clearCurrentSharedSecret,
+  getCurrentPrivateKey,
+  setCurrentProjectId,
+  setCurrentSharedSecret,
+} from "./auth-state.js";
 
 /** Standard { data, error } response shape. */
 interface ApiResponse {
@@ -143,6 +149,17 @@ function requireDevToken(devToken: string | undefined): ReturnType<typeof errorR
   return null;
 }
 
+/** Encode Uint8Array to standard base64. */
+function bytesToBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64");
+}
+
+/** Decode standard base64 to Uint8Array. */
+function base64ToBytes(b64: string): Uint8Array {
+  const buf = Buffer.from(b64, "base64");
+  return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+}
+
 /**
  * Register project management tools on the MCP server.
  */
@@ -165,7 +182,12 @@ export function registerProjectTools(
       if (authError) return authError;
 
       try {
-        const project = await devGet<{ id: string; name: string; status: string }>(
+        const project = await devGet<{
+          id: string;
+          name: string;
+          status: string;
+          wrapped_encryption_key?: string | null;
+        }>(
           projectUrl,
           devToken!,
           `/v1/projects/${encodeURIComponent(project_id)}`,
@@ -173,11 +195,40 @@ export function registerProjectTools(
 
         setCurrentProjectId(project.id);
 
+        // Reset any prior shared secret before deriving a new one.
+        clearCurrentSharedSecret();
+
+        // Unwrap the per-project encryption key if both a configured
+        // private key AND a server-stored wrapped key are present.
+        const privKey = getCurrentPrivateKey();
+        let encryptionActive = false;
+        if (privKey && project.wrapped_encryption_key) {
+          try {
+            const wrapped = base64ToBytes(project.wrapped_encryption_key);
+            const sharedSecret = await decapsulate(wrapped, privKey);
+            setCurrentSharedSecret(sharedSecret);
+            encryptionActive = true;
+          } catch (decapErr) {
+            return errorResult({
+              data: null,
+              error:
+                "Failed to decapsulate wrapped_encryption_key with the configured PQDB_PRIVATE_KEY: " +
+                (decapErr instanceof Error
+                  ? decapErr.message
+                  : String(decapErr)),
+            });
+          }
+        }
+
+        // Project object is returned as-is (wrapped_encryption_key is
+        // already ciphertext, and the decapsulated shared secret is
+        // intentionally NOT included in the response).
         return successResult({
           data: {
             message: `Switched to project "${project.name}" (${project.id})`,
             project,
             active_project_id: project.id,
+            encryption_active: encryptionActive,
           },
           error: null,
         });
@@ -250,7 +301,7 @@ export function registerProjectTools(
 
   mcpServer.tool(
     "pqdb_create_project",
-    "Create a new pqdb project. Requires PQDB_DEV_TOKEN.",
+    "Create a new pqdb project. Requires PQDB_DEV_TOKEN. When PQDB_PRIVATE_KEY is also set, the project is created with a ML-KEM-768 wrapped encryption key so searchable/private columns can be used immediately.",
     {
       name: z.string().describe("Name of the project"),
       region: z.string().optional().describe("Region for the project (e.g. us-east-1)"),
@@ -263,17 +314,61 @@ export function registerProjectTools(
         const body: Record<string, string> = { name };
         if (region) body.region = region;
 
-        const project = await devPost<{ id: string; name: string }>(
-          projectUrl,
-          devToken!,
-          "/v1/projects",
-          body,
-        );
+        const privKey = getCurrentPrivateKey();
+        let warning: string | null = null;
+        let wrappedEncryptionKeyPresent = false;
+        // Always reset any prior shared secret before creating a new project.
+        clearCurrentSharedSecret();
+
+        if (privKey) {
+          // Fetch the developer's stored ML-KEM public key.
+          const pkResp = await devGet<{ public_key: string | null }>(
+            projectUrl,
+            devToken!,
+            "/v1/auth/me/public-key",
+          );
+          if (!pkResp.public_key) {
+            return errorResult({
+              data: null,
+              error:
+                "Developer has no ML-KEM public key on file. Upload one before " +
+                "creating an encrypted project (see the dashboard signup/key-management flow).",
+            });
+          }
+
+          const publicKey = base64ToBytes(pkResp.public_key);
+          const { ciphertext, sharedSecret } = await encapsulate(publicKey);
+
+          // Send the wrapped encryption key in the create body.
+          body.wrapped_encryption_key = bytesToBase64(ciphertext);
+
+          // Store the shared secret in process memory only — never
+          // serialize it into the tool response.
+          setCurrentSharedSecret(sharedSecret);
+          wrappedEncryptionKeyPresent = true;
+        } else {
+          warning =
+            "No PQDB_PRIVATE_KEY set — project created without encryption. " +
+            "Set PQDB_PRIVATE_KEY to enable searchable/private columns.";
+        }
+
+        const project = await devPost<{
+          id: string;
+          name: string;
+          wrapped_encryption_key?: string | null;
+        }>(projectUrl, devToken!, "/v1/projects", body);
 
         // Auto-select the newly created project
         setCurrentProjectId(project.id);
 
-        return successResult({ data: project, error: null });
+        return successResult({
+          data: {
+            project,
+            encryption_active: wrappedEncryptionKeyPresent,
+            warning,
+          },
+          error: null,
+        });
       } catch (err) {
         return errorResult({
           data: null,

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -12,6 +12,11 @@ import { registerNlQueryTool } from "./nl-query.js";
 import { registerProjectTools } from "./project-tools.js";
 import { registerAdminTools } from "./admin-tools.js";
 import { registerDocsTools } from "./docs-tools.js";
+import {
+  clearCurrentPrivateKey,
+  clearCurrentSharedSecret,
+  setCurrentPrivateKey,
+} from "./auth-state.js";
 
 export const SERVER_NAME = "pqdb-mcp";
 export const SERVER_VERSION = "0.1.0";
@@ -46,6 +51,17 @@ export function createPqdbMcpServer(config: ServerConfig): PqdbMcpServer {
   );
 
   const encryptionEnabled = !!config.encryptionKey;
+
+  // Load the developer's ML-KEM private key into auth-state (US-008).
+  // Always reset both the private key and the shared secret on server
+  // construction — they are per-developer / per-project values and must
+  // not leak between server instances in tests or between restarts in
+  // production.
+  clearCurrentPrivateKey();
+  clearCurrentSharedSecret();
+  if (config.privateKey !== undefined) {
+    setCurrentPrivateKey(config.privateKey);
+  }
 
   const pqdbClient = createClient(config.projectUrl, config.apiKey, {
     encryptionKey: config.encryptionKey,

--- a/mcp/tests/e2e/us008-mcp-private-key.test.ts
+++ b/mcp/tests/e2e/us008-mcp-private-key.test.ts
@@ -1,0 +1,288 @@
+/**
+ * US-008 integration test — MCP server with PQDB_PRIVATE_KEY does a full
+ * encapsulate → create_project → insert → query round trip on a
+ * searchable column.
+ *
+ * Boots a real FastAPI backend against real Postgres + Vault, then:
+ *   1. Signs up a developer with a freshly generated ML-KEM-768 keypair
+ *   2. Creates an MCP server instance configured with the private key
+ *   3. Calls pqdb_create_project and asserts wrapped_encryption_key != null
+ *   4. Verifies the raw shared secret is NOT in the tool response
+ *   5. Creates a table with a searchable column and round-trips data
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn, type ChildProcess } from "child_process";
+import * as path from "path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createPqdbMcpServer } from "../../src/server.js";
+import type { ServerConfig } from "../../src/config.js";
+import { generateKeyPair } from "@pqdb/client";
+
+const API_PORT = 8770;
+const API_URL = `http://localhost:${API_PORT}`;
+const BACKEND_DIR = path.resolve(__dirname, "../../../backend");
+
+const RUN_ID = Date.now();
+const DEV_EMAIL = `us008-mcp-${RUN_ID}@test.pqdb.dev`;
+const DEV_PASSWORD = "SuperSecretP@ss123!";
+
+let serverProcess: ChildProcess;
+let developerAccessToken: string;
+let privateKey: Uint8Array;
+
+async function apiCall(
+  method: string,
+  urlPath: string,
+  body?: unknown,
+  headers?: Record<string, string>,
+): Promise<{ status: number; json: unknown }> {
+  const opts: RequestInit = {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+  };
+  if (body !== undefined) opts.body = JSON.stringify(body);
+  const resp = await fetch(`${API_URL}${urlPath}`, opts);
+  const json = await resp.json().catch(() => null);
+  return { status: resp.status, json };
+}
+
+async function waitForServer(timeoutMs = 30_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const resp = await fetch(`${API_URL}/health`);
+      if (resp.ok) return;
+    } catch {
+      // not ready
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`Server did not become ready within ${timeoutMs}ms`);
+}
+
+async function createMcpClient(
+  apiKey: string,
+  devToken: string,
+  privKey: Uint8Array | undefined,
+): Promise<Client> {
+  const config: ServerConfig = {
+    projectUrl: API_URL,
+    transport: "stdio",
+    port: 3001,
+    apiKey,
+    encryptionKey: undefined,
+    devToken,
+    projectId: undefined,
+    privateKey: privKey,
+  };
+  const { mcpServer } = createPqdbMcpServer(config);
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await mcpServer.connect(serverTransport);
+  const client = new Client({
+    name: "us008-test-client",
+    version: "1.0.0",
+  });
+  await client.connect(clientTransport);
+  return client;
+}
+
+beforeAll(async () => {
+  // Generate a real ML-KEM-768 keypair for the developer
+  const keypair = await generateKeyPair();
+  privateKey = keypair.secretKey;
+  const publicKeyB64 = Buffer.from(keypair.publicKey).toString("base64");
+
+  serverProcess = spawn(
+    "uv",
+    [
+      "run",
+      "uvicorn",
+      "pqdb_api.app:create_app",
+      "--factory",
+      "--port",
+      String(API_PORT),
+    ],
+    {
+      cwd: BACKEND_DIR,
+      env: {
+        ...process.env,
+        PQDB_DATABASE_URL:
+          "postgresql+asyncpg://postgres:postgres@localhost:5432/pqdb_platform",
+        PQDB_VAULT_ADDR: "http://localhost:8200",
+        PQDB_VAULT_TOKEN: "dev-root-token",
+        PQDB_SUPERUSER_DSN:
+          "postgresql://postgres:postgres@localhost:5432/postgres",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  serverProcess.stderr?.on("data", (chunk: Buffer) => {
+    const msg = chunk.toString();
+    if (msg.includes("ERROR") || msg.includes("Traceback")) {
+      console.error("[backend]", msg);
+    }
+  });
+
+  await waitForServer();
+
+  // Sign up developer with the generated public key
+  const signupResp = await apiCall("POST", "/v1/auth/signup", {
+    email: DEV_EMAIL,
+    password: DEV_PASSWORD,
+    ml_kem_public_key: publicKeyB64,
+  });
+  expect(signupResp.status).toBe(201);
+  developerAccessToken = (signupResp.json as { access_token: string })
+    .access_token;
+}, 60_000);
+
+afterAll(async () => {
+  if (serverProcess) {
+    serverProcess.kill("SIGTERM");
+    await new Promise((r) => setTimeout(r, 500));
+    if (!serverProcess.killed) {
+      serverProcess.kill("SIGKILL");
+    }
+  }
+});
+
+describe("US-008 — MCP server + PQDB_PRIVATE_KEY integration", () => {
+  it("pqdb_create_project produces a wrapped_encryption_key and does not leak the shared secret", async () => {
+    const mcpClient = await createMcpClient(
+      "",
+      developerAccessToken,
+      privateKey,
+    );
+
+    // 1 — Create an encrypted project via the MCP tool
+    const createResult = await mcpClient.callTool({
+      name: "pqdb_create_project",
+      arguments: {
+        name: `us008-mcp-${RUN_ID}`,
+        region: "us-east-1",
+      },
+    });
+    expect(createResult.isError).toBeFalsy();
+
+    const rawText = (createResult.content as Array<{ text: string }>)[0].text;
+    const parsed = JSON.parse(rawText) as {
+      data: {
+        project: {
+          id: string;
+          wrapped_encryption_key: string | null;
+          api_keys: Array<{ role: string; key: string }>;
+        };
+        encryption_active: boolean;
+        warning: string | null;
+      };
+      error: string | null;
+    };
+
+    expect(parsed.error).toBeNull();
+    expect(parsed.data.encryption_active).toBe(true);
+    expect(parsed.data.warning).toBeNull();
+    // Backend echoes the wrapped_encryption_key we sent.
+    expect(parsed.data.project.wrapped_encryption_key).toBeTruthy();
+    expect(typeof parsed.data.project.wrapped_encryption_key).toBe("string");
+
+    // SECURITY: the response must not contain any leaked key material.
+    // Shared secret is 32 bytes — its base64 is trivially short; look for
+    // the private key's first-16-byte prefix base64 (high-confidence canary).
+    const privKeyPrefix = Buffer.from(privateKey.slice(0, 32)).toString(
+      "base64",
+    );
+    expect(rawText).not.toContain(privKeyPrefix);
+
+    const projectId = parsed.data.project.id;
+
+    // 2 — Round-trip on a searchable column using the SDK + service API key
+    // (obtained via platform API since MCP create_project echoes api_keys).
+    const serviceApiKey = parsed.data.project.api_keys.find(
+      (k) => k.role === "service",
+    )?.key;
+    expect(serviceApiKey).toBeTruthy();
+
+    // Create a table with a searchable column via the platform API.
+    const createTable = await apiCall(
+      "POST",
+      "/v1/db/tables",
+      {
+        name: "us008_contacts",
+        columns: [
+          { name: "name", data_type: "text", sensitivity: "plain" },
+          { name: "email", data_type: "text", sensitivity: "searchable" },
+        ],
+      },
+      { apikey: serviceApiKey! },
+    );
+    expect(createTable.status).toBe(201);
+
+    // Insert a row via the SDK (with the derived shared secret encryption)
+    const sharedSecretB64 = "placeholder"; // not used here; SDK derives its own
+    expect(sharedSecretB64).toBeTruthy();
+
+    // Minimal plaintext insert via raw endpoint to verify the project is
+    // addressable; encrypted round-trips with the shared secret are
+    // validated in the unit tests and the SDK's own e2e suite. The key
+    // US-008 assertion is that wrapped_encryption_key != null, which we
+    // already checked above.
+    const insertResp = await apiCall(
+      "POST",
+      "/v1/db/us008_contacts/insert",
+      {
+        rows: [{ name: "Alice" }],
+      },
+      { apikey: serviceApiKey! },
+    );
+    expect([200, 201]).toContain(insertResp.status);
+
+    // 3 — pqdb_select_project should decapsulate without error
+    const selectResult = await mcpClient.callTool({
+      name: "pqdb_select_project",
+      arguments: { project_id: projectId },
+    });
+    expect(selectResult.isError).toBeFalsy();
+    const selParsed = JSON.parse(
+      (selectResult.content as Array<{ text: string }>)[0].text,
+    ) as {
+      data: { encryption_active: boolean };
+    };
+    expect(selParsed.data.encryption_active).toBe(true);
+  }, 60_000);
+
+  it("pqdb_create_project without PQDB_PRIVATE_KEY creates a plaintext project with a warning", async () => {
+    const mcpClient = await createMcpClient(
+      "",
+      developerAccessToken,
+      undefined,
+    );
+
+    const result = await mcpClient.callTool({
+      name: "pqdb_create_project",
+      arguments: {
+        name: `us008-mcp-plain-${RUN_ID}`,
+        region: "us-east-1",
+      },
+    });
+    expect(result.isError).toBeFalsy();
+
+    const parsed = JSON.parse(
+      (result.content as Array<{ text: string }>)[0].text,
+    ) as {
+      data: {
+        project: { wrapped_encryption_key: string | null };
+        encryption_active: boolean;
+        warning: string | null;
+      };
+    };
+    expect(parsed.data.encryption_active).toBe(false);
+    expect(parsed.data.warning).toContain("No PQDB_PRIVATE_KEY set");
+    expect(parsed.data.project.wrapped_encryption_key).toBeNull();
+  }, 30_000);
+});

--- a/mcp/tests/e2e/us008-mcp-private-key.test.ts
+++ b/mcp/tests/e2e/us008-mcp-private-key.test.ts
@@ -204,7 +204,7 @@ describe("US-008 — MCP server + PQDB_PRIVATE_KEY integration", () => {
     // 2 — Round-trip on a searchable column using the SDK + service API key
     // (obtained via platform API since MCP create_project echoes api_keys).
     const serviceApiKey = parsed.data.project.api_keys.find(
-      (k) => k.role === "service",
+      (k) => k.role === "service_role" || k.role === "service",
     )?.key;
     expect(serviceApiKey).toBeTruthy();
 
@@ -223,25 +223,6 @@ describe("US-008 — MCP server + PQDB_PRIVATE_KEY integration", () => {
     );
     expect(createTable.status).toBe(201);
 
-    // Insert a row via the SDK (with the derived shared secret encryption)
-    const sharedSecretB64 = "placeholder"; // not used here; SDK derives its own
-    expect(sharedSecretB64).toBeTruthy();
-
-    // Minimal plaintext insert via raw endpoint to verify the project is
-    // addressable; encrypted round-trips with the shared secret are
-    // validated in the unit tests and the SDK's own e2e suite. The key
-    // US-008 assertion is that wrapped_encryption_key != null, which we
-    // already checked above.
-    const insertResp = await apiCall(
-      "POST",
-      "/v1/db/us008_contacts/insert",
-      {
-        rows: [{ name: "Alice" }],
-      },
-      { apikey: serviceApiKey! },
-    );
-    expect([200, 201]).toContain(insertResp.status);
-
     // 3 — pqdb_select_project should decapsulate without error
     const selectResult = await mcpClient.callTool({
       name: "pqdb_select_project",
@@ -255,6 +236,139 @@ describe("US-008 — MCP server + PQDB_PRIVATE_KEY integration", () => {
     };
     expect(selParsed.data.encryption_active).toBe(true);
   }, 60_000);
+
+  it("encrypted insert/query round-trip on a searchable column uses the per-project shared secret", async () => {
+    // Regression test for PR #149 defect: the shared secret produced by
+    // pqdb_create_project was never consumed by pqdb_insert_rows /
+    // pqdb_query_rows, so an AI agent that set PQDB_PRIVATE_KEY would see
+    // "encryption_active: true" and then fail on the first CRUD call.
+    //
+    // This test exercises the full wiring: create encrypted project → create
+    // a table with a searchable column → insert via MCP → query via MCP with
+    // an `.eq` filter on the searchable column → assert the row round-trips.
+    // Success implies the blind-index HMAC and the encrypt/decrypt keypair
+    // are all derived from the SAME per-project shared secret. Any drift
+    // (e.g., deriving from a legacy env var instead) would cause the
+    // HMAC-indexed eq filter to return zero rows.
+
+    // Use a separate MCP client that also has the service API key, so CRUD
+    // calls authenticate as the project (not the developer). The private
+    // key is required so pqdb_create_project can encapsulate.
+    const keypair2 = await generateKeyPair();
+    const privateKey2 = keypair2.secretKey;
+    const publicKeyB64_2 = Buffer.from(keypair2.publicKey).toString("base64");
+
+    // Sign up a fresh developer for this test so we don't interfere with
+    // the public key registered in beforeAll.
+    const email2 = `us008-mcp-rt-${RUN_ID}@test.pqdb.dev`;
+    const signup2 = await apiCall("POST", "/v1/auth/signup", {
+      email: email2,
+      password: DEV_PASSWORD,
+      ml_kem_public_key: publicKeyB64_2,
+    });
+    expect(signup2.status).toBe(201);
+    const devToken2 = (signup2.json as { access_token: string }).access_token;
+
+    // Phase A: create the encrypted project via MCP (no apiKey yet).
+    const mcpCreate = await createMcpClient("", devToken2, privateKey2);
+    const createResult = await mcpCreate.callTool({
+      name: "pqdb_create_project",
+      arguments: { name: `us008-mcp-rt-${RUN_ID}`, region: "us-east-1" },
+    });
+    expect(createResult.isError).toBeFalsy();
+    const created = JSON.parse(
+      (createResult.content as Array<{ text: string }>)[0].text,
+    ) as {
+      data: {
+        project: {
+          id: string;
+          api_keys: Array<{ role: string; key: string }>;
+          wrapped_encryption_key: string | null;
+        };
+        encryption_active: boolean;
+      };
+    };
+    expect(created.data.encryption_active).toBe(true);
+    expect(created.data.project.wrapped_encryption_key).toBeTruthy();
+
+    const serviceApiKey = created.data.project.api_keys.find(
+      (k) => k.role === "service_role" || k.role === "service",
+    )?.key;
+    expect(serviceApiKey).toBeTruthy();
+
+    // Create the table (needs service key). Do this via the platform API;
+    // table DDL isn't the MCP tool we're exercising here.
+    const createTable = await apiCall(
+      "POST",
+      "/v1/db/tables",
+      {
+        name: "us008_rt_contacts",
+        columns: [
+          { name: "name", data_type: "text", sensitivity: "plain" },
+          { name: "email", data_type: "text", sensitivity: "searchable" },
+        ],
+      },
+      { apikey: serviceApiKey! },
+    );
+    expect(createTable.status).toBe(201);
+
+    // Phase B: spin up a SECOND MCP client that carries the service API
+    // key (so CRUD tools authenticate as the project) AND the private key
+    // (so pqdb_select_project can decapsulate and populate the shared
+    // secret). Creating the client does NOT call create_project, so we
+    // must explicitly select the project to populate the shared secret.
+    const mcpCrud = await createMcpClient(
+      serviceApiKey!,
+      devToken2,
+      privateKey2,
+    );
+    const selectResult = await mcpCrud.callTool({
+      name: "pqdb_select_project",
+      arguments: { project_id: created.data.project.id },
+    });
+    expect(selectResult.isError).toBeFalsy();
+    const selParsed = JSON.parse(
+      (selectResult.content as Array<{ text: string }>)[0].text,
+    ) as { data: { encryption_active: boolean } };
+    expect(selParsed.data.encryption_active).toBe(true);
+
+    // INSERT via MCP — this path runs transformInsertRows which encrypts
+    // the `email` column AND computes its blind-index HMAC using the
+    // per-project shared secret derived keypair + HMAC key.
+    const insertResult = await mcpCrud.callTool({
+      name: "pqdb_insert_rows",
+      arguments: {
+        table: "us008_rt_contacts",
+        rows: [{ name: "Alice", email: "alice@us008.test" }],
+      },
+    });
+    expect(insertResult.isError).toBeFalsy();
+
+    // QUERY via MCP with an .eq filter on the searchable `email` column.
+    // The SDK rewrites this into an HMAC equality lookup on `email_index`.
+    // If the HMAC key used on insert and the HMAC key used on query are
+    // different — which would happen if CRUD was still reading the legacy
+    // PQDB_ENCRYPTION_KEY env var — the lookup would return zero rows.
+    const queryResult = await mcpCrud.callTool({
+      name: "pqdb_query_rows",
+      arguments: {
+        table: "us008_rt_contacts",
+        filters: [{ column: "email", op: "eq", value: "alice@us008.test" }],
+      },
+    });
+    expect(queryResult.isError).toBeFalsy();
+    const queryParsed = JSON.parse(
+      (queryResult.content as Array<{ text: string }>)[0].text,
+    ) as { data: Array<{ name?: string; email?: string }>; error: string | null };
+    expect(queryParsed.error).toBeNull();
+    expect(queryParsed.data).toBeDefined();
+    expect(queryParsed.data.length).toBe(1);
+    expect(queryParsed.data[0].name).toBe("Alice");
+    // The decrypted email column must round-trip back to the plaintext.
+    // This proves the ML-KEM keypair used to encrypt was derived from the
+    // same shared secret that's available for decryption.
+    expect(queryParsed.data[0].email).toBe("alice@us008.test");
+  }, 90_000);
 
   it("pqdb_create_project without PQDB_PRIVATE_KEY creates a plaintext project with a warning", async () => {
     const mcpClient = await createMcpClient(

--- a/mcp/tests/unit/auth-state.test.ts
+++ b/mcp/tests/unit/auth-state.test.ts
@@ -7,6 +7,7 @@ import {
   getCurrentPrivateKey,
   setCurrentSharedSecret,
   getCurrentSharedSecret,
+  getCurrentEncryptionKeyString,
   clearCurrentPrivateKey,
   clearCurrentSharedSecret,
 } from "../../src/auth-state.js";
@@ -50,6 +51,40 @@ describe("auth-state: private key storage (US-008)", () => {
     expect(got!.length).toBe(32);
     expect(got![0]).toBe(0);
     expect(got![31]).toBe(31);
+  });
+
+  it("getCurrentEncryptionKeyString returns null when no shared secret is set", () => {
+    expect(getCurrentEncryptionKeyString()).toBeNull();
+  });
+
+  it("getCurrentEncryptionKeyString encodes the shared secret as base64url-no-padding (43 chars for 32 bytes)", () => {
+    // Use a known 32-byte value so we can verify the exact encoding.
+    // 32 bytes of 0xFF -> base64 "//////////////////////////////////////////8="
+    //                  -> base64url-no-pad "__________________________________________8"
+    const ss = new Uint8Array(32).fill(0xff);
+    setCurrentSharedSecret(ss);
+    const str = getCurrentEncryptionKeyString();
+    expect(str).not.toBeNull();
+    // 32 bytes base64url-no-pad is exactly 43 characters
+    expect(str!.length).toBe(43);
+    // Must not contain standard-base64 chars (+, /, =)
+    expect(str).not.toMatch(/[+/=]/);
+    // Round-trip: decode it back (normalize + repad) and compare
+    const padded = str! + "=".repeat((4 - (str!.length % 4)) % 4);
+    const b64 = padded.replace(/-/g, "+").replace(/_/g, "/");
+    const decoded = new Uint8Array(Buffer.from(b64, "base64"));
+    expect(decoded.length).toBe(32);
+    expect(Array.from(decoded)).toEqual(Array.from(ss));
+  });
+
+  it("getCurrentEncryptionKeyString reflects updates to the stored shared secret", () => {
+    setCurrentSharedSecret(new Uint8Array(32).fill(0xaa));
+    const first = getCurrentEncryptionKeyString();
+    setCurrentSharedSecret(new Uint8Array(32).fill(0xbb));
+    const second = getCurrentEncryptionKeyString();
+    expect(first).not.toBe(second);
+    clearCurrentSharedSecret();
+    expect(getCurrentEncryptionKeyString()).toBeNull();
   });
 
   it("private key and shared secret are stored independently", () => {

--- a/mcp/tests/unit/auth-state.test.ts
+++ b/mcp/tests/unit/auth-state.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for auth-state: private key + shared secret storage (US-008).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  setCurrentPrivateKey,
+  getCurrentPrivateKey,
+  setCurrentSharedSecret,
+  getCurrentSharedSecret,
+  clearCurrentPrivateKey,
+  clearCurrentSharedSecret,
+} from "../../src/auth-state.js";
+
+describe("auth-state: private key storage (US-008)", () => {
+  beforeEach(() => {
+    clearCurrentPrivateKey();
+    clearCurrentSharedSecret();
+  });
+
+  it("setCurrentPrivateKey then getCurrentPrivateKey round-trips the key bytes", () => {
+    const key = new Uint8Array(2400);
+    for (let i = 0; i < key.length; i++) {
+      key[i] = i % 256;
+    }
+    setCurrentPrivateKey(key);
+    const got = getCurrentPrivateKey();
+    expect(got).toBeInstanceOf(Uint8Array);
+    expect(got!.length).toBe(2400);
+    expect(got![0]).toBe(0);
+    expect(got![255]).toBe(255);
+  });
+
+  it("getCurrentPrivateKey returns undefined before set", () => {
+    expect(getCurrentPrivateKey()).toBeUndefined();
+  });
+
+  it("clearCurrentPrivateKey removes the stored key", () => {
+    setCurrentPrivateKey(new Uint8Array(2400));
+    expect(getCurrentPrivateKey()).toBeDefined();
+    clearCurrentPrivateKey();
+    expect(getCurrentPrivateKey()).toBeUndefined();
+  });
+
+  it("setCurrentSharedSecret then getCurrentSharedSecret round-trips", () => {
+    const ss = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) ss[i] = i;
+    setCurrentSharedSecret(ss);
+    const got = getCurrentSharedSecret();
+    expect(got).toBeInstanceOf(Uint8Array);
+    expect(got!.length).toBe(32);
+    expect(got![0]).toBe(0);
+    expect(got![31]).toBe(31);
+  });
+
+  it("private key and shared secret are stored independently", () => {
+    const pk = new Uint8Array(2400).fill(0xaa);
+    const ss = new Uint8Array(32).fill(0xbb);
+    setCurrentPrivateKey(pk);
+    setCurrentSharedSecret(ss);
+    expect(getCurrentPrivateKey()![0]).toBe(0xaa);
+    expect(getCurrentSharedSecret()![0]).toBe(0xbb);
+    clearCurrentSharedSecret();
+    expect(getCurrentSharedSecret()).toBeUndefined();
+    // Private key survives shared-secret clear
+    expect(getCurrentPrivateKey()).toBeDefined();
+  });
+});

--- a/mcp/tests/unit/config.test.ts
+++ b/mcp/tests/unit/config.test.ts
@@ -140,6 +140,7 @@ describe("buildConfig", () => {
   it("builds complete config from args + env", () => {
     process.env.PQDB_API_KEY = "pqdb_service_key456";
     process.env.PQDB_ENCRYPTION_KEY = "enc-key";
+    delete process.env.PQDB_PRIVATE_KEY;
     const config = buildConfig({
       projectUrl: "http://localhost:8000",
       transport: "sse",
@@ -152,6 +153,8 @@ describe("buildConfig", () => {
       apiKey: "pqdb_service_key456",
       encryptionKey: "enc-key",
       devToken: undefined,
+      projectId: undefined,
+      privateKey: undefined,
     });
   });
 
@@ -213,5 +216,105 @@ describe("buildConfig", () => {
       port: 3001,
     });
     expect(config.projectUrl).toBe("https://localhost");
+  });
+
+  // ── PQDB_PRIVATE_KEY (US-008) ─────────────────────────────────────────
+
+  describe("PQDB_PRIVATE_KEY parsing", () => {
+    // ML-KEM-768 secret key = 2400 bytes
+    const VALID_KEY_SIZE = 2400;
+
+    function makeKeyBase64(length: number): string {
+      const bytes = new Uint8Array(length);
+      for (let i = 0; i < length; i++) {
+        bytes[i] = i % 256;
+      }
+      return Buffer.from(bytes).toString("base64");
+    }
+
+    function makeKeyBase64Url(length: number): string {
+      const bytes = new Uint8Array(length);
+      for (let i = 0; i < length; i++) {
+        bytes[i] = i % 256;
+      }
+      return Buffer.from(bytes).toString("base64url");
+    }
+
+    it("privateKey is undefined when PQDB_PRIVATE_KEY is not set", () => {
+      process.env.PQDB_API_KEY = "pqdb_anon_testkey123";
+      delete process.env.PQDB_PRIVATE_KEY;
+      const config = buildConfig({
+        projectUrl: "http://localhost:8000",
+        transport: "stdio",
+        port: 3001,
+      });
+      expect(config.privateKey).toBeUndefined();
+    });
+
+    it("decodes a valid standard base64 PQDB_PRIVATE_KEY into a Uint8Array of 2400 bytes", () => {
+      process.env.PQDB_API_KEY = "pqdb_anon_testkey123";
+      process.env.PQDB_PRIVATE_KEY = makeKeyBase64(VALID_KEY_SIZE);
+      const config = buildConfig({
+        projectUrl: "http://localhost:8000",
+        transport: "stdio",
+        port: 3001,
+      });
+      expect(config.privateKey).toBeInstanceOf(Uint8Array);
+      expect(config.privateKey!.length).toBe(VALID_KEY_SIZE);
+      // Verify round-trip: first byte should be 0, second 1, ...
+      expect(config.privateKey![0]).toBe(0);
+      expect(config.privateKey![1]).toBe(1);
+      expect(config.privateKey![255]).toBe(255);
+    });
+
+    it("decodes a valid base64url PQDB_PRIVATE_KEY into a Uint8Array of 2400 bytes", () => {
+      process.env.PQDB_API_KEY = "pqdb_anon_testkey123";
+      process.env.PQDB_PRIVATE_KEY = makeKeyBase64Url(VALID_KEY_SIZE);
+      const config = buildConfig({
+        projectUrl: "http://localhost:8000",
+        transport: "stdio",
+        port: 3001,
+      });
+      expect(config.privateKey).toBeInstanceOf(Uint8Array);
+      expect(config.privateKey!.length).toBe(VALID_KEY_SIZE);
+      expect(config.privateKey![0]).toBe(0);
+      expect(config.privateKey![1]).toBe(1);
+    });
+
+    it("throws a clear error when PQDB_PRIVATE_KEY decodes to the wrong length", () => {
+      process.env.PQDB_API_KEY = "pqdb_anon_testkey123";
+      process.env.PQDB_PRIVATE_KEY = makeKeyBase64(100); // too small
+      expect(() =>
+        buildConfig({
+          projectUrl: "http://localhost:8000",
+          transport: "stdio",
+          port: 3001,
+        }),
+      ).toThrow(/PQDB_PRIVATE_KEY.*2400/);
+    });
+
+    it("throws a clear error when PQDB_PRIVATE_KEY is not valid base64", () => {
+      process.env.PQDB_API_KEY = "pqdb_anon_testkey123";
+      process.env.PQDB_PRIVATE_KEY = "!!!not valid base64!!!";
+      expect(() =>
+        buildConfig({
+          projectUrl: "http://localhost:8000",
+          transport: "stdio",
+          port: 3001,
+        }),
+      ).toThrow(/PQDB_PRIVATE_KEY/);
+    });
+
+    it("rejects an oversized PQDB_PRIVATE_KEY with a clear error", () => {
+      process.env.PQDB_API_KEY = "pqdb_anon_testkey123";
+      process.env.PQDB_PRIVATE_KEY = makeKeyBase64(5000);
+      expect(() =>
+        buildConfig({
+          projectUrl: "http://localhost:8000",
+          transport: "stdio",
+          port: 3001,
+        }),
+      ).toThrow(/PQDB_PRIVATE_KEY/);
+    });
   });
 });

--- a/mcp/tests/unit/create-project-encap.test.ts
+++ b/mcp/tests/unit/create-project-encap.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Unit tests for pqdb_create_project with PQDB_PRIVATE_KEY (US-008).
+ *
+ * Covers:
+ *   - With private key: fetches public key, calls encapsulate, sends
+ *     wrapped_encryption_key in POST body, stores sharedSecret in auth-state
+ *   - Without private key: plain project creation + warning in result
+ *   - Never leaks raw private key or shared secret into tool response
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createPqdbMcpServer } from "../../src/server.js";
+import type { ServerConfig } from "../../src/config.js";
+import {
+  clearCurrentPrivateKey,
+  clearCurrentSharedSecret,
+  getCurrentPrivateKey,
+  getCurrentSharedSecret,
+  setCurrentPrivateKey,
+} from "../../src/auth-state.js";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+// Mock encapsulate/decapsulate from @pqdb/client so we don't need real ML-KEM
+// Signature matches sdk/src/crypto/pqc.ts:
+//   encapsulate(publicKey) -> { ciphertext, sharedSecret }
+//   decapsulate(ciphertext, secretKey) -> sharedSecret
+const mockCiphertext = new Uint8Array(1088).fill(0xcc);
+const mockSharedSecret = new Uint8Array(32).fill(0xdd);
+
+vi.mock("@pqdb/client", async () => {
+  return {
+    createClient: vi.fn(() => ({
+      auth: {},
+      defineTable: vi.fn(),
+      from: vi.fn(),
+      reindex: vi.fn(),
+    })),
+    encapsulate: vi.fn(async (_publicKey: Uint8Array) => ({
+      ciphertext: mockCiphertext,
+      sharedSecret: mockSharedSecret,
+    })),
+    decapsulate: vi.fn(async (_ct: Uint8Array, _sk: Uint8Array) => {
+      return mockSharedSecret;
+    }),
+  };
+});
+
+// Global fetch mock
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function makeConfig(overrides: Partial<ServerConfig> = {}): ServerConfig {
+  return {
+    projectUrl: "http://localhost:8000",
+    transport: "stdio",
+    port: 3001,
+    apiKey: "",
+    encryptionKey: undefined,
+    devToken: "dev-jwt-token-123",
+    projectId: undefined,
+    privateKey: undefined,
+    ...overrides,
+  };
+}
+
+async function createTestClient(
+  overrides: Partial<ServerConfig> = {},
+): Promise<Client> {
+  const { mcpServer } = createPqdbMcpServer(makeConfig(overrides));
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await mcpServer.connect(serverTransport);
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await client.connect(clientTransport);
+  return client;
+}
+
+function mockFetchOk(data: unknown): void {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => data,
+  });
+}
+
+// A valid-shaped ML-KEM-768 private key (2400 bytes of distinct-ish bytes)
+function makePrivateKey(): Uint8Array {
+  const key = new Uint8Array(2400);
+  for (let i = 0; i < key.length; i++) {
+    key[i] = (i * 7) % 256;
+  }
+  return key;
+}
+
+// Public key base64 (value doesn't matter because encapsulate is mocked)
+const PUBLIC_KEY_B64 = Buffer.from(new Uint8Array(1184).fill(0x11)).toString(
+  "base64",
+);
+
+describe("pqdb_create_project with PQDB_PRIVATE_KEY (US-008)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearCurrentPrivateKey();
+    clearCurrentSharedSecret();
+  });
+
+  afterEach(() => {
+    clearCurrentPrivateKey();
+    clearCurrentSharedSecret();
+  });
+
+  it("fetches developer public key, calls encapsulate, sends wrapped_encryption_key in POST body, stores shared secret", async () => {
+    const privateKey = makePrivateKey();
+    const client = await createTestClient({ privateKey });
+
+    // 1st fetch: GET /v1/auth/me/public-key
+    mockFetchOk({ public_key: PUBLIC_KEY_B64 });
+    // 2nd fetch: POST /v1/projects (echoes wrapped_encryption_key)
+    const createdProject = {
+      id: "proj-new-1",
+      name: "Encrypted Project",
+      region: "us-east-1",
+      status: "active",
+      database_name: "pqdb_project_xyz",
+      wrapped_encryption_key: Buffer.from(mockCiphertext).toString("base64"),
+    };
+    mockFetchOk(createdProject);
+
+    const result = await client.callTool({
+      name: "pqdb_create_project",
+      arguments: { name: "Encrypted Project", region: "us-east-1" },
+    });
+
+    // Two fetch calls total
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // First call: GET public key with dev JWT
+    const firstCall = mockFetch.mock.calls[0];
+    expect(firstCall[0]).toBe("http://localhost:8000/v1/auth/me/public-key");
+    expect(firstCall[1]).toMatchObject({
+      method: "GET",
+      headers: expect.objectContaining({
+        Authorization: "Bearer dev-jwt-token-123",
+      }),
+    });
+
+    // Second call: POST /v1/projects with base64 wrapped_encryption_key
+    const secondCall = mockFetch.mock.calls[1];
+    expect(secondCall[0]).toBe("http://localhost:8000/v1/projects");
+    expect(secondCall[1].method).toBe("POST");
+    const body = JSON.parse(secondCall[1].body as string);
+    expect(body.name).toBe("Encrypted Project");
+    expect(body.region).toBe("us-east-1");
+    expect(body.wrapped_encryption_key).toBe(
+      Buffer.from(mockCiphertext).toString("base64"),
+    );
+
+    // Tool result — success, NO raw shared secret leaked
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ text: string }>)[0].text;
+
+    // SECURITY: assert the raw shared secret (base64) is NOT in the response
+    const sharedSecretB64 = Buffer.from(mockSharedSecret).toString("base64");
+    expect(text).not.toContain(sharedSecretB64);
+
+    // SECURITY: the raw private key bytes must not leak either
+    const privateKeyB64 = Buffer.from(privateKey).toString("base64");
+    expect(text).not.toContain(privateKeyB64);
+
+    // Shared secret is stored in auth-state for subsequent CRUD
+    const stored = getCurrentSharedSecret();
+    expect(stored).toBeInstanceOf(Uint8Array);
+    expect(stored!.length).toBe(32);
+    expect(Buffer.from(stored!).toString("hex")).toBe(
+      Buffer.from(mockSharedSecret).toString("hex"),
+    );
+  });
+
+  it("without PQDB_PRIVATE_KEY: creates plaintext project and emits a warning in the tool result", async () => {
+    const client = await createTestClient({ privateKey: undefined });
+
+    // Only one fetch: POST /v1/projects (no public-key fetch because no key)
+    mockFetchOk({
+      id: "proj-plaintext-1",
+      name: "Plaintext Project",
+      region: "us-east-1",
+      status: "active",
+    });
+
+    const result = await client.callTool({
+      name: "pqdb_create_project",
+      arguments: { name: "Plaintext Project" },
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const call = mockFetch.mock.calls[0];
+    expect(call[0]).toBe("http://localhost:8000/v1/projects");
+    const body = JSON.parse(call[1].body as string);
+    expect(body.name).toBe("Plaintext Project");
+    // No wrapped_encryption_key in plaintext path
+    expect(body.wrapped_encryption_key).toBeUndefined();
+
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    // Warning is visible to the AI agent
+    expect(text).toContain("No PQDB_PRIVATE_KEY set");
+    expect(text.toLowerCase()).toContain("searchable");
+
+    // No shared secret is stored in this path
+    expect(getCurrentSharedSecret()).toBeUndefined();
+  });
+
+  it("fails gracefully when developer has no public key uploaded", async () => {
+    const privateKey = makePrivateKey();
+    const client = await createTestClient({ privateKey });
+
+    // Public key endpoint returns null
+    mockFetchOk({ public_key: null });
+
+    const result = await client.callTool({
+      name: "pqdb_create_project",
+      arguments: { name: "NoKeyProject" },
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    expect(text).toMatch(/public.key/i);
+    // POST to /v1/projects should NOT have been made
+    expect(
+      mockFetch.mock.calls.find(
+        (c) => c[0] === "http://localhost:8000/v1/projects",
+      ),
+    ).toBeUndefined();
+    expect(getCurrentSharedSecret()).toBeUndefined();
+  });
+
+  it("sets the in-memory private key from config at server construction", async () => {
+    const privateKey = makePrivateKey();
+    await createTestClient({ privateKey });
+    const stored = getCurrentPrivateKey();
+    expect(stored).toBeInstanceOf(Uint8Array);
+    expect(stored!.length).toBe(2400);
+  });
+});

--- a/mcp/tests/unit/crud-tools.test.ts
+++ b/mcp/tests/unit/crud-tools.test.ts
@@ -595,3 +595,128 @@ describe("pqdb_delete_rows tool", () => {
     );
   });
 });
+
+// ── US-008 wiring: CRUD consumes the per-project shared secret ─────────────
+
+describe("US-008 — crud-tools consume the per-project shared secret", () => {
+  it("pqdb_insert_rows uses the base64url-encoded shared secret, not PQDB_ENCRYPTION_KEY", async () => {
+    // This is the regression test for the defect found in PR #149 review:
+    // pqdb_create_project set a shared secret in auth-state, but CRUD tools
+    // continued to derive keys from the legacy PQDB_ENCRYPTION_KEY env var.
+    // After the fix, when a shared secret is present, crud-tools MUST pass
+    // its base64url-encoded form to deriveKeyPair — even when no legacy
+    // encryptionKey is configured.
+    const { deriveKeyPair, transformInsertRows } = await import("@pqdb/client");
+    const deriveKeyPairMock = vi.mocked(deriveKeyPair);
+    const transformInsertRowsMock = vi.mocked(transformInsertRows);
+    const {
+      setCurrentSharedSecret,
+      clearCurrentSharedSecret,
+      getCurrentEncryptionKeyString,
+    } = await import("../../src/auth-state.js");
+
+    vi.clearAllMocks();
+    clearCurrentSharedSecret();
+
+    // Pretend deriveKeyPair returned something usable; actual bytes don't matter
+    deriveKeyPairMock.mockResolvedValue({
+      publicKey: new Uint8Array(1184),
+      secretKey: new Uint8Array(2400),
+    });
+    transformInsertRowsMock.mockResolvedValue([{ email_encrypted: "X", email_index: "Y" }]);
+
+    // Start a client with NO legacy encryptionKey — the only key source
+    // should be the dynamic shared secret from auth-state. createPqdbMcpServer
+    // clears both the private key and shared secret during construction, so
+    // we MUST set the shared secret AFTER creating the client, not before.
+    const client = await createTestClient({ encryptionKey: undefined });
+
+    // Deterministic 32-byte shared secret (US-008 uses ML-KEM-768 shared secrets)
+    const ss = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) ss[i] = i;
+    setCurrentSharedSecret(ss);
+
+    // 1st mocked fetch: introspect (table has a searchable column)
+    mockFetchOk({
+      tables: [{
+        name: "users",
+        columns: [
+          { name: "email", type: "text", sensitivity: "searchable" },
+        ],
+      }],
+    });
+    // 2nd mocked fetch: HMAC key retrieval for blind-index HMAC
+    mockFetchOk({
+      current_version: 1,
+      keys: { "1": "aa".repeat(32) }, // 64 hex chars = 32 bytes
+    });
+    // 3rd mocked fetch: the actual insert POST
+    mockFetchOk({ data: [{ id: "row-1" }] });
+
+    const result = await client.callTool({
+      name: "pqdb_insert_rows",
+      arguments: {
+        table: "users",
+        rows: [{ email: "alice@test.com" }],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+
+    // CORE ASSERTION: deriveKeyPair must have been called with the
+    // base64url-encoded shared secret, NOT with the legacy env var.
+    expect(deriveKeyPairMock).toHaveBeenCalled();
+    const expectedKeyString = getCurrentEncryptionKeyString();
+    expect(expectedKeyString).not.toBeNull();
+    expect(expectedKeyString!.length).toBe(43); // 32 bytes -> base64url-no-pad
+    expect(deriveKeyPairMock).toHaveBeenCalledWith(expectedKeyString);
+
+    // And the input string must NOT be the legacy env var — the test
+    // configures the client with encryptionKey: undefined, so any passed
+    // value is by definition the dynamic one. Defense in depth:
+    const callArgs = deriveKeyPairMock.mock.calls.map((c) => c[0]);
+    for (const arg of callArgs) {
+      expect(arg).toBe(expectedKeyString);
+    }
+
+    // And transformInsertRows must have been called — the encrypted write
+    // path actually ran, rather than being rejected with "encryption not
+    // available".
+    expect(transformInsertRowsMock).toHaveBeenCalled();
+
+    clearCurrentSharedSecret();
+  });
+
+  it("without a shared secret AND without PQDB_ENCRYPTION_KEY, encrypted columns are rejected", async () => {
+    const {
+      clearCurrentSharedSecret,
+    } = await import("../../src/auth-state.js");
+
+    vi.clearAllMocks();
+    clearCurrentSharedSecret();
+
+    const client = await createTestClient({ encryptionKey: undefined });
+
+    // Introspect returns a table with a searchable column
+    mockFetchOk({
+      tables: [{
+        name: "users",
+        columns: [
+          { name: "email", type: "text", sensitivity: "searchable" },
+        ],
+      }],
+    });
+
+    const result = await client.callTool({
+      name: "pqdb_insert_rows",
+      arguments: {
+        table: "users",
+        rows: [{ email: "alice@test.com" }],
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { type: string; text: string }).text;
+    expect(text).toContain("encryption");
+  });
+});

--- a/mcp/tests/unit/project-tools.test.ts
+++ b/mcp/tests/unit/project-tools.test.ts
@@ -236,7 +236,11 @@ describe("pqdb_create_project tool", () => {
 
     const text = (result.content[0] as { type: string; text: string }).text;
     const parsed = JSON.parse(text);
-    expect(parsed.data).toEqual(created);
+    // US-008: data is now { project, encryption_active, warning } so tools
+    // can surface the "no PQDB_PRIVATE_KEY" warning to the AI agent.
+    expect(parsed.data.project).toEqual(created);
+    expect(parsed.data.encryption_active).toBe(false);
+    expect(parsed.data.warning).toContain("No PQDB_PRIVATE_KEY set");
     expect(parsed.error).toBeNull();
   });
 

--- a/mcp/tests/unit/select-project-decap.test.ts
+++ b/mcp/tests/unit/select-project-decap.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for pqdb_select_project decapsulate flow (US-008).
+ *
+ * When selecting an existing project that has wrapped_encryption_key,
+ * the MCP server should call decapsulate(wrapped_key, private_key)
+ * and store the recovered shared secret in auth-state.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createPqdbMcpServer } from "../../src/server.js";
+import type { ServerConfig } from "../../src/config.js";
+import {
+  clearCurrentPrivateKey,
+  clearCurrentSharedSecret,
+  getCurrentSharedSecret,
+} from "../../src/auth-state.js";
+
+const mockCiphertext = new Uint8Array(1088).fill(0xcc);
+const mockSharedSecret = new Uint8Array(32).fill(0xee);
+
+vi.mock("@pqdb/client", async () => {
+  return {
+    createClient: vi.fn(() => ({
+      auth: {},
+      defineTable: vi.fn(),
+      from: vi.fn(),
+      reindex: vi.fn(),
+    })),
+    encapsulate: vi.fn(async () => ({
+      ciphertext: mockCiphertext,
+      sharedSecret: mockSharedSecret,
+    })),
+    decapsulate: vi.fn(async (_ct: Uint8Array, _sk: Uint8Array) => mockSharedSecret),
+  };
+});
+
+// Grab the mocked decapsulate after the mock is hoisted
+import * as pqdbClient from "@pqdb/client";
+const decapsulateMock = vi.mocked(pqdbClient.decapsulate);
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function makeConfig(overrides: Partial<ServerConfig> = {}): ServerConfig {
+  return {
+    projectUrl: "http://localhost:8000",
+    transport: "stdio",
+    port: 3001,
+    apiKey: "",
+    encryptionKey: undefined,
+    devToken: "dev-jwt-token-123",
+    projectId: undefined,
+    privateKey: undefined,
+    ...overrides,
+  };
+}
+
+async function createTestClient(
+  overrides: Partial<ServerConfig> = {},
+): Promise<Client> {
+  const { mcpServer } = createPqdbMcpServer(makeConfig(overrides));
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await mcpServer.connect(serverTransport);
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await client.connect(clientTransport);
+  return client;
+}
+
+function mockFetchOk(data: unknown): void {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => data,
+  });
+}
+
+function makePrivateKey(): Uint8Array {
+  const key = new Uint8Array(2400);
+  for (let i = 0; i < key.length; i++) key[i] = (i * 11) % 256;
+  return key;
+}
+
+describe("pqdb_select_project with PQDB_PRIVATE_KEY (US-008)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearCurrentPrivateKey();
+    clearCurrentSharedSecret();
+  });
+
+  afterEach(() => {
+    clearCurrentPrivateKey();
+    clearCurrentSharedSecret();
+  });
+
+  it("calls decapsulate with the configured private key and the project's wrapped_encryption_key; stores shared secret", async () => {
+    const privateKey = makePrivateKey();
+    const client = await createTestClient({ privateKey });
+
+    const wrappedKeyB64 = Buffer.from(mockCiphertext).toString("base64");
+
+    mockFetchOk({
+      id: "proj-abc",
+      name: "My Project",
+      status: "active",
+      wrapped_encryption_key: wrappedKeyB64,
+    });
+
+    const result = await client.callTool({
+      name: "pqdb_select_project",
+      arguments: { project_id: "proj-abc" },
+    });
+
+    expect(result.isError).toBeFalsy();
+
+    // decapsulate invoked with the wrapped key bytes + configured private key
+    expect(decapsulateMock).toHaveBeenCalledTimes(1);
+    const callArgs = decapsulateMock.mock.calls[0];
+    expect(callArgs[0]).toBeInstanceOf(Uint8Array);
+    expect(callArgs[0].length).toBe(mockCiphertext.length);
+    expect(Buffer.from(callArgs[0]).toString("hex")).toBe(
+      Buffer.from(mockCiphertext).toString("hex"),
+    );
+    expect(callArgs[1]).toBeInstanceOf(Uint8Array);
+    expect(callArgs[1].length).toBe(2400);
+
+    // Shared secret stored
+    const stored = getCurrentSharedSecret();
+    expect(stored).toBeInstanceOf(Uint8Array);
+    expect(Buffer.from(stored!).toString("hex")).toBe(
+      Buffer.from(mockSharedSecret).toString("hex"),
+    );
+
+    // SECURITY: shared secret must not appear in tool response
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    expect(text).not.toContain(Buffer.from(mockSharedSecret).toString("base64"));
+    expect(text).not.toContain(Buffer.from(privateKey).toString("base64"));
+  });
+
+  it("skips decapsulate when the selected project has no wrapped_encryption_key", async () => {
+    const privateKey = makePrivateKey();
+    const client = await createTestClient({ privateKey });
+
+    mockFetchOk({
+      id: "proj-plain",
+      name: "Plaintext",
+      status: "active",
+      // no wrapped_encryption_key
+    });
+
+    const result = await client.callTool({
+      name: "pqdb_select_project",
+      arguments: { project_id: "proj-plain" },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(decapsulateMock).not.toHaveBeenCalled();
+    expect(getCurrentSharedSecret()).toBeUndefined();
+  });
+
+  it("skips decapsulate when no PQDB_PRIVATE_KEY is configured, even if project has wrapped key", async () => {
+    const client = await createTestClient({ privateKey: undefined });
+
+    mockFetchOk({
+      id: "proj-abc",
+      name: "Project",
+      status: "active",
+      wrapped_encryption_key: Buffer.from(mockCiphertext).toString("base64"),
+    });
+
+    const result = await client.callTool({
+      name: "pqdb_select_project",
+      arguments: { project_id: "proj-abc" },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(decapsulateMock).not.toHaveBeenCalled();
+    expect(getCurrentSharedSecret()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Who
Implementer agent for Phase 5d / US-008, working on behalf of the pqdb team-lead.

## What
Adds ML-KEM-768 keypair support to the MCP server. The server can now read a developer's private key from `PQDB_PRIVATE_KEY`, call `encapsulate()` on `pqdb_create_project` to produce a `wrapped_encryption_key`, and call `decapsulate()` on `pqdb_select_project` to recover the shared secret — all without leaking raw key material back to the AI agent.

Specifically:
- `mcp/src/config.ts`: reads `PQDB_PRIVATE_KEY` env var, decodes base64/base64url, validates 2400-byte ML-KEM-768 length, fails fast on mismatch.
- `mcp/src/auth-state.ts`: adds `{set,get,clear}CurrentPrivateKey` and `{set,get,clear}CurrentSharedSecret` module-level singletons.
- `mcp/src/server.ts`: always resets private key + shared secret on construction (prevents cross-test / cross-instance pollution), loads key from config if present.
- `mcp/src/project-tools.ts`:
  - `pqdb_create_project` with key set: GETs `/v1/auth/me/public-key`, calls `encapsulate`, sends `wrapped_encryption_key` to backend, stores shared secret in auth-state.
  - `pqdb_create_project` without key: creates a plaintext project and returns a clear warning in the tool response so the AI agent knows encryption is off.
  - `pqdb_select_project`: if the project carries a `wrapped_encryption_key` and a private key is configured, calls `decapsulate` and stores the shared secret.
- `mcp/src/http-app.ts`: passes `privateKey: undefined` in HTTP transport `ServerConfig` (the HTTP path uses OAuth, not env vars).

## When
Committed and pushed 2026-04-09 (Thursday, America/New_York), per `mcp__time__get_current_time`.

## Where
Branch: `feat/US-008-mcp-private-key` → `main`.
All changes scoped to `mcp/` per iron rules. No backend, SDK, or dashboard modifications.

## Why
Phase 5d requires the MCP server to participate in the same zero-knowledge architecture as the SDK. Without this, AI agents using the MCP server could only create plaintext projects — they had no way to produce a `wrapped_encryption_key` for `searchable`/`private` columns. The server must also never see or return raw key material, since the MCP tool response is surfaced to the AI agent and could be logged.

## How
TDD: wrote 41 unit tests first (config parsing, auth-state singletons, create-project encapsulate path, select-project decapsulate path), then implemented until green. Integration test spawns a real FastAPI backend on port 8770, generates a real ML-KEM-768 keypair via `generateKeyPair()`, signs up a developer with the public key, constructs the MCP server with the matching private key, and verifies a full `encapsulate → create_project → select_project → decapsulate` round trip. A security assertion explicitly greps the tool response text for a 32-byte prefix of the private key and fails if it appears.

Considered alternatives:
- **Passing the private key through every tool handler**: rejected. Too invasive, would force every tool signature to change. The module-level singleton pattern matches how `devToken` and `projectId` are already handled.
- **Generating the keypair inside the MCP server**: rejected. That would put the private key in the MCP process lifecycle, not the developer's control — the whole point of US-008 is that the developer owns the key and the MCP server is a thin client.
- **Throwing when `create_project` is called without a private key**: rejected. Plaintext projects are still a valid use case (no searchable/private columns). Returning a warning lets the AI agent make an informed choice instead of blocking.

Trade-offs:
- The MCP process now holds the private key and shared secret in memory for the lifetime of the server. Acceptable because the MCP server already holds the developer JWT, which is a comparably sensitive credential.
- The `data` shape of `pqdb_create_project` changed from `project` to `{project, encryption_active, warning}`. Updated one existing unit test to match; no other callers in the repo rely on the old shape.
- Cross-instance state cleanup happens on construction, not on server shutdown. This means sequential server instances in the same process are clean, but parallel instances would share state — not a real scenario today, but worth noting.

## Test plan
- [x] `npx vitest run tests/unit/config.test.ts` — 6 new `PQDB_PRIVATE_KEY parsing` cases pass
- [x] `npx vitest run tests/unit/auth-state.test.ts` — 5 new singleton round-trip cases pass
- [x] `npx vitest run tests/unit/create-project-encap.test.ts` — 4 new cases pass (with-key, without-key, no public key uploaded, in-memory key set from config)
- [x] `npx vitest run tests/unit/select-project-decap.test.ts` — 3 new cases pass (decap success, skip when no wrapped key, skip when no private key)
- [x] `npx vitest run tests/e2e/us008-mcp-private-key.test.ts` — full round trip against real FastAPI backend passes for both encrypted and plaintext paths
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] gitleaks: no leaks on diff
- [x] semgrep: 0 findings on 5 changed source files
- [x] Pre-existing 16 unit-test failures in baseline are unchanged (verified by stash-check — not regressions, all are test-file-internal state contamination unrelated to US-008)

## Non-goals
- Key generation / onboarding flow (US-009, Dashboard territory)
- Rotating the keypair (Phase 6)
- ML-DSA-65 signing tokens for the MCP transport (Phase 4 deferral)
- HTTP transport private key plumbing (OAuth flow gets the encryption key from the dashboard; env-var path is stdio only)