### PR TITLE
feat(US-006): create-project uses ML-KEM encapsulate

### DIFF
--- a/dashboard/src/components/create-project-dialog.tsx
+++ b/dashboard/src/components/create-project-dialog.tsx
@@ -11,8 +11,8 @@ import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { createProject, type ProjectCreateResponse } from "~/lib/projects";
-import { useEnvelopeKeys, uint8ArrayToBase64 } from "~/lib/keypair-context";
-import { generateEncryptionKey, wrapKey } from "~/lib/envelope-crypto";
+import { useKeypair, useEnvelopeKeys, uint8ArrayToBase64 } from "~/lib/keypair-context";
+import { encapsulate } from "@pqdb/client";
 
 interface CreateProjectDialogProps {
   open: boolean;
@@ -28,7 +28,8 @@ export function CreateProjectDialog({
   const [name, setName] = React.useState("");
   const [error, setError] = React.useState<string | null>(null);
   const [loading, setLoading] = React.useState(false);
-  const { wrappingKey, addEncryptionKey } = useEnvelopeKeys();
+  const { publicKey } = useKeypair();
+  const { setProjectEncryptionKey } = useEnvelopeKeys();
 
   function resetForm() {
     setName("");
@@ -49,18 +50,18 @@ export function CreateProjectDialog({
 
     try {
       let wrappedEncryptionKey: string | undefined;
-      let encryptionKey: string | undefined;
+      let sharedSecret: Uint8Array | undefined;
 
-      if (wrappingKey) {
-        encryptionKey = generateEncryptionKey();
-        const wrappedBlob = await wrapKey(encryptionKey, wrappingKey);
-        wrappedEncryptionKey = uint8ArrayToBase64(wrappedBlob);
+      if (publicKey) {
+        const result = await encapsulate(publicKey);
+        sharedSecret = result.sharedSecret;
+        wrappedEncryptionKey = uint8ArrayToBase64(result.ciphertext);
       }
 
       const project = await createProject(name.trim(), "us-east-1", wrappedEncryptionKey);
 
-      if (wrappingKey && encryptionKey) {
-        addEncryptionKey(project.id, encryptionKey);
+      if (sharedSecret) {
+        setProjectEncryptionKey(project.id, sharedSecret);
       }
 
       resetForm();

--- a/dashboard/src/lib/keypair-context.tsx
+++ b/dashboard/src/lib/keypair-context.tsx
@@ -79,6 +79,7 @@ export interface EnvelopeKeyState {
   clearKeys: () => void;
   getEncryptionKey: (projectId: string) => string | null;
   addEncryptionKey: (projectId: string, key: string) => void;
+  setProjectEncryptionKey: (projectId: string, sharedSecret: Uint8Array) => void;
   unwrapProjectKeys: (
     projects: Array<{ id: string; wrapped_encryption_key: string | null }>,
   ) => Promise<void>;
@@ -91,6 +92,7 @@ const EnvelopeKeyContext = React.createContext<EnvelopeKeyState>({
   clearKeys: () => {},
   getEncryptionKey: () => null,
   addEncryptionKey: () => {},
+  setProjectEncryptionKey: () => {},
   unwrapProjectKeys: async () => {},
 });
 
@@ -261,6 +263,18 @@ export function KeypairProvider({
     [],
   );
 
+  const setProjectEncryptionKey = React.useCallback(
+    (projectId: string, sharedSecret: Uint8Array) => {
+      const base64 = uint8ArrayToBase64(sharedSecret);
+      setEncryptionKeys((prev) => {
+        const next = new Map(prev);
+        next.set(projectId, base64);
+        return next;
+      });
+    },
+    [],
+  );
+
   const unwrapProjectKeys = React.useCallback(
     async (
       projects: Array<{ id: string; wrapped_encryption_key: string | null }>,
@@ -361,6 +375,7 @@ export function KeypairProvider({
       clearKeys,
       getEncryptionKey,
       addEncryptionKey,
+      setProjectEncryptionKey,
       unwrapProjectKeys,
     }),
     [
@@ -370,6 +385,7 @@ export function KeypairProvider({
       clearKeys,
       getEncryptionKey,
       addEncryptionKey,
+      setProjectEncryptionKey,
       unwrapProjectKeys,
     ],
   );

--- a/dashboard/tests/unit/create-project-dialog.test.tsx
+++ b/dashboard/tests/unit/create-project-dialog.test.tsx
@@ -10,27 +10,43 @@ vi.mock("~/lib/projects", () => ({
   createProject: mockCreateProject,
 }));
 
-const { mockUseEnvelopeKeys, mockGenerateEncryptionKey, mockWrapKey } =
-  vi.hoisted(() => ({
+const { mockUseKeypair, mockUseEnvelopeKeys, mockEncapsulate } = vi.hoisted(
+  () => ({
+    mockUseKeypair: vi.fn(),
     mockUseEnvelopeKeys: vi.fn(),
-    mockGenerateEncryptionKey: vi.fn(),
-    mockWrapKey: vi.fn(),
-  }));
+    mockEncapsulate: vi.fn(),
+  }),
+);
 
 vi.mock("~/lib/keypair-context", () => ({
+  useKeypair: mockUseKeypair,
   useEnvelopeKeys: mockUseEnvelopeKeys,
   uint8ArrayToBase64: (bytes: Uint8Array) =>
     btoa(String.fromCharCode(...bytes)),
 }));
 
-vi.mock("~/lib/envelope-crypto", () => ({
-  generateEncryptionKey: mockGenerateEncryptionKey,
-  wrapKey: mockWrapKey,
+vi.mock("@pqdb/client", () => ({
+  encapsulate: mockEncapsulate,
 }));
 
 import { CreateProjectDialog } from "~/components/create-project-dialog";
 
-const fakeWrappingKey = {} as CryptoKey;
+function setupKeypair(
+  overrides: Partial<{
+    publicKey: Uint8Array | null;
+    privateKey: Uint8Array | null;
+    loaded: boolean;
+    error: string | null;
+  }> = {},
+) {
+  const defaults = {
+    publicKey: null,
+    privateKey: null,
+    loaded: true,
+    error: null,
+  };
+  mockUseKeypair.mockReturnValue({ ...defaults, ...overrides });
+}
 
 function setupEnvelopeKeys(overrides: Record<string, unknown> = {}) {
   const defaults = {
@@ -40,11 +56,17 @@ function setupEnvelopeKeys(overrides: Record<string, unknown> = {}) {
     clearKeys: vi.fn(),
     getEncryptionKey: vi.fn(() => null),
     addEncryptionKey: vi.fn(),
+    setProjectEncryptionKey: vi.fn(),
     unwrapProjectKeys: vi.fn(),
   };
   mockUseEnvelopeKeys.mockReturnValue({ ...defaults, ...overrides });
   return { ...defaults, ...overrides };
 }
+
+const fakePublicKey = new Uint8Array(1184); // ML-KEM-768 public key is 1184 bytes
+const fakeCiphertext = new Uint8Array([10, 20, 30, 40, 50]);
+const fakeSharedSecret = new Uint8Array(32); // 32-byte shared secret
+fakeSharedSecret.fill(0xab);
 
 const createdProject = {
   id: "new-id",
@@ -73,6 +95,7 @@ describe("CreateProjectDialog", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    setupKeypair();
     setupEnvelopeKeys();
   });
 
@@ -103,107 +126,65 @@ describe("CreateProjectDialog", () => {
     expect(mockCreateProject).not.toHaveBeenCalled();
   });
 
-  it("calls createProject without wrappedEncryptionKey when no wrapping key (OAuth)", async () => {
+  it("calls encapsulate(publicKey), POSTs base64 ciphertext, stores sharedSecret in context", async () => {
     const user = userEvent.setup();
-    setupEnvelopeKeys({ wrappingKey: null });
+    const mockSetProjectEncryptionKey = vi.fn();
+    setupKeypair({ publicKey: fakePublicKey });
+    setupEnvelopeKeys({
+      setProjectEncryptionKey: mockSetProjectEncryptionKey,
+    });
+
+    mockEncapsulate.mockResolvedValueOnce({
+      ciphertext: fakeCiphertext,
+      sharedSecret: fakeSharedSecret,
+    });
+    mockCreateProject.mockResolvedValueOnce({
+      ...createdProject,
+      id: "proj-encap",
+    });
+
+    render(<CreateProjectDialog {...defaultProps} />);
+
+    await user.type(screen.getByLabelText(/project name/i), "PQC Project");
+    await user.click(screen.getByRole("button", { name: /^create$/i }));
+
+    await waitFor(() => {
+      // Verify encapsulate was called with the public key
+      expect(mockEncapsulate).toHaveBeenCalledWith(fakePublicKey);
+    });
+
+    // Verify createProject was called with base64-encoded ciphertext
+    const wrappedKeyArg = mockCreateProject.mock.calls[0][2];
+    expect(typeof wrappedKeyArg).toBe("string");
+    // base64 of fakeCiphertext [10, 20, 30, 40, 50]
+    const expectedBase64 = btoa(String.fromCharCode(...fakeCiphertext));
+    expect(wrappedKeyArg).toBe(expectedBase64);
+
+    // Verify shared secret was stored in context
+    expect(mockSetProjectEncryptionKey).toHaveBeenCalledWith(
+      "proj-encap",
+      fakeSharedSecret,
+    );
+  });
+
+  it("does not call encapsulate when publicKey is null (keypair not loaded)", async () => {
+    const user = userEvent.setup();
+    setupKeypair({ publicKey: null });
     mockCreateProject.mockResolvedValueOnce(createdProject);
 
     render(<CreateProjectDialog {...defaultProps} />);
 
-    await user.type(screen.getByLabelText(/project name/i), "New Project");
+    await user.type(screen.getByLabelText(/project name/i), "No Key Project");
     await user.click(screen.getByRole("button", { name: /^create$/i }));
 
     await waitFor(() => {
       expect(mockCreateProject).toHaveBeenCalledWith(
-        "New Project",
+        "No Key Project",
         "us-east-1",
         undefined,
       );
     });
-    expect(mockGenerateEncryptionKey).not.toHaveBeenCalled();
-    expect(mockWrapKey).not.toHaveBeenCalled();
-  });
-
-  it("generates and wraps encryption key when wrapping key is available", async () => {
-    const user = userEvent.setup();
-    const mockAddEncryptionKey = vi.fn();
-    setupEnvelopeKeys({
-      wrappingKey: fakeWrappingKey,
-      addEncryptionKey: mockAddEncryptionKey,
-    });
-
-    const fakeEncKey = "fake-encryption-key-base64url";
-    const fakeWrappedBlob = new Uint8Array([1, 2, 3, 4, 5]);
-    mockGenerateEncryptionKey.mockReturnValue(fakeEncKey);
-    mockWrapKey.mockResolvedValue(fakeWrappedBlob);
-    mockCreateProject.mockResolvedValueOnce({
-      ...createdProject,
-      id: "proj-123",
-    });
-
-    render(<CreateProjectDialog {...defaultProps} />);
-
-    await user.type(screen.getByLabelText(/project name/i), "New Project");
-    await user.click(screen.getByRole("button", { name: /^create$/i }));
-
-    await waitFor(() => {
-      expect(mockGenerateEncryptionKey).toHaveBeenCalledOnce();
-      expect(mockWrapKey).toHaveBeenCalledWith(fakeEncKey, fakeWrappingKey);
-    });
-
-    // Verify createProject was called with the base64 wrapped key
-    const wrappedKeyArg = mockCreateProject.mock.calls[0][2];
-    expect(typeof wrappedKeyArg).toBe("string");
-    expect(wrappedKeyArg.length).toBeGreaterThan(0);
-  });
-
-  it("stores encryption key in context after successful project creation", async () => {
-    const user = userEvent.setup();
-    const mockAddEncryptionKey = vi.fn();
-    setupEnvelopeKeys({
-      wrappingKey: fakeWrappingKey,
-      addEncryptionKey: mockAddEncryptionKey,
-    });
-
-    const fakeEncKey = "fake-enc-key";
-    mockGenerateEncryptionKey.mockReturnValue(fakeEncKey);
-    mockWrapKey.mockResolvedValue(new Uint8Array([10, 20, 30]));
-    mockCreateProject.mockResolvedValueOnce({
-      ...createdProject,
-      id: "proj-456",
-    });
-
-    render(<CreateProjectDialog {...defaultProps} />);
-
-    await user.type(screen.getByLabelText(/project name/i), "New Project");
-    await user.click(screen.getByRole("button", { name: /^create$/i }));
-
-    await waitFor(() => {
-      expect(mockAddEncryptionKey).toHaveBeenCalledWith(
-        "proj-456",
-        fakeEncKey,
-      );
-    });
-  });
-
-  it("does not store encryption key if wrapping key is null", async () => {
-    const user = userEvent.setup();
-    const mockAddEncryptionKey = vi.fn();
-    setupEnvelopeKeys({
-      wrappingKey: null,
-      addEncryptionKey: mockAddEncryptionKey,
-    });
-    mockCreateProject.mockResolvedValueOnce(createdProject);
-
-    render(<CreateProjectDialog {...defaultProps} />);
-
-    await user.type(screen.getByLabelText(/project name/i), "New Project");
-    await user.click(screen.getByRole("button", { name: /^create$/i }));
-
-    await waitFor(() => {
-      expect(mockCreateProject).toHaveBeenCalled();
-    });
-    expect(mockAddEncryptionKey).not.toHaveBeenCalled();
+    expect(mockEncapsulate).not.toHaveBeenCalled();
   });
 
   it("calls onCreated with project data on success", async () => {
@@ -259,5 +240,23 @@ describe("CreateProjectDialog", () => {
       created_at: "2026-03-18T00:00:00Z",
       api_keys: [],
     });
+  });
+
+  it("shows error when encapsulate fails", async () => {
+    const user = userEvent.setup();
+    setupKeypair({ publicKey: fakePublicKey });
+    setupEnvelopeKeys();
+
+    mockEncapsulate.mockRejectedValueOnce(new Error("Encapsulation failed"));
+
+    render(<CreateProjectDialog {...defaultProps} />);
+
+    await user.type(screen.getByLabelText(/project name/i), "Fail Project");
+    await user.click(screen.getByRole("button", { name: /^create$/i }));
+
+    expect(
+      await screen.findByText(/encapsulation failed/i),
+    ).toBeInTheDocument();
+    expect(mockCreateProject).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Who
Isaac Quintero + Claude Opus 4.6 (pair-programming)

## What
- `create-project-dialog.tsx`: Replaced `envelope-crypto` imports with `encapsulate` from `@pqdb/client`. Now calls `encapsulate(publicKey)` to produce `{ciphertext, sharedSecret}`, sends `base64(ciphertext)` as `wrapped_encryption_key` in POST body, and stores `sharedSecret` in keypair context via new `setProjectEncryptionKey()`.
- `keypair-context.tsx`: Added `setProjectEncryptionKey(projectId, sharedSecret: Uint8Array)` to `EnvelopeKeyState` interface and provider. Converts `Uint8Array` to base64 string for backward compat with existing `getEncryptionKey()` consumers.
- `create-project-dialog.test.tsx`: Rewritten to mock `@pqdb/client` `encapsulate`, verify base64 ciphertext is POSTed, and `sharedSecret` is stored in context. 10 tests passing.

## When
2026-04-10

## Where
- `dashboard/src/components/create-project-dialog.tsx`
- `dashboard/src/lib/keypair-context.tsx`
- `dashboard/tests/unit/create-project-dialog.test.tsx`

## Why
The create project flow previously used password-derived AES wrapping keys (envelope-crypto) to wrap a random encryption key. This meant the flow depended on the user password being available at key-wrap time. With ML-KEM-768 encapsulate, we produce a shared secret from the user public key instead -- the backend never sees the plaintext shared secret, and no password is needed. This is US-006 of Phase 5d, moving the dashboard toward full PQC zero-knowledge architecture.

## How
- The dialog calls `useKeypair()` for the ML-KEM public key and `encapsulate(publicKey)` from `@pqdb/client` to produce `{ciphertext, sharedSecret}`.
- `base64(ciphertext)` is sent as `wrapped_encryption_key` in POST `/v1/projects` body (same field, different content).
- `sharedSecret` (32-byte `Uint8Array`) stored via `setProjectEncryptionKey(projectId, sharedSecret)` which converts to base64 internally for backward compat with `getEncryptionKey()`.
- `projects.ts` `createProject()` signature unchanged.

**Considered:**
- Storing sharedSecret as raw Uint8Array in a separate Map: rejected, would break existing getEncryptionKey consumers expecting strings.
- Using addEncryptionKey with manual base64 in dialog: rejected, better to encapsulate conversion in dedicated setProjectEncryptionKey per US-007 coordination.
- Deleting envelope-crypto.ts now: deferred, still imported by login-page, signup-page, change-password-dialog, keypair-context.

**Trade-offs:**
- sharedSecret stored as base64 string for backward compat.
- envelope-crypto.ts not deleted yet -- 4 consumers still depend on it.

## Test plan
- [x] Unit tests: 10 passing (`npx vitest run tests/unit/create-project-dialog.test.tsx`)
- [x] Full suite: 579/580 pass (1 pre-existing failure in login-mcp-redirect on main)
- [x] Typecheck: `tsc --noEmit` zero errors
- [x] Production build: `vite build` succeeds
- [x] Gitleaks: no leaks
- [ ] CI pipeline

## Non-goals
- Deleting envelope-crypto.ts (deferred until login/signup/change-password migrate off legacy wrapping)
- E2E encrypt/query/decrypt round-trip test (requires full stack)
- Modifying projects.ts createProject() signature
- Touching backend, SDK, or MCP code