### PR TITLE
[US-005a] Dashboard keypair context — load from IndexedDB

### DIFF
--- a/dashboard/e2e/keypair-context-happy-path.spec.ts
+++ b/dashboard/e2e/keypair-context-happy-path.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * E2E: keypair context happy path.
+ *
+ * Verifies that after signup (which stores the ML-KEM-768 keypair in IDB),
+ * the keypair context loads the keys from IndexedDB and:
+ *  - The missing-key banner is NOT shown
+ *  - Create Project succeeds (proves keypair context provides keys)
+ */
+import { test, expect } from "@playwright/test";
+import { signUp, testEmail } from "./helpers";
+
+test("signup stores keypair in IDB, banner hidden, Create Project works", async ({
+  page,
+}) => {
+  const email = testEmail();
+  const password = "password123";
+
+  // Sign up — this generates a keypair, stores it in IDB, and lands on /projects
+  await signUp(page, email, password);
+  await expect(page).toHaveURL(/\/projects/);
+
+  // The missing-key banner should NOT be shown — keypair loaded from IDB
+  const banner = page.locator("[role='status']").filter({
+    hasText: /encryption key not loaded/i,
+  });
+  await expect(banner).toHaveCount(0);
+
+  // Create a project to prove the keypair context is providing keys
+  await page.getByRole("button", { name: "Create Project" }).click();
+  await page.getByLabel("Project Name").fill(`e2e-keypair-${Date.now()}`);
+  await page.getByRole("button", { name: "Create" }).click();
+
+  // Navigation to the project overview proves project creation succeeded
+  await expect(page).toHaveURL(/\/projects\/[a-f0-9-]+/, { timeout: 15_000 });
+});

--- a/dashboard/src/components/change-password-dialog.tsx
+++ b/dashboard/src/components/change-password-dialog.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { api } from "~/lib/api-client";
 import { setTokens } from "~/lib/auth-store";
 import { deriveWrappingKey, unwrapKey, wrapKey } from "~/lib/envelope-crypto";
-import { useEnvelopeKeys } from "~/lib/envelope-key-context";
+import { useEnvelopeKeys } from "~/lib/keypair-context";
 import { fetchProjects } from "~/lib/projects";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";

--- a/dashboard/src/components/create-project-dialog.tsx
+++ b/dashboard/src/components/create-project-dialog.tsx
@@ -11,7 +11,7 @@ import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { createProject, type ProjectCreateResponse } from "~/lib/projects";
-import { useEnvelopeKeys, uint8ArrayToBase64 } from "~/lib/envelope-key-context";
+import { useEnvelopeKeys, uint8ArrayToBase64 } from "~/lib/keypair-context";
 import { generateEncryptionKey, wrapKey } from "~/lib/envelope-crypto";
 
 interface CreateProjectDialogProps {

--- a/dashboard/src/components/login-page.tsx
+++ b/dashboard/src/components/login-page.tsx
@@ -6,7 +6,7 @@ import { isValidEmail } from "~/lib/validation";
 import { startPasskeyAuthentication } from "~/lib/passkey";
 import { getMcpCallbackParams, handleMcpRedirect } from "~/lib/mcp-callback";
 import { deriveWrappingKey, unwrapKey } from "~/lib/envelope-crypto";
-import { useEnvelopeKeys } from "~/lib/envelope-key-context";
+import { useEnvelopeKeys } from "~/lib/keypair-context";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";

--- a/dashboard/src/components/reveal-encryption-key.tsx
+++ b/dashboard/src/components/reveal-encryption-key.tsx
@@ -9,7 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from "~/components/ui/card";
-import { useEnvelopeKeys } from "~/lib/envelope-key-context";
+import { useEnvelopeKeys } from "~/lib/keypair-context";
 
 interface RevealEncryptionKeyProps {
   projectId: string;

--- a/dashboard/src/components/signup-page.tsx
+++ b/dashboard/src/components/signup-page.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from "~/lib/navigation";
 import { isValidEmail } from "~/lib/validation";
 import { handleMcpRedirect } from "~/lib/mcp-callback";
 import { deriveWrappingKey } from "~/lib/envelope-crypto";
-import { useEnvelopeKeys } from "~/lib/envelope-key-context";
+import { useEnvelopeKeys } from "~/lib/keypair-context";
 import { saveKeypair } from "~/lib/keypair-store";
 import { RecoveryFileModal } from "~/components/recovery-file-modal";
 import { Button } from "~/components/ui/button";

--- a/dashboard/src/lib/auth-store.ts
+++ b/dashboard/src/lib/auth-store.ts
@@ -43,12 +43,27 @@ export function setTokens(
   if (options?.persist && typeof sessionStorage !== "undefined") {
     sessionStorage.setItem(SESSION_KEY, JSON.stringify(tokens));
   }
+
+  // Notify login listeners (e.g., KeypairProvider)
+  for (const cb of loginCallbacks) {
+    cb();
+  }
 }
 
-type LogoutCallback = () => void;
-const logoutCallbacks: Set<LogoutCallback> = new Set();
+type AuthCallback = () => void;
 
-export function onLogout(callback: LogoutCallback): () => void {
+const loginCallbacks: Set<AuthCallback> = new Set();
+
+export function onLogin(callback: AuthCallback): () => void {
+  loginCallbacks.add(callback);
+  return () => {
+    loginCallbacks.delete(callback);
+  };
+}
+
+const logoutCallbacks: Set<AuthCallback> = new Set();
+
+export function onLogout(callback: AuthCallback): () => void {
   logoutCallbacks.add(callback);
   return () => {
     logoutCallbacks.delete(callback);

--- a/dashboard/src/lib/auth-store.ts
+++ b/dashboard/src/lib/auth-store.ts
@@ -74,7 +74,7 @@ export function clearTokens(): void {
     }
   }
 
-  // Notify logout listeners (e.g., EnvelopeKeyProvider)
+  // Notify logout listeners (e.g., KeypairProvider)
   for (const cb of logoutCallbacks) {
     cb();
   }

--- a/dashboard/src/lib/keypair-context.tsx
+++ b/dashboard/src/lib/keypair-context.tsx
@@ -16,7 +16,7 @@ import {
   wrapKey,
   generateEncryptionKey,
 } from "./envelope-crypto";
-import { getAccessToken, onLogout } from "./auth-store";
+import { getAccessToken, onLogin, onLogout } from "./auth-store";
 import { loadKeypair } from "./keypair-store";
 
 /* ------------------------------------------------------------------ */
@@ -137,9 +137,32 @@ export function KeypairProvider({
     error: null,
   });
 
-  // Load keypair from IndexedDB on mount
+  // Track the access token reactively so the keypair loads both on mount
+  // (page refresh with existing token) AND after a fresh login/signup.
+  const [token, setToken] = React.useState<string | null>(() =>
+    getAccessToken(),
+  );
+
+  // Subscribe to auth state changes
   React.useEffect(() => {
-    const token = getAccessToken();
+    const unsubLogin = onLogin(() => setToken(getAccessToken()));
+    const unsubLogout = onLogout(() => {
+      setToken(null);
+      setKeypairState({
+        publicKey: null,
+        privateKey: null,
+        loaded: false,
+        error: null,
+      });
+    });
+    return () => {
+      unsubLogin();
+      unsubLogout();
+    };
+  }, []);
+
+  // Load keypair from IndexedDB whenever token changes
+  React.useEffect(() => {
     if (!token) return;
 
     const developerId = developerIdFromToken(token);
@@ -179,7 +202,7 @@ export function KeypairProvider({
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [token]);
 
   /* --- Legacy envelope-key state --- */
   const [wrappingKey, setWrappingKeyState] = React.useState<CryptoKey | null>(
@@ -196,18 +219,12 @@ export function KeypairProvider({
     }
   }, [encryptionKeys]);
 
-  // Clear keys on logout
+  // Clear legacy envelope keys on logout
   React.useEffect(() => {
     return onLogout(() => {
       setWrappingKeyState(null);
       setEncryptionKeys(new Map());
       clearKeysFromStorage();
-      setKeypairState({
-        publicKey: null,
-        privateKey: null,
-        loaded: false,
-        error: null,
-      });
     });
   }, []);
 

--- a/dashboard/src/lib/keypair-context.tsx
+++ b/dashboard/src/lib/keypair-context.tsx
@@ -1,9 +1,13 @@
 /**
- * EnvelopeKeyContext — React context for envelope encryption key management.
+ * KeypairContext — React context for ML-KEM-768 keypair management.
  *
- * Holds the wrapping key (derived from password via PBKDF2) and a map of
- * per-project encryption keys. When projects are loaded, wrapped blobs are
- * auto-unwrapped. Projects without a wrapped key get one auto-generated.
+ * Loads the developer's keypair from IndexedDB on mount and exposes it via
+ * useKeypair(). Also preserves the legacy envelope-key API surface so that
+ * existing consumers (create-project, reveal-encryption-key, table routes,
+ * login, signup, change-password) continue to work during the migration to
+ * full PQC encapsulate/decapsulate (US-006, US-007).
+ *
+ * Replaces envelope-key-context.tsx.
  */
 
 import * as React from "react";
@@ -13,6 +17,47 @@ import {
   generateEncryptionKey,
 } from "./envelope-crypto";
 import { getAccessToken, onLogout } from "./auth-store";
+import { loadKeypair } from "./keypair-store";
+
+/* ------------------------------------------------------------------ */
+/*  Keypair context (new PQC API)                                     */
+/* ------------------------------------------------------------------ */
+
+export interface KeypairState {
+  publicKey: Uint8Array | null;
+  privateKey: Uint8Array | null;
+  loaded: boolean;
+  error: string | null;
+}
+
+const KeypairContext = React.createContext<KeypairState>({
+  publicKey: null,
+  privateKey: null,
+  loaded: false,
+  error: null,
+});
+
+/**
+ * Decode the `sub` claim from a JWT without verifying the signature.
+ * Only used to key the IndexedDB lookup — the token is already server-issued.
+ */
+function developerIdFromToken(token: string): string | null {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) return null;
+    const payload = parts[1]!.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = payload + "=".repeat((4 - (payload.length % 4)) % 4);
+    const decoded = atob(padded);
+    const claims = JSON.parse(decoded) as { sub?: string };
+    return claims.sub ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Legacy envelope-key context (backward compat)                     */
+/* ------------------------------------------------------------------ */
 
 function base64ToUint8Array(base64: string): Uint8Array {
   const binary = atob(base64);
@@ -75,11 +120,68 @@ function clearKeysFromStorage(): void {
   sessionStorage.removeItem(ENVELOPE_KEYS_STORAGE_KEY);
 }
 
-export function EnvelopeKeyProvider({
+/* ------------------------------------------------------------------ */
+/*  Combined provider                                                 */
+/* ------------------------------------------------------------------ */
+
+export function KeypairProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  /* --- Keypair state (new) --- */
+  const [keypairState, setKeypairState] = React.useState<KeypairState>({
+    publicKey: null,
+    privateKey: null,
+    loaded: false,
+    error: null,
+  });
+
+  // Load keypair from IndexedDB on mount
+  React.useEffect(() => {
+    const token = getAccessToken();
+    if (!token) return;
+
+    const developerId = developerIdFromToken(token);
+    if (!developerId) return;
+
+    let cancelled = false;
+
+    loadKeypair(developerId)
+      .then((stored) => {
+        if (cancelled) return;
+        if (stored) {
+          setKeypairState({
+            publicKey: stored.publicKey,
+            privateKey: stored.secretKey,
+            loaded: true,
+            error: null,
+          });
+        } else {
+          setKeypairState({
+            publicKey: null,
+            privateKey: null,
+            loaded: true,
+            error: "missing",
+          });
+        }
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setKeypairState({
+          publicKey: null,
+          privateKey: null,
+          loaded: true,
+          error: "missing",
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  /* --- Legacy envelope-key state --- */
   const [wrappingKey, setWrappingKeyState] = React.useState<CryptoKey | null>(
     null,
   );
@@ -100,14 +202,18 @@ export function EnvelopeKeyProvider({
       setWrappingKeyState(null);
       setEncryptionKeys(new Map());
       clearKeysFromStorage();
+      setKeypairState({
+        publicKey: null,
+        privateKey: null,
+        loaded: false,
+        error: null,
+      });
     });
   }, []);
 
-  // Use a ref to access wrappingKey in callbacks without stale closures
   const wrappingKeyRef = React.useRef<CryptoKey | null>(null);
   wrappingKeyRef.current = wrappingKey;
 
-  // Use a ref for encryptionKeys to avoid stale closures
   const encryptionKeysRef = React.useRef<Map<string, string>>(encryptionKeys);
   encryptionKeysRef.current = encryptionKeys;
 
@@ -149,17 +255,14 @@ export function EnvelopeKeyProvider({
       const newEntries: Array<[string, string]> = [];
 
       for (const project of projects) {
-        // Skip projects already in the map
         if (currentKeys.has(project.id)) continue;
 
         try {
           if (project.wrapped_encryption_key) {
-            // Unwrap existing wrapped key
             const blob = base64ToUint8Array(project.wrapped_encryption_key);
             const decryptedKey = await unwrapKey(blob, wk);
             newEntries.push([project.id, decryptedKey]);
           } else {
-            // Auto-generate a key, wrap it, PATCH to server
             const encKey = generateEncryptionKey();
             const wrappedBlob = await wrapKey(encKey, wk);
             const wrappedBase64 = uint8ArrayToBase64(wrappedBlob);
@@ -233,7 +336,7 @@ export function EnvelopeKeyProvider({
     };
   }, [wrappingKey, unwrapProjectKeys]);
 
-  const value = React.useMemo(
+  const envelopeValue = React.useMemo(
     () => ({
       wrappingKey,
       encryptionKeys,
@@ -255,12 +358,27 @@ export function EnvelopeKeyProvider({
   );
 
   return (
-    <EnvelopeKeyContext.Provider value={value}>
-      {children}
-    </EnvelopeKeyContext.Provider>
+    <KeypairContext.Provider value={keypairState}>
+      <EnvelopeKeyContext.Provider value={envelopeValue}>
+        {children}
+      </EnvelopeKeyContext.Provider>
+    </KeypairContext.Provider>
   );
 }
 
+/* ------------------------------------------------------------------ */
+/*  Hooks                                                             */
+/* ------------------------------------------------------------------ */
+
+/** New PQC keypair hook: {publicKey, privateKey, loaded, error}. */
+export function useKeypair(): KeypairState {
+  return React.useContext(KeypairContext);
+}
+
+/** Legacy envelope-key hook — backward compat for existing consumers. */
 export function useEnvelopeKeys(): EnvelopeKeyState {
   return React.useContext(EnvelopeKeyContext);
 }
+
+// Re-export EnvelopeKeyProvider as an alias so __root.tsx migration is clear
+export { KeypairProvider as EnvelopeKeyProvider };

--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -7,10 +7,23 @@ import {
 } from "@tanstack/react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "~/lib/theme";
-import { EnvelopeKeyProvider } from "~/lib/envelope-key-context";
+import { KeypairProvider, useKeypair } from "~/lib/keypair-context";
 import { SidebarNav } from "~/components/sidebar-nav";
 import { TopBar } from "~/components/top-bar";
 import appCss from "~/styles/app.css?url";
+
+function KeypairBanner() {
+  const { error } = useKeypair();
+  if (error !== "missing") return null;
+  return (
+    <div
+      role="status"
+      className="bg-yellow-900/30 border-b border-yellow-700/50 px-4 py-2 text-sm text-yellow-200"
+    >
+      Encryption key not loaded. Keypair recovery coming soon.
+    </div>
+  );
+}
 
 const AUTH_ROUTES = ["/login", "/signup"];
 
@@ -42,7 +55,7 @@ function RootComponent() {
       </head>
       <body>
         <QueryClientProvider client={queryClient}>
-          <EnvelopeKeyProvider>
+          <KeypairProvider>
             <ThemeProvider>
               {isAuthRoute ? (
                 <Outlet />
@@ -51,6 +64,7 @@ function RootComponent() {
                   <SidebarNav />
                   <div className="flex flex-1 flex-col overflow-hidden">
                     <TopBar />
+                    <KeypairBanner />
                     <main className="flex-1 overflow-auto p-6">
                       <Outlet />
                     </main>
@@ -58,7 +72,7 @@ function RootComponent() {
                 </div>
               )}
             </ThemeProvider>
-          </EnvelopeKeyProvider>
+          </KeypairProvider>
         </QueryClientProvider>
         <Scripts />
       </body>

--- a/dashboard/src/routes/projects/$projectId/tables/$tableName.tsx
+++ b/dashboard/src/routes/projects/$projectId/tables/$tableName.tsx
@@ -5,7 +5,7 @@ import { AuthGuard } from "~/components/auth-guard";
 import { TableDataViewer } from "~/components/table-data-viewer";
 import { Skeleton } from "~/components/ui/skeleton";
 import { EncryptionProvider, useEncryption } from "~/lib/encryption-context";
-import { useEnvelopeKeys } from "~/lib/envelope-key-context";
+import { useEnvelopeKeys } from "~/lib/keypair-context";
 import { ProjectProvider, useProjectContext } from "~/lib/project-context";
 
 export const Route = createFileRoute(

--- a/dashboard/src/routes/projects/$projectId/tables/index.tsx
+++ b/dashboard/src/routes/projects/$projectId/tables/index.tsx
@@ -4,7 +4,7 @@ import { AuthGuard } from "~/components/auth-guard";
 import { TableListPage } from "~/components/table-list-page";
 import { Skeleton } from "~/components/ui/skeleton";
 import { EncryptionProvider, useEncryption } from "~/lib/encryption-context";
-import { useEnvelopeKeys } from "~/lib/envelope-key-context";
+import { useEnvelopeKeys } from "~/lib/keypair-context";
 import { ProjectProvider, useProjectContext } from "~/lib/project-context";
 
 export const Route = createFileRoute("/projects/$projectId/tables/")({

--- a/dashboard/tests/unit/change-password-dialog.test.tsx
+++ b/dashboard/tests/unit/change-password-dialog.test.tsx
@@ -35,7 +35,7 @@ vi.mock("~/lib/projects", () => ({
   fetchProjects: mockFetchProjects,
 }));
 
-vi.mock("~/lib/envelope-key-context", () => ({
+vi.mock("~/lib/keypair-context", () => ({
   useEnvelopeKeys: () => ({
     setWrappingKey: mockSetWrappingKey,
     encryptionKeys: new Map(),

--- a/dashboard/tests/unit/create-project-dialog.test.tsx
+++ b/dashboard/tests/unit/create-project-dialog.test.tsx
@@ -17,7 +17,7 @@ const { mockUseEnvelopeKeys, mockGenerateEncryptionKey, mockWrapKey } =
     mockWrapKey: vi.fn(),
   }));
 
-vi.mock("~/lib/envelope-key-context", () => ({
+vi.mock("~/lib/keypair-context", () => ({
   useEnvelopeKeys: mockUseEnvelopeKeys,
   uint8ArrayToBase64: (bytes: Uint8Array) =>
     btoa(String.fromCharCode(...bytes)),

--- a/dashboard/tests/unit/envelope-key-context.test.tsx
+++ b/dashboard/tests/unit/envelope-key-context.test.tsx
@@ -2,9 +2,9 @@ import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { render, act, renderHook } from "@testing-library/react";
 import * as React from "react";
 import {
-  EnvelopeKeyProvider,
+  KeypairProvider,
   useEnvelopeKeys,
-} from "~/lib/envelope-key-context";
+} from "~/lib/keypair-context";
 import * as envelopeCrypto from "~/lib/envelope-crypto";
 
 // Mock envelope-crypto module
@@ -12,6 +12,11 @@ vi.mock("~/lib/envelope-crypto", () => ({
   unwrapKey: vi.fn(),
   wrapKey: vi.fn(),
   generateEncryptionKey: vi.fn(),
+}));
+
+// Mock keypair-store (KeypairProvider calls loadKeypair on mount)
+vi.mock("~/lib/keypair-store", () => ({
+  loadKeypair: vi.fn().mockResolvedValue(null),
 }));
 
 // Mock global fetch
@@ -31,7 +36,7 @@ describe("EnvelopeKeyContext", () => {
 
   it("provides default state with null wrapping key and empty encryption keys", () => {
     const { result } = renderHook(() => useEnvelopeKeys(), {
-      wrapper: EnvelopeKeyProvider,
+      wrapper: KeypairProvider,
     });
 
     expect(result.current.wrappingKey).toBeNull();
@@ -42,7 +47,7 @@ describe("EnvelopeKeyContext", () => {
     const fakeKey = {} as CryptoKey;
 
     const { result } = renderHook(() => useEnvelopeKeys(), {
-      wrapper: EnvelopeKeyProvider,
+      wrapper: KeypairProvider,
     });
 
     await act(async () => {
@@ -56,7 +61,7 @@ describe("EnvelopeKeyContext", () => {
     const fakeKey = {} as CryptoKey;
 
     const { result } = renderHook(() => useEnvelopeKeys(), {
-      wrapper: EnvelopeKeyProvider,
+      wrapper: KeypairProvider,
     });
 
     await act(async () => {
@@ -77,7 +82,7 @@ describe("EnvelopeKeyContext", () => {
 
   it("getEncryptionKey returns null for unknown project", () => {
     const { result } = renderHook(() => useEnvelopeKeys(), {
-      wrapper: EnvelopeKeyProvider,
+      wrapper: KeypairProvider,
     });
 
     expect(result.current.getEncryptionKey("unknown")).toBeNull();
@@ -85,7 +90,7 @@ describe("EnvelopeKeyContext", () => {
 
   it("addEncryptionKey stores and retrieves a key for a project", async () => {
     const { result } = renderHook(() => useEnvelopeKeys(), {
-      wrapper: EnvelopeKeyProvider,
+      wrapper: KeypairProvider,
     });
 
     await act(async () => {
@@ -100,7 +105,7 @@ describe("EnvelopeKeyContext", () => {
     (envelopeCrypto.unwrapKey as Mock).mockResolvedValue("decrypted-key-1");
 
     const { result } = renderHook(() => useEnvelopeKeys(), {
-      wrapper: EnvelopeKeyProvider,
+      wrapper: KeypairProvider,
     });
 
     await act(async () => {
@@ -124,7 +129,7 @@ describe("EnvelopeKeyContext", () => {
     (envelopeCrypto.unwrapKey as Mock).mockResolvedValue("decrypted-key-2");
 
     const { result } = renderHook(() => useEnvelopeKeys(), {
-      wrapper: EnvelopeKeyProvider,
+      wrapper: KeypairProvider,
     });
 
     await act(async () => {
@@ -161,7 +166,7 @@ describe("EnvelopeKeyContext", () => {
     });
 
     const { result } = renderHook(() => useEnvelopeKeys(), {
-      wrapper: EnvelopeKeyProvider,
+      wrapper: KeypairProvider,
     });
 
     await act(async () => {
@@ -198,7 +203,7 @@ describe("EnvelopeKeyContext", () => {
       .mockResolvedValueOnce("decrypted-key-2");
 
     const { result } = renderHook(() => useEnvelopeKeys(), {
-      wrapper: EnvelopeKeyProvider,
+      wrapper: KeypairProvider,
     });
 
     await act(async () => {
@@ -222,7 +227,7 @@ describe("EnvelopeKeyContext", () => {
 
   it("unwrapProjectKeys does nothing without a wrapping key", async () => {
     const { result } = renderHook(() => useEnvelopeKeys(), {
-      wrapper: EnvelopeKeyProvider,
+      wrapper: KeypairProvider,
     });
 
     const projects = [

--- a/dashboard/tests/unit/keypair-context.test.tsx
+++ b/dashboard/tests/unit/keypair-context.test.tsx
@@ -5,10 +5,13 @@ import "fake-indexeddb/auto";
 import { IDBFactory } from "fake-indexeddb";
 
 // Hoisted mocks — must be declared before module imports
-const { mockLoadKeypair, mockGetAccessToken } = vi.hoisted(() => ({
-  mockLoadKeypair: vi.fn(),
-  mockGetAccessToken: vi.fn(),
-}));
+const { mockLoadKeypair, mockGetAccessToken, loginCallbacks, logoutCallbacks } =
+  vi.hoisted(() => ({
+    mockLoadKeypair: vi.fn(),
+    mockGetAccessToken: vi.fn(),
+    loginCallbacks: new Set<() => void>(),
+    logoutCallbacks: new Set<() => void>(),
+  }));
 
 vi.mock("~/lib/keypair-store", () => ({
   loadKeypair: mockLoadKeypair,
@@ -16,7 +19,18 @@ vi.mock("~/lib/keypair-store", () => ({
 
 vi.mock("~/lib/auth-store", () => ({
   getAccessToken: mockGetAccessToken,
-  onLogout: vi.fn(() => () => {}),
+  onLogin: vi.fn((cb: () => void) => {
+    loginCallbacks.add(cb);
+    return () => {
+      loginCallbacks.delete(cb);
+    };
+  }),
+  onLogout: vi.fn((cb: () => void) => {
+    logoutCallbacks.add(cb);
+    return () => {
+      logoutCallbacks.delete(cb);
+    };
+  }),
 }));
 
 // Mock envelope-crypto (needed by legacy envelope key functionality)
@@ -46,6 +60,8 @@ describe("keypair-context", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetch.mockReset();
+    loginCallbacks.clear();
+    logoutCallbacks.clear();
     globalThis.indexedDB = new IDBFactory();
     sessionStorage.clear();
   });
@@ -135,5 +151,94 @@ describe("keypair-context", () => {
     expect(result.current.publicKey).toBeNull();
     expect(result.current.privateKey).toBeNull();
     expect(result.current.error).toBe("missing");
+  });
+
+  it("loads keypair when token becomes available after initial mount (race condition fix)", async () => {
+    const devId = "44444444-4444-4444-4444-444444444444";
+    const storedKeypair = {
+      publicKey: new Uint8Array([10, 20, 30]),
+      secretKey: new Uint8Array([40, 50, 60]),
+    };
+
+    // Start with no token — simulates provider mounting before login
+    mockGetAccessToken.mockReturnValue(null);
+    mockFetch.mockResolvedValue({ ok: false });
+
+    const { result } = renderHook(() => useKeypair(), {
+      wrapper: KeypairProvider,
+    });
+
+    // Initially: loaded=false, no keypair
+    expect(result.current.loaded).toBe(false);
+    expect(result.current.publicKey).toBeNull();
+    expect(mockLoadKeypair).not.toHaveBeenCalled();
+
+    // Simulate login: token becomes available, then fire onLogin callbacks
+    mockGetAccessToken.mockReturnValue(fakeAccessToken(devId));
+    mockLoadKeypair.mockResolvedValue(storedKeypair);
+
+    act(() => {
+      for (const cb of loginCallbacks) cb();
+    });
+
+    // Wait for effect to re-run and load the keypair
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.publicKey).toEqual(storedKeypair.publicKey);
+    expect(result.current.privateKey).toEqual(storedKeypair.secretKey);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("resets keypair state on logout and reloads on re-login", async () => {
+    const devId = "55555555-5555-5555-5555-555555555555";
+    const storedKeypair = {
+      publicKey: new Uint8Array([1, 2, 3]),
+      secretKey: new Uint8Array([4, 5, 6]),
+    };
+
+    // Start logged in
+    mockGetAccessToken.mockReturnValue(fakeAccessToken(devId));
+    mockLoadKeypair.mockResolvedValue(storedKeypair);
+    mockFetch.mockResolvedValue({ ok: false });
+
+    const { result } = renderHook(() => useKeypair(), {
+      wrapper: KeypairProvider,
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+    expect(result.current.publicKey).toEqual(storedKeypair.publicKey);
+
+    // Simulate logout
+    mockGetAccessToken.mockReturnValue(null);
+    act(() => {
+      for (const cb of logoutCallbacks) cb();
+    });
+
+    expect(result.current.loaded).toBe(false);
+    expect(result.current.publicKey).toBeNull();
+    expect(result.current.privateKey).toBeNull();
+
+    // Simulate re-login
+    const devId2 = "66666666-6666-6666-6666-666666666666";
+    const keypair2 = {
+      publicKey: new Uint8Array([7, 8, 9]),
+      secretKey: new Uint8Array([10, 11, 12]),
+    };
+    mockGetAccessToken.mockReturnValue(fakeAccessToken(devId2));
+    mockLoadKeypair.mockResolvedValue(keypair2);
+
+    act(() => {
+      for (const cb of loginCallbacks) cb();
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+    expect(result.current.publicKey).toEqual(keypair2.publicKey);
+    expect(result.current.privateKey).toEqual(keypair2.secretKey);
   });
 });

--- a/dashboard/tests/unit/keypair-context.test.tsx
+++ b/dashboard/tests/unit/keypair-context.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import * as React from "react";
+import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
+
+// Hoisted mocks — must be declared before module imports
+const { mockLoadKeypair, mockGetAccessToken } = vi.hoisted(() => ({
+  mockLoadKeypair: vi.fn(),
+  mockGetAccessToken: vi.fn(),
+}));
+
+vi.mock("~/lib/keypair-store", () => ({
+  loadKeypair: mockLoadKeypair,
+}));
+
+vi.mock("~/lib/auth-store", () => ({
+  getAccessToken: mockGetAccessToken,
+  onLogout: vi.fn(() => () => {}),
+}));
+
+// Mock envelope-crypto (needed by legacy envelope key functionality)
+vi.mock("~/lib/envelope-crypto", () => ({
+  unwrapKey: vi.fn(),
+  wrapKey: vi.fn(),
+  generateEncryptionKey: vi.fn(),
+}));
+
+// Mock global fetch (used by legacy envelope key auto-unwrap)
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { KeypairProvider, useKeypair } from "~/lib/keypair-context";
+
+/**
+ * Build a fake JWT access token with the given `sub` claim.
+ * The signature is bogus but the payload is valid base64url JSON.
+ */
+function fakeAccessToken(sub: string): string {
+  const header = btoa(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
+  const payload = btoa(JSON.stringify({ sub, exp: 9999999999 }));
+  return `${header}.${payload}.fake-sig`;
+}
+
+describe("keypair-context", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+    globalThis.indexedDB = new IDBFactory();
+    sessionStorage.clear();
+  });
+
+  it("loads keypair from IndexedDB and returns {publicKey, privateKey, loaded: true}", async () => {
+    const devId = "11111111-1111-1111-1111-111111111111";
+    const storedKeypair = {
+      publicKey: new Uint8Array([1, 2, 3, 4]),
+      secretKey: new Uint8Array([5, 6, 7, 8]),
+    };
+
+    mockGetAccessToken.mockReturnValue(fakeAccessToken(devId));
+    mockLoadKeypair.mockResolvedValue(storedKeypair);
+    // Prevent auto-unwrap fetch from interfering
+    mockFetch.mockResolvedValue({ ok: false });
+
+    const { result } = renderHook(() => useKeypair(), {
+      wrapper: KeypairProvider,
+    });
+
+    // Initially loaded is false
+    expect(result.current.loaded).toBe(false);
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.publicKey).toEqual(storedKeypair.publicKey);
+    expect(result.current.privateKey).toEqual(storedKeypair.secretKey);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns {loaded: true, error: 'missing'} when IndexedDB has no keypair", async () => {
+    const devId = "22222222-2222-2222-2222-222222222222";
+
+    mockGetAccessToken.mockReturnValue(fakeAccessToken(devId));
+    mockLoadKeypair.mockResolvedValue(null);
+    mockFetch.mockResolvedValue({ ok: false });
+
+    const { result } = renderHook(() => useKeypair(), {
+      wrapper: KeypairProvider,
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.publicKey).toBeNull();
+    expect(result.current.privateKey).toBeNull();
+    expect(result.current.error).toBe("missing");
+  });
+
+  it("does not attempt to load when no access token is present", async () => {
+    mockGetAccessToken.mockReturnValue(null);
+    mockFetch.mockResolvedValue({ ok: false });
+
+    const { result } = renderHook(() => useKeypair(), {
+      wrapper: KeypairProvider,
+    });
+
+    // Should remain in initial state — no token means no developer id
+    // Give it a tick to settle
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(mockLoadKeypair).not.toHaveBeenCalled();
+    expect(result.current.loaded).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("handles IndexedDB errors gracefully by setting error", async () => {
+    const devId = "33333333-3333-3333-3333-333333333333";
+
+    mockGetAccessToken.mockReturnValue(fakeAccessToken(devId));
+    mockLoadKeypair.mockRejectedValue(new Error("IDB quota exceeded"));
+    mockFetch.mockResolvedValue({ ok: false });
+
+    const { result } = renderHook(() => useKeypair(), {
+      wrapper: KeypairProvider,
+    });
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.publicKey).toBeNull();
+    expect(result.current.privateKey).toBeNull();
+    expect(result.current.error).toBe("missing");
+  });
+});

--- a/dashboard/tests/unit/reveal-encryption-key.test.tsx
+++ b/dashboard/tests/unit/reveal-encryption-key.test.tsx
@@ -7,7 +7,7 @@ const { mockGetEncryptionKey } = vi.hoisted(() => ({
   mockGetEncryptionKey: vi.fn(),
 }));
 
-vi.mock("~/lib/envelope-key-context", () => ({
+vi.mock("~/lib/keypair-context", () => ({
   useEnvelopeKeys: () => ({
     getEncryptionKey: mockGetEncryptionKey,
   }),


### PR DESCRIPTION
## Who
Isaac Quintero + Claude Opus 4.6 (pair-programming)

## What
- New `keypair-context.tsx` replaces `envelope-key-context.tsx`
- `KeypairProvider` loads developer ML-KEM-768 keypair from IndexedDB on mount via `loadKeypair(developerId)` and exposes it through `useKeypair()` returning `{publicKey, privateKey, loaded, error}`
- All 8 consumers of `envelope-key-context` migrated to import from `keypair-context`
- Legacy `useEnvelopeKeys()` hook preserved for backward compat until US-006/US-007 complete full PQC migration
- Placeholder banner ("Encryption key not loaded. Keypair recovery coming soon.") renders in dashboard layout when `error=missing`
- Unit tests for happy path (keypair found) and missing keypair scenarios

## When
2026-04-10

## Where
- `dashboard/src/lib/keypair-context.tsx` (new, replaces `envelope-key-context.tsx`)
- `dashboard/src/lib/envelope-key-context.tsx` (deleted)
- `dashboard/src/routes/__root.tsx` (provider swap + banner component)
- `dashboard/src/components/{login,signup,change-password,create-project,reveal-encryption-key}` (import migration)
- `dashboard/src/routes/projects/$projectId/tables/{index,$tableName}.tsx` (import migration)
- `dashboard/tests/unit/{keypair-context,envelope-key-context,create-project-dialog,change-password-dialog,reveal-encryption-key}.test.tsx` (new + updated)

## Why
The dashboard needs to auto-load the developer ML-KEM-768 keypair from IndexedDB on login so downstream components (Create Project, table data viewer) can use it for PQC encapsulate/decapsulate without password prompts. US-004 already stores the keypair in IndexedDB during signup; this story makes that keypair available via React context for the rest of the app. The placeholder banner for error=missing communicates the state until US-005b adds the recovery modal.

## How
- `KeypairProvider` extracts the developer ID from the JWT access token (sub claim), calls `loadKeypair(developerId)` from `keypair-store.ts`, and sets context state accordingly
- Legacy envelope-key functionality (wrapping key, per-project encryption keys, auto-unwrap) preserved inside the same provider via a second nested context, allowing existing consumers to work unchanged during transition
- `envelope-key-context.tsx` deleted; all imports point to `keypair-context.tsx`
- **Considered:** Keep `envelope-key-context.tsx` alongside new `keypair-context.tsx` with separate providers -- rejected, leads to dual provider confusion
- **Chosen:** Merge both into single `keypair-context.tsx` with dual hooks -- single provider, backward compat preserved, clean migration path
- **Trade-offs:** `keypair-context.tsx` is larger because it carries legacy envelope key logic; cleaned up when US-006/007 complete

## Test plan
- [x] Unit test: context loads from IndexedDB mock, returns `{publicKey, privateKey, loaded: true}` on happy path
- [x] Unit test: context with empty IndexedDB returns `{loaded: true, error: missing}`
- [x] Unit test: no crash when access token is absent
- [x] Unit test: handles IndexedDB errors gracefully
- [x] All existing envelope-key-context tests pass with updated imports (64/67 test files pass, 3 pre-existing failures on main)
- [x] Typecheck passes (`tsc --noEmit` -- only pre-existing `@pqdb/client` warning)
- [x] Production build succeeds
- [x] gitleaks: no leaks found
- [ ] Verify in browser: fresh login with keypair in IndexedDB loads it transparently
- [ ] CI passes

## Non-goals
- Recovery modal for missing keypair (US-005b)
- Create Project using encapsulate instead of envelope wrapping (US-006)
- Project-load using decapsulate instead of envelope unwrapping (US-007)
- Deletion of `envelope-crypto.ts` (US-006)

Generated with [Claude Code](https://claude.com/claude-code)