### PR TITLE
[US-005b] Recovery modal — upload or regenerate keypair

### DIFF
--- a/backend/src/pqdb_api/routes/auth.py
+++ b/backend/src/pqdb_api/routes/auth.py
@@ -284,9 +284,7 @@ async def update_my_public_key(
     if developer is None:
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
-    developer.ml_kem_public_key = base64.b64decode(
-        body.public_key, validate=True
-    )
+    developer.ml_kem_public_key = base64.b64decode(body.public_key, validate=True)
     await session.commit()
     logger.info("developer_public_key_updated", developer_id=str(developer_id))
     return UpdatePublicKeyResponse(ok=True)

--- a/backend/src/pqdb_api/routes/auth.py
+++ b/backend/src/pqdb_api/routes/auth.py
@@ -237,6 +237,61 @@ async def get_my_public_key(
     return PublicKeyResponse(public_key=pk_b64)
 
 
+class UpdatePublicKeyRequest(BaseModel):
+    """Request body for PUT /v1/auth/me/public-key (key rotation)."""
+
+    public_key: str
+
+    @field_validator("public_key")
+    @classmethod
+    def _validate_b64(cls, v: str) -> str:
+        try:
+            decoded = base64.b64decode(v, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            msg = f"public_key must be valid base64: {exc}"
+            raise ValueError(msg) from exc
+        if len(decoded) != ML_KEM_768_PUBLIC_KEY_BYTES:
+            msg = (
+                "public_key must decode to exactly "
+                f"{ML_KEM_768_PUBLIC_KEY_BYTES} bytes "
+                f"(ML-KEM-768 public key size), got {len(decoded)}"
+            )
+            raise ValueError(msg)
+        return v
+
+
+class UpdatePublicKeyResponse(BaseModel):
+    """Response body for PUT /v1/auth/me/public-key."""
+
+    ok: bool
+
+
+@router.put("/me/public-key", response_model=UpdatePublicKeyResponse)
+async def update_my_public_key(
+    body: UpdatePublicKeyRequest,
+    developer_id: uuid.UUID = Depends(get_current_developer_id),
+    session: AsyncSession = Depends(get_session),
+) -> UpdatePublicKeyResponse:
+    """Replace the authenticated developer's ML-KEM-768 public key.
+
+    Used during key rotation / recovery: the client generates a new
+    keypair and uploads the new public key here.
+    """
+    result = await session.execute(
+        select(Developer).where(Developer.id == developer_id)
+    )
+    developer = result.scalar_one_or_none()
+    if developer is None:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    developer.ml_kem_public_key = base64.b64decode(
+        body.public_key, validate=True
+    )
+    await session.commit()
+    logger.info("developer_public_key_updated", developer_id=str(developer_id))
+    return UpdatePublicKeyResponse(ok=True)
+
+
 class ChangePasswordRequest(BaseModel):
     """Request body for changing password."""
 

--- a/backend/tests/integration/test_auth_public_key.py
+++ b/backend/tests/integration/test_auth_public_key.py
@@ -1,42 +1,26 @@
-"""Integration tests for developer ML-KEM-768 public key handling.
+"""Integration tests for GET/PUT /v1/auth/me/public-key.
 
-Boots the real FastAPI app with a real Postgres database. Verifies:
-
-1. POST /v1/auth/signup accepts an optional ``ml_kem_public_key`` field
-   (base64-encoded). When provided, the decoded bytes are stored on the
-   developer record.
-2. When the field is omitted the column stays NULL.
-3. Malformed base64 in the signup payload is rejected with HTTP 422
-   (no silent NULL write).
-4. GET /v1/auth/me/public-key returns ``{public_key: str | None}`` for
-   the authenticated developer, base64-encoding the stored bytes.
-5. GET /v1/auth/me/public-key without a bearer token returns 401.
+Boots the real FastAPI app with real Postgres, tests key retrieval
+and key rotation endpoints.
 """
 
-from __future__ import annotations
-
 import base64
-import uuid
 from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy.ext.asyncio import (
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from pqdb_api.database import get_session
 from pqdb_api.routes.auth import router as auth_router
 from pqdb_api.routes.health import router as health_router
 from pqdb_api.services.auth import generate_mldsa65_keypair
 
-# Skip if liboqs is not available (matches test_auth.py pattern)
+# Skip the entire module if liboqs is not available
 try:
-    import oqs
+    import oqs  # noqa: F401
 
     HAS_OQS = True
 except (ImportError, SystemExit, RuntimeError):
@@ -46,18 +30,10 @@ pytestmark = pytest.mark.skipif(
     not HAS_OQS, reason="liboqs native library not available"
 )
 
-
-# ML-KEM-768 public keys are 1184 bytes (NIST FIPS 203). The server now
-# enforces this length at the API boundary, so tests must use real keys
-# of the correct length.
-ML_KEM_768_PK_LEN = 1184
-
-
-def _real_ml_kem_pk() -> bytes:
-    """Generate a real ML-KEM-768 public key via liboqs."""
-    with oqs.KeyEncapsulation("ML-KEM-768") as kem:
-        pk: bytes = kem.generate_keypair()
-        return pk
+# ML-KEM-768 public key is exactly 1184 bytes
+VALID_PUBLIC_KEY = base64.b64encode(bytes(1184)).decode()
+VALID_PUBLIC_KEY_2 = base64.b64encode(bytes([1] * 1184)).decode()
+WRONG_LENGTH_KEY = base64.b64encode(bytes(100)).decode()
 
 
 def _create_test_app(test_db_url: str) -> FastAPI:
@@ -94,203 +70,109 @@ def client(test_db_url: str) -> Iterator[TestClient]:
         yield c
 
 
-def _unique_email(prefix: str) -> str:
-    return f"{prefix}-{uuid.uuid4().hex[:8]}@example.com"
+def _signup(client: TestClient, email: str = "dev@test.com") -> str:
+    """Sign up and return the access token."""
+    resp = client.post(
+        "/v1/auth/signup",
+        json={"email": email, "password": "testpass123"},
+    )
+    assert resp.status_code == 201
+    return resp.json()["access_token"]
 
 
-class TestSignupWithPublicKey:
-    """Tests for the ml_kem_public_key field on POST /v1/auth/signup."""
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
 
-    def test_signup_with_public_key_stores_bytes(self, client: TestClient) -> None:
-        """Signup WITH public key -> stored, GET endpoint returns it (bytes match)."""
-        pk_bytes = _real_ml_kem_pk()
-        assert len(pk_bytes) == ML_KEM_768_PK_LEN
-        pk_b64 = base64.b64encode(pk_bytes).decode("ascii")
-        email = _unique_email("withkey")
 
-        resp = client.post(
-            "/v1/auth/signup",
-            json={
-                "email": email,
-                "password": "securepass123",
-                "ml_kem_public_key": pk_b64,
-            },
+class TestPutPublicKey:
+    """Tests for PUT /v1/auth/me/public-key."""
+
+    def test_put_public_key_requires_auth(self, client: TestClient) -> None:
+        resp = client.put(
+            "/v1/auth/me/public-key",
+            json={"public_key": VALID_PUBLIC_KEY},
         )
-        assert resp.status_code == 201, resp.text
-        data = resp.json()
-        # Response shape MUST be unchanged: only the token triple.
-        assert set(data.keys()) == {"access_token", "refresh_token", "token_type"}
-        assert data["token_type"] == "bearer"
+        assert resp.status_code in (401, 403)
 
-        token = data["access_token"]
+    def test_put_public_key_success(self, client: TestClient) -> None:
+        token = _signup(client)
+
+        resp = client.put(
+            "/v1/auth/me/public-key",
+            json={"public_key": VALID_PUBLIC_KEY},
+            headers=_auth(token),
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+        # Verify the key was persisted
         get_resp = client.get(
             "/v1/auth/me/public-key",
-            headers={"Authorization": f"Bearer {token}"},
+            headers=_auth(token),
         )
         assert get_resp.status_code == 200
-        body = get_resp.json()
-        assert set(body.keys()) == {"public_key"}
-        assert body["public_key"] is not None
-        # Bytes must round-trip exactly.
-        assert base64.b64decode(body["public_key"]) == pk_bytes
+        assert get_resp.json()["public_key"] == VALID_PUBLIC_KEY
 
-    def test_signup_without_public_key_stores_null(self, client: TestClient) -> None:
-        """Signup WITHOUT public key -> stored NULL, GET returns {public_key: null}."""
-        email = _unique_email("nokey")
+    def test_put_public_key_replaces_existing(self, client: TestClient) -> None:
+        """PUT overwrites a previously stored key (key rotation)."""
+        token = _signup(client, email="rotate@test.com")
 
-        resp = client.post(
-            "/v1/auth/signup",
-            json={"email": email, "password": "securepass123"},
+        # Set initial key
+        resp1 = client.put(
+            "/v1/auth/me/public-key",
+            json={"public_key": VALID_PUBLIC_KEY},
+            headers=_auth(token),
         )
-        assert resp.status_code == 201, resp.text
-        data = resp.json()
-        assert set(data.keys()) == {"access_token", "refresh_token", "token_type"}
+        assert resp1.status_code == 200
 
-        token = data["access_token"]
+        # Rotate to new key
+        resp2 = client.put(
+            "/v1/auth/me/public-key",
+            json={"public_key": VALID_PUBLIC_KEY_2},
+            headers=_auth(token),
+        )
+        assert resp2.status_code == 200
+
+        # Verify the new key is stored
         get_resp = client.get(
             "/v1/auth/me/public-key",
-            headers={"Authorization": f"Bearer {token}"},
+            headers=_auth(token),
         )
         assert get_resp.status_code == 200
-        body = get_resp.json()
-        assert body == {"public_key": None}
+        assert get_resp.json()["public_key"] == VALID_PUBLIC_KEY_2
 
-    def test_signup_with_malformed_base64_returns_422(self, client: TestClient) -> None:
-        """Malformed base64 in signup payload must be rejected with 422.
-
-        The server must NOT silently store NULL when the client sent
-        something. Bad input is a client error, not a missing value.
-        """
-        email = _unique_email("badb64")
-
-        resp = client.post(
-            "/v1/auth/signup",
-            json={
-                "email": email,
-                "password": "securepass123",
-                # Not valid base64 — contains characters outside the alphabet.
-                "ml_kem_public_key": "not!!valid##base64@@",
-            },
-        )
-        assert resp.status_code == 422, resp.text
-
-    def test_signup_with_wrong_length_key_returns_422(self, client: TestClient) -> None:
-        """Bad-length base64 must be rejected at the boundary, not silently stored.
-
-        100 bytes is valid base64 but not a valid ML-KEM-768 public key.
-        The invariant is "if developers.ml_kem_public_key is non-NULL,
-        it holds exactly 1184 bytes" — the API must enforce it.
-        """
-        short_b64 = base64.b64encode(b"x" * 100).decode("ascii")
-        resp = client.post(
-            "/v1/auth/signup",
-            json={
-                "email": _unique_email("shortkey"),
-                "password": "testpassword123",
-                "ml_kem_public_key": short_b64,
-            },
-        )
-        assert resp.status_code == 422, resp.text
-        # Error message must name the required length so clients know what to fix.
-        assert "1184" in resp.text
-
-    def test_signup_with_empty_string_key_returns_422(self, client: TestClient) -> None:
-        """Empty base64 string must be rejected — empty bytes is not a valid key.
-
-        This is the most important edge case: an empty string decodes
-        cleanly to b"" and the old validator would happily persist it.
-        """
-        resp = client.post(
-            "/v1/auth/signup",
-            json={
-                "email": _unique_email("emptykey"),
-                "password": "testpassword123",
-                "ml_kem_public_key": "",
-            },
-        )
-        assert resp.status_code == 422, resp.text
-
-    def test_signup_with_oversized_key_returns_422(self, client: TestClient) -> None:
-        """Oversized base64 must be rejected at the boundary."""
-        long_b64 = base64.b64encode(b"x" * 2000).decode("ascii")
-        resp = client.post(
-            "/v1/auth/signup",
-            json={
-                "email": _unique_email("longkey"),
-                "password": "testpassword123",
-                "ml_kem_public_key": long_b64,
-            },
-        )
-        assert resp.status_code == 422, resp.text
-
-
-class TestGetPublicKey:
-    """Tests for GET /v1/auth/me/public-key."""
-
-    def test_get_public_key_without_token_returns_401(self, client: TestClient) -> None:
-        resp = client.get("/v1/auth/me/public-key")
-        # Strict 401 per the AC — missing credentials is an authentication
-        # failure, not an authorization failure. The middleware now uses
-        # HTTPBearer(auto_error=False) to raise 401 explicitly.
-        assert resp.status_code == 401
-
-    def test_get_public_key_with_invalid_token_returns_401(
+    def test_put_public_key_rejects_wrong_length(
         self, client: TestClient
     ) -> None:
-        resp = client.get(
+        token = _signup(client, email="badlen@test.com")
+
+        resp = client.put(
             "/v1/auth/me/public-key",
-            headers={"Authorization": "Bearer not.a.real.token"},
+            json={"public_key": WRONG_LENGTH_KEY},
+            headers=_auth(token),
         )
-        assert resp.status_code == 401
+        assert resp.status_code == 422
 
-    def test_two_developers_get_isolated_keys(self, client: TestClient) -> None:
-        """Cross-tenant safety: each developer's GET returns ONLY their own key.
+    def test_put_public_key_rejects_invalid_base64(
+        self, client: TestClient
+    ) -> None:
+        token = _signup(client, email="badb64@test.com")
 
-        This is the most important test for the read path. A silent
-        cross-tenant leak would be catastrophic in a multi-tenant system,
-        so verify both developers get their own key and that the keys
-        are NOT crossed.
-        """
-        pk_a = _real_ml_kem_pk()
-        pk_b = _real_ml_kem_pk()
-        assert pk_a != pk_b  # sanity: keypairs are random
-
-        resp_a = client.post(
-            "/v1/auth/signup",
-            json={
-                "email": _unique_email("isolation_a"),
-                "password": "testpassword123",
-                "ml_kem_public_key": base64.b64encode(pk_a).decode("ascii"),
-            },
-        )
-        assert resp_a.status_code == 201, resp_a.text
-        token_a = resp_a.json()["access_token"]
-
-        resp_b = client.post(
-            "/v1/auth/signup",
-            json={
-                "email": _unique_email("isolation_b"),
-                "password": "testpassword123",
-                "ml_kem_public_key": base64.b64encode(pk_b).decode("ascii"),
-            },
-        )
-        assert resp_b.status_code == 201, resp_b.text
-        token_b = resp_b.json()["access_token"]
-
-        get_a = client.get(
+        resp = client.put(
             "/v1/auth/me/public-key",
-            headers={"Authorization": f"Bearer {token_a}"},
+            json={"public_key": "not-valid-base64!!!"},
+            headers=_auth(token),
         )
-        assert get_a.status_code == 200
-        assert base64.b64decode(get_a.json()["public_key"]) == pk_a
+        assert resp.status_code == 422
 
-        get_b = client.get(
+    def test_put_public_key_rejects_missing_body(
+        self, client: TestClient
+    ) -> None:
+        token = _signup(client, email="nobody@test.com")
+
+        resp = client.put(
             "/v1/auth/me/public-key",
-            headers={"Authorization": f"Bearer {token_b}"},
+            json={},
+            headers=_auth(token),
         )
-        assert get_b.status_code == 200
-        assert base64.b64decode(get_b.json()["public_key"]) == pk_b
-
-        # Critical: keys are NOT crossed.
-        assert base64.b64decode(get_a.json()["public_key"]) != pk_b
-        assert base64.b64decode(get_b.json()["public_key"]) != pk_a
+        assert resp.status_code == 422

--- a/backend/tests/integration/test_auth_public_key.py
+++ b/backend/tests/integration/test_auth_public_key.py
@@ -1,26 +1,42 @@
-"""Integration tests for GET/PUT /v1/auth/me/public-key.
+"""Integration tests for developer ML-KEM-768 public key handling.
 
-Boots the real FastAPI app with real Postgres, tests key retrieval
-and key rotation endpoints.
+Boots the real FastAPI app with a real Postgres database. Verifies:
+
+1. POST /v1/auth/signup accepts an optional ``ml_kem_public_key`` field
+   (base64-encoded). When provided, the decoded bytes are stored on the
+   developer record.
+2. When the field is omitted the column stays NULL.
+3. Malformed base64 in the signup payload is rejected with HTTP 422
+   (no silent NULL write).
+4. GET /v1/auth/me/public-key returns ``{public_key: str | None}`` for
+   the authenticated developer, base64-encoding the stored bytes.
+5. GET /v1/auth/me/public-key without a bearer token returns 401.
 """
 
+from __future__ import annotations
+
 import base64
+import uuid
 from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 from pqdb_api.database import get_session
 from pqdb_api.routes.auth import router as auth_router
 from pqdb_api.routes.health import router as health_router
 from pqdb_api.services.auth import generate_mldsa65_keypair
 
-# Skip the entire module if liboqs is not available
+# Skip if liboqs is not available (matches test_auth.py pattern)
 try:
-    import oqs  # noqa: F401
+    import oqs
 
     HAS_OQS = True
 except (ImportError, SystemExit, RuntimeError):
@@ -30,10 +46,18 @@ pytestmark = pytest.mark.skipif(
     not HAS_OQS, reason="liboqs native library not available"
 )
 
-# ML-KEM-768 public key is exactly 1184 bytes
-VALID_PUBLIC_KEY = base64.b64encode(bytes(1184)).decode()
-VALID_PUBLIC_KEY_2 = base64.b64encode(bytes([1] * 1184)).decode()
-WRONG_LENGTH_KEY = base64.b64encode(bytes(100)).decode()
+
+# ML-KEM-768 public keys are 1184 bytes (NIST FIPS 203). The server now
+# enforces this length at the API boundary, so tests must use real keys
+# of the correct length.
+ML_KEM_768_PK_LEN = 1184
+
+
+def _real_ml_kem_pk() -> bytes:
+    """Generate a real ML-KEM-768 public key via liboqs."""
+    with oqs.KeyEncapsulation("ML-KEM-768") as kem:
+        pk: bytes = kem.generate_keypair()
+        return pk
 
 
 def _create_test_app(test_db_url: str) -> FastAPI:
@@ -70,104 +94,294 @@ def client(test_db_url: str) -> Iterator[TestClient]:
         yield c
 
 
-def _signup(client: TestClient, email: str = "dev@test.com") -> str:
-    """Sign up and return the access token."""
-    resp = client.post(
-        "/v1/auth/signup",
-        json={"email": email, "password": "testpass123"},
-    )
-    assert resp.status_code == 201
-    token: str = resp.json()["access_token"]
-    return token
+def _unique_email(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}@example.com"
 
 
-def _auth(token: str) -> dict[str, str]:
-    return {"Authorization": f"Bearer {token}"}
+class TestSignupWithPublicKey:
+    """Tests for the ml_kem_public_key field on POST /v1/auth/signup."""
+
+    def test_signup_with_public_key_stores_bytes(self, client: TestClient) -> None:
+        """Signup WITH public key -> stored, GET endpoint returns it (bytes match)."""
+        pk_bytes = _real_ml_kem_pk()
+        assert len(pk_bytes) == ML_KEM_768_PK_LEN
+        pk_b64 = base64.b64encode(pk_bytes).decode("ascii")
+        email = _unique_email("withkey")
+
+        resp = client.post(
+            "/v1/auth/signup",
+            json={
+                "email": email,
+                "password": "securepass123",
+                "ml_kem_public_key": pk_b64,
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        # Response shape MUST be unchanged: only the token triple.
+        assert set(data.keys()) == {"access_token", "refresh_token", "token_type"}
+        assert data["token_type"] == "bearer"
+
+        token = data["access_token"]
+        get_resp = client.get(
+            "/v1/auth/me/public-key",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert get_resp.status_code == 200
+        body = get_resp.json()
+        assert set(body.keys()) == {"public_key"}
+        assert body["public_key"] is not None
+        # Bytes must round-trip exactly.
+        assert base64.b64decode(body["public_key"]) == pk_bytes
+
+    def test_signup_without_public_key_stores_null(self, client: TestClient) -> None:
+        """Signup WITHOUT public key -> stored NULL, GET returns {public_key: null}."""
+        email = _unique_email("nokey")
+
+        resp = client.post(
+            "/v1/auth/signup",
+            json={"email": email, "password": "securepass123"},
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert set(data.keys()) == {"access_token", "refresh_token", "token_type"}
+
+        token = data["access_token"]
+        get_resp = client.get(
+            "/v1/auth/me/public-key",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert get_resp.status_code == 200
+        body = get_resp.json()
+        assert body == {"public_key": None}
+
+    def test_signup_with_malformed_base64_returns_422(self, client: TestClient) -> None:
+        """Malformed base64 in signup payload must be rejected with 422.
+
+        The server must NOT silently store NULL when the client sent
+        something. Bad input is a client error, not a missing value.
+        """
+        email = _unique_email("badb64")
+
+        resp = client.post(
+            "/v1/auth/signup",
+            json={
+                "email": email,
+                "password": "securepass123",
+                # Not valid base64 — contains characters outside the alphabet.
+                "ml_kem_public_key": "not!!valid##base64@@",
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_signup_with_wrong_length_key_returns_422(self, client: TestClient) -> None:
+        """Bad-length base64 must be rejected at the boundary, not silently stored.
+
+        100 bytes is valid base64 but not a valid ML-KEM-768 public key.
+        The invariant is "if developers.ml_kem_public_key is non-NULL,
+        it holds exactly 1184 bytes" — the API must enforce it.
+        """
+        short_b64 = base64.b64encode(b"x" * 100).decode("ascii")
+        resp = client.post(
+            "/v1/auth/signup",
+            json={
+                "email": _unique_email("shortkey"),
+                "password": "testpassword123",
+                "ml_kem_public_key": short_b64,
+            },
+        )
+        assert resp.status_code == 422, resp.text
+        # Error message must name the required length so clients know what to fix.
+        assert "1184" in resp.text
+
+    def test_signup_with_empty_string_key_returns_422(self, client: TestClient) -> None:
+        """Empty base64 string must be rejected — empty bytes is not a valid key.
+
+        This is the most important edge case: an empty string decodes
+        cleanly to b"" and the old validator would happily persist it.
+        """
+        resp = client.post(
+            "/v1/auth/signup",
+            json={
+                "email": _unique_email("emptykey"),
+                "password": "testpassword123",
+                "ml_kem_public_key": "",
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_signup_with_oversized_key_returns_422(self, client: TestClient) -> None:
+        """Oversized base64 must be rejected at the boundary."""
+        long_b64 = base64.b64encode(b"x" * 2000).decode("ascii")
+        resp = client.post(
+            "/v1/auth/signup",
+            json={
+                "email": _unique_email("longkey"),
+                "password": "testpassword123",
+                "ml_kem_public_key": long_b64,
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
+
+class TestGetPublicKey:
+    """Tests for GET /v1/auth/me/public-key."""
+
+    def test_get_public_key_without_token_returns_401(self, client: TestClient) -> None:
+        resp = client.get("/v1/auth/me/public-key")
+        # Strict 401 per the AC — missing credentials is an authentication
+        # failure, not an authorization failure. The middleware now uses
+        # HTTPBearer(auto_error=False) to raise 401 explicitly.
+        assert resp.status_code == 401
+
+    def test_get_public_key_with_invalid_token_returns_401(
+        self, client: TestClient
+    ) -> None:
+        resp = client.get(
+            "/v1/auth/me/public-key",
+            headers={"Authorization": "Bearer not.a.real.token"},
+        )
+        assert resp.status_code == 401
+
+    def test_two_developers_get_isolated_keys(self, client: TestClient) -> None:
+        """Cross-tenant safety: each developer's GET returns ONLY their own key.
+
+        This is the most important test for the read path. A silent
+        cross-tenant leak would be catastrophic in a multi-tenant system,
+        so verify both developers get their own key and that the keys
+        are NOT crossed.
+        """
+        pk_a = _real_ml_kem_pk()
+        pk_b = _real_ml_kem_pk()
+        assert pk_a != pk_b  # sanity: keypairs are random
+
+        resp_a = client.post(
+            "/v1/auth/signup",
+            json={
+                "email": _unique_email("isolation_a"),
+                "password": "testpassword123",
+                "ml_kem_public_key": base64.b64encode(pk_a).decode("ascii"),
+            },
+        )
+        assert resp_a.status_code == 201, resp_a.text
+        token_a = resp_a.json()["access_token"]
+
+        resp_b = client.post(
+            "/v1/auth/signup",
+            json={
+                "email": _unique_email("isolation_b"),
+                "password": "testpassword123",
+                "ml_kem_public_key": base64.b64encode(pk_b).decode("ascii"),
+            },
+        )
+        assert resp_b.status_code == 201, resp_b.text
+        token_b = resp_b.json()["access_token"]
+
+        get_a = client.get(
+            "/v1/auth/me/public-key",
+            headers={"Authorization": f"Bearer {token_a}"},
+        )
+        assert get_a.status_code == 200
+        assert base64.b64decode(get_a.json()["public_key"]) == pk_a
+
+        get_b = client.get(
+            "/v1/auth/me/public-key",
+            headers={"Authorization": f"Bearer {token_b}"},
+        )
+        assert get_b.status_code == 200
+        assert base64.b64decode(get_b.json()["public_key"]) == pk_b
+
+        # Critical: keys are NOT crossed.
+        assert base64.b64decode(get_a.json()["public_key"]) != pk_b
+        assert base64.b64decode(get_b.json()["public_key"]) != pk_a
 
 
 class TestPutPublicKey:
-    """Tests for PUT /v1/auth/me/public-key."""
+    """Tests for PUT /v1/auth/me/public-key (key rotation)."""
+
+    def _signup_and_auth(
+        self, client: TestClient, email: str,
+    ) -> tuple[str, dict[str, str]]:
+        """Sign up and return (token, auth headers)."""
+        resp = client.post(
+            "/v1/auth/signup",
+            json={"email": email, "password": "securepass123"},
+        )
+        assert resp.status_code == 201, resp.text
+        token: str = resp.json()["access_token"]
+        return token, {"Authorization": f"Bearer {token}"}
 
     def test_put_public_key_requires_auth(self, client: TestClient) -> None:
+        pk_b64 = base64.b64encode(_real_ml_kem_pk()).decode("ascii")
         resp = client.put(
             "/v1/auth/me/public-key",
-            json={"public_key": VALID_PUBLIC_KEY},
+            json={"public_key": pk_b64},
         )
-        assert resp.status_code in (401, 403)
+        assert resp.status_code == 401
 
     def test_put_public_key_success(self, client: TestClient) -> None:
-        token = _signup(client)
+        pk_bytes = _real_ml_kem_pk()
+        pk_b64 = base64.b64encode(pk_bytes).decode("ascii")
+        _, headers = self._signup_and_auth(client, _unique_email("put"))
 
         resp = client.put(
             "/v1/auth/me/public-key",
-            json={"public_key": VALID_PUBLIC_KEY},
-            headers=_auth(token),
+            json={"public_key": pk_b64},
+            headers=headers,
         )
         assert resp.status_code == 200
         assert resp.json() == {"ok": True}
 
-        # Verify the key was persisted
-        get_resp = client.get(
-            "/v1/auth/me/public-key",
-            headers=_auth(token),
-        )
+        get_resp = client.get("/v1/auth/me/public-key", headers=headers)
         assert get_resp.status_code == 200
-        assert get_resp.json()["public_key"] == VALID_PUBLIC_KEY
+        assert base64.b64decode(get_resp.json()["public_key"]) == pk_bytes
 
     def test_put_public_key_replaces_existing(self, client: TestClient) -> None:
         """PUT overwrites a previously stored key (key rotation)."""
-        token = _signup(client, email="rotate@test.com")
+        pk_a = _real_ml_kem_pk()
+        pk_b = _real_ml_kem_pk()
+        assert pk_a != pk_b
+        _, headers = self._signup_and_auth(client, _unique_email("rotate"))
 
-        # Set initial key
-        resp1 = client.put(
+        client.put(
             "/v1/auth/me/public-key",
-            json={"public_key": VALID_PUBLIC_KEY},
-            headers=_auth(token),
+            json={"public_key": base64.b64encode(pk_a).decode("ascii")},
+            headers=headers,
         )
-        assert resp1.status_code == 200
+        client.put(
+            "/v1/auth/me/public-key",
+            json={"public_key": base64.b64encode(pk_b).decode("ascii")},
+            headers=headers,
+        )
 
-        # Rotate to new key
-        resp2 = client.put(
-            "/v1/auth/me/public-key",
-            json={"public_key": VALID_PUBLIC_KEY_2},
-            headers=_auth(token),
-        )
-        assert resp2.status_code == 200
-
-        # Verify the new key is stored
-        get_resp = client.get(
-            "/v1/auth/me/public-key",
-            headers=_auth(token),
-        )
-        assert get_resp.status_code == 200
-        assert get_resp.json()["public_key"] == VALID_PUBLIC_KEY_2
+        get_resp = client.get("/v1/auth/me/public-key", headers=headers)
+        assert base64.b64decode(get_resp.json()["public_key"]) == pk_b
 
     def test_put_public_key_rejects_wrong_length(self, client: TestClient) -> None:
-        token = _signup(client, email="badlen@test.com")
-
+        _, headers = self._signup_and_auth(client, _unique_email("putbadlen"))
+        short_b64 = base64.b64encode(b"x" * 100).decode("ascii")
         resp = client.put(
             "/v1/auth/me/public-key",
-            json={"public_key": WRONG_LENGTH_KEY},
-            headers=_auth(token),
+            json={"public_key": short_b64},
+            headers=headers,
         )
         assert resp.status_code == 422
+        assert "1184" in resp.text
 
     def test_put_public_key_rejects_invalid_base64(self, client: TestClient) -> None:
-        token = _signup(client, email="badb64@test.com")
-
+        _, headers = self._signup_and_auth(client, _unique_email("putbadb64"))
         resp = client.put(
             "/v1/auth/me/public-key",
-            json={"public_key": "not-valid-base64!!!"},
-            headers=_auth(token),
+            json={"public_key": "not!!valid##base64@@"},
+            headers=headers,
         )
         assert resp.status_code == 422
 
     def test_put_public_key_rejects_missing_body(self, client: TestClient) -> None:
-        token = _signup(client, email="nobody@test.com")
-
+        _, headers = self._signup_and_auth(client, _unique_email("putnobody"))
         resp = client.put(
             "/v1/auth/me/public-key",
             json={},
-            headers=_auth(token),
+            headers=headers,
         )
         assert resp.status_code == 422

--- a/backend/tests/integration/test_auth_public_key.py
+++ b/backend/tests/integration/test_auth_public_key.py
@@ -141,9 +141,7 @@ class TestPutPublicKey:
         assert get_resp.status_code == 200
         assert get_resp.json()["public_key"] == VALID_PUBLIC_KEY_2
 
-    def test_put_public_key_rejects_wrong_length(
-        self, client: TestClient
-    ) -> None:
+    def test_put_public_key_rejects_wrong_length(self, client: TestClient) -> None:
         token = _signup(client, email="badlen@test.com")
 
         resp = client.put(
@@ -153,9 +151,7 @@ class TestPutPublicKey:
         )
         assert resp.status_code == 422
 
-    def test_put_public_key_rejects_invalid_base64(
-        self, client: TestClient
-    ) -> None:
+    def test_put_public_key_rejects_invalid_base64(self, client: TestClient) -> None:
         token = _signup(client, email="badb64@test.com")
 
         resp = client.put(
@@ -165,9 +161,7 @@ class TestPutPublicKey:
         )
         assert resp.status_code == 422
 
-    def test_put_public_key_rejects_missing_body(
-        self, client: TestClient
-    ) -> None:
+    def test_put_public_key_rejects_missing_body(self, client: TestClient) -> None:
         token = _signup(client, email="nobody@test.com")
 
         resp = client.put(

--- a/backend/tests/integration/test_auth_public_key.py
+++ b/backend/tests/integration/test_auth_public_key.py
@@ -300,7 +300,9 @@ class TestPutPublicKey:
     """Tests for PUT /v1/auth/me/public-key (key rotation)."""
 
     def _signup_and_auth(
-        self, client: TestClient, email: str,
+        self,
+        client: TestClient,
+        email: str,
     ) -> tuple[str, dict[str, str]]:
         """Sign up and return (token, auth headers)."""
         resp = client.post(

--- a/backend/tests/integration/test_auth_public_key.py
+++ b/backend/tests/integration/test_auth_public_key.py
@@ -77,7 +77,8 @@ def _signup(client: TestClient, email: str = "dev@test.com") -> str:
         json={"email": email, "password": "testpass123"},
     )
     assert resp.status_code == 201
-    return resp.json()["access_token"]
+    token: str = resp.json()["access_token"]
+    return token
 
 
 def _auth(token: str) -> dict[str, str]:

--- a/dashboard/src/components/recover-keypair-modal.tsx
+++ b/dashboard/src/components/recover-keypair-modal.tsx
@@ -1,0 +1,278 @@
+import * as React from "react";
+import { Button } from "~/components/ui/button";
+import { Label } from "~/components/ui/label";
+import { generateKeyPair } from "@pqdb/client";
+import { saveKeypair, deleteKeypair } from "~/lib/keypair-store";
+import { getAccessToken } from "~/lib/auth-store";
+
+interface RecoverKeypairModalProps {
+  developerId: string;
+  onReload: () => void;
+}
+
+function fromBase64(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary);
+}
+
+function arraysEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+type Mode = "choose" | "upload" | "regenerate";
+
+/**
+ * Recovery modal shown when keypair-context reports error='missing'.
+ * Offers two paths: upload a recovery file or generate a new keypair.
+ */
+export function RecoverKeypairModal({
+  developerId,
+  onReload,
+}: RecoverKeypairModalProps) {
+  const [mode, setMode] = React.useState<Mode>("choose");
+  const [error, setError] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [acknowledged, setAcknowledged] = React.useState(false);
+
+  async function handleFileUpload(
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setError(null);
+    setLoading(true);
+
+    try {
+      const text = await file.text();
+      const data = JSON.parse(text);
+
+      if (!data.public_key || !data.private_key) {
+        setError("Invalid recovery file format.");
+        setLoading(false);
+        return;
+      }
+
+      const filePublicKey = fromBase64(data.public_key);
+      const fileSecretKey = fromBase64(data.private_key);
+
+      // Fetch the server's stored public key to validate match
+      const token = getAccessToken();
+      const resp = await fetch("/v1/auth/me/public-key", {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+
+      if (!resp.ok) {
+        setError("Failed to verify public key with server.");
+        setLoading(false);
+        return;
+      }
+
+      const serverData = await resp.json();
+      if (!serverData.public_key) {
+        setError("No public key stored on server.");
+        setLoading(false);
+        return;
+      }
+
+      const serverPublicKey = fromBase64(serverData.public_key);
+
+      if (!arraysEqual(filePublicKey, serverPublicKey)) {
+        setError("This recovery file does not match your account.");
+        setLoading(false);
+        return;
+      }
+
+      // Match confirmed — save to IndexedDB
+      await saveKeypair(developerId, {
+        publicKey: filePublicKey,
+        secretKey: fileSecretKey,
+      });
+
+      onReload();
+    } catch {
+      setError("Failed to parse recovery file.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleRegenerate() {
+    setError(null);
+    setLoading(true);
+
+    try {
+      const keypair = await generateKeyPair();
+
+      const token = getAccessToken();
+      const resp = await fetch("/v1/auth/me/public-key", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({
+          public_key: toBase64(keypair.publicKey),
+        }),
+      });
+
+      if (!resp.ok) {
+        setError("Failed to upload new public key to server.");
+        setLoading(false);
+        return;
+      }
+
+      // Clear old keypair and save new one
+      await deleteKeypair(developerId);
+      await saveKeypair(developerId, {
+        publicKey: keypair.publicKey,
+        secretKey: keypair.secretKey,
+      });
+
+      onReload();
+    } catch {
+      setError("Failed to generate new keypair.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="recover-keypair-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+    >
+      <div className="w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg">
+        <h2
+          id="recover-keypair-title"
+          className="text-xl font-semibold"
+        >
+          Keypair Recovery
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Your encryption keypair was not found in this browser. Choose
+          how to restore access to your encrypted data.
+        </p>
+
+        {error && (
+          <p className="mt-3 text-sm text-red-500" role="alert">
+            {error}
+          </p>
+        )}
+
+        {mode === "choose" && (
+          <div className="mt-6 flex flex-col gap-3">
+            <Button
+              type="button"
+              onClick={() => setMode("upload")}
+              className="w-full"
+            >
+              Upload recovery file
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setMode("regenerate")}
+              className="w-full"
+            >
+              Generate new keypair
+            </Button>
+          </div>
+        )}
+
+        {mode === "upload" && (
+          <div className="mt-6 flex flex-col gap-3">
+            <Label htmlFor="recovery-file-input" className="text-sm">
+              Select your recovery file (.json)
+            </Label>
+            <input
+              id="recovery-file-input"
+              data-testid="recovery-file-input"
+              type="file"
+              accept=".json,application/json"
+              onChange={handleFileUpload}
+              disabled={loading}
+              className="text-sm"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setMode("choose");
+                setError(null);
+              }}
+              disabled={loading}
+            >
+              Back
+            </Button>
+          </div>
+        )}
+
+        {mode === "regenerate" && (
+          <div className="mt-6 flex flex-col gap-3">
+            <p className="text-sm font-medium text-red-500">
+              All projects created before this moment will become
+              unrecoverable. This cannot be undone.
+            </p>
+            <div className="flex items-start gap-2">
+              <input
+                id="regenerate-ack"
+                type="checkbox"
+                role="checkbox"
+                checked={acknowledged}
+                onChange={(e) => setAcknowledged(e.target.checked)}
+                className="mt-1"
+              />
+              <Label
+                htmlFor="regenerate-ack"
+                className="text-sm font-normal leading-tight"
+              >
+                I understand
+              </Label>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setMode("choose");
+                  setError(null);
+                  setAcknowledged(false);
+                }}
+                disabled={loading}
+              >
+                Back
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={handleRegenerate}
+                disabled={!acknowledged || loading}
+              >
+                Confirm
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/lib/keypair-context.tsx
+++ b/dashboard/src/lib/keypair-context.tsx
@@ -28,6 +28,8 @@ export interface KeypairState {
   privateKey: Uint8Array | null;
   loaded: boolean;
   error: string | null;
+  /** Re-trigger keypair load from IndexedDB (e.g. after recovery). */
+  reload: () => void;
 }
 
 const KeypairContext = React.createContext<KeypairState>({
@@ -35,13 +37,14 @@ const KeypairContext = React.createContext<KeypairState>({
   privateKey: null,
   loaded: false,
   error: null,
+  reload: () => {},
 });
 
 /**
  * Decode the `sub` claim from a JWT without verifying the signature.
  * Only used to key the IndexedDB lookup — the token is already server-issued.
  */
-function developerIdFromToken(token: string): string | null {
+export function developerIdFromToken(token: string): string | null {
   try {
     const parts = token.split(".");
     if (parts.length !== 3) return null;
@@ -130,12 +133,19 @@ export function KeypairProvider({
   children: React.ReactNode;
 }) {
   /* --- Keypair state (new) --- */
-  const [keypairState, setKeypairState] = React.useState<KeypairState>({
+  const [kpCore, setKpCore] = React.useState<Omit<KeypairState, "reload">>({
     publicKey: null,
     privateKey: null,
     loaded: false,
     error: null,
   });
+
+  // Bump to retrigger the IndexedDB load (used by reload callback).
+  const [loadGeneration, setLoadGeneration] = React.useState(0);
+
+  const reload = React.useCallback(() => {
+    setLoadGeneration((g) => g + 1);
+  }, []);
 
   // Track the access token reactively so the keypair loads both on mount
   // (page refresh with existing token) AND after a fresh login/signup.
@@ -148,7 +158,7 @@ export function KeypairProvider({
     const unsubLogin = onLogin(() => setToken(getAccessToken()));
     const unsubLogout = onLogout(() => {
       setToken(null);
-      setKeypairState({
+      setKpCore({
         publicKey: null,
         privateKey: null,
         loaded: false,
@@ -161,7 +171,7 @@ export function KeypairProvider({
     };
   }, []);
 
-  // Load keypair from IndexedDB whenever token changes
+  // Load keypair from IndexedDB whenever token or loadGeneration changes
   React.useEffect(() => {
     if (!token) return;
 
@@ -174,14 +184,14 @@ export function KeypairProvider({
       .then((stored) => {
         if (cancelled) return;
         if (stored) {
-          setKeypairState({
+          setKpCore({
             publicKey: stored.publicKey,
             privateKey: stored.secretKey,
             loaded: true,
             error: null,
           });
         } else {
-          setKeypairState({
+          setKpCore({
             publicKey: null,
             privateKey: null,
             loaded: true,
@@ -191,7 +201,7 @@ export function KeypairProvider({
       })
       .catch(() => {
         if (cancelled) return;
-        setKeypairState({
+        setKpCore({
           publicKey: null,
           privateKey: null,
           loaded: true,
@@ -202,7 +212,12 @@ export function KeypairProvider({
     return () => {
       cancelled = true;
     };
-  }, [token]);
+  }, [token, loadGeneration]);
+
+  const keypairState: KeypairState = React.useMemo(
+    () => ({ ...kpCore, reload }),
+    [kpCore, reload],
+  );
 
   /* --- Legacy envelope-key state --- */
   const [wrappingKey, setWrappingKeyState] = React.useState<CryptoKey | null>(

--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -7,22 +7,26 @@ import {
 } from "@tanstack/react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "~/lib/theme";
-import { KeypairProvider, useKeypair } from "~/lib/keypair-context";
+import {
+  KeypairProvider,
+  useKeypair,
+  developerIdFromToken,
+} from "~/lib/keypair-context";
+import { getAccessToken } from "~/lib/auth-store";
 import { SidebarNav } from "~/components/sidebar-nav";
 import { TopBar } from "~/components/top-bar";
+import { RecoverKeypairModal } from "~/components/recover-keypair-modal";
 import appCss from "~/styles/app.css?url";
 
-function KeypairBanner() {
-  const { error } = useKeypair();
+function KeypairRecovery() {
+  const { error, reload } = useKeypair();
   if (error !== "missing") return null;
-  return (
-    <div
-      role="status"
-      className="bg-yellow-900/30 border-b border-yellow-700/50 px-4 py-2 text-sm text-yellow-200"
-    >
-      Encryption key not loaded. Keypair recovery coming soon.
-    </div>
-  );
+
+  const token = getAccessToken();
+  const developerId = token ? developerIdFromToken(token) : null;
+  if (!developerId) return null;
+
+  return <RecoverKeypairModal developerId={developerId} onReload={reload} />;
 }
 
 const AUTH_ROUTES = ["/login", "/signup"];
@@ -64,7 +68,7 @@ function RootComponent() {
                   <SidebarNav />
                   <div className="flex flex-1 flex-col overflow-hidden">
                     <TopBar />
-                    <KeypairBanner />
+                    <KeypairRecovery />
                     <main className="flex-1 overflow-auto p-6">
                       <Outlet />
                     </main>

--- a/dashboard/tests/unit/recover-keypair-modal.test.tsx
+++ b/dashboard/tests/unit/recover-keypair-modal.test.tsx
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
+
+// Hoisted mocks
+const {
+  mockGetAccessToken,
+  mockSaveKeypair,
+  mockDeleteKeypair,
+  mockGenerateKeyPair,
+  mockFetch,
+  mockReloadKeypair,
+} = vi.hoisted(() => ({
+  mockGetAccessToken: vi.fn(),
+  mockSaveKeypair: vi.fn(),
+  mockDeleteKeypair: vi.fn(),
+  mockGenerateKeyPair: vi.fn(),
+  mockFetch: vi.fn(),
+  mockReloadKeypair: vi.fn(),
+}));
+
+vi.mock("~/lib/auth-store", () => ({
+  getAccessToken: mockGetAccessToken,
+  onLogin: vi.fn(() => () => undefined),
+  onLogout: vi.fn(() => () => undefined),
+}));
+
+vi.mock("~/lib/keypair-store", () => ({
+  saveKeypair: mockSaveKeypair,
+  loadKeypair: vi.fn(),
+  deleteKeypair: mockDeleteKeypair,
+}));
+
+vi.mock("@pqdb/client", () => ({
+  generateKeyPair: mockGenerateKeyPair,
+}));
+
+// Stub global fetch
+vi.stubGlobal("fetch", mockFetch);
+
+import { RecoverKeypairModal } from "~/components/recover-keypair-modal";
+
+// ML-KEM-768 sizes
+const PK_BYTES = 1184;
+const SK_BYTES = 2400;
+
+const MOCK_PUBLIC_KEY = new Uint8Array(PK_BYTES).fill(7);
+const MOCK_SECRET_KEY = new Uint8Array(SK_BYTES).fill(11);
+const MOCK_PUBLIC_KEY_2 = new Uint8Array(PK_BYTES).fill(9);
+const MOCK_SECRET_KEY_2 = new Uint8Array(SK_BYTES).fill(13);
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary);
+}
+
+function fromBase64(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+const DEV_ID = "11111111-1111-1111-1111-111111111111";
+const DEV_EMAIL = "test@example.com";
+
+function fakeAccessToken(sub: string): string {
+  const header = btoa(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
+  const payload = btoa(JSON.stringify({ sub, exp: 9999999999 }));
+  return `${header}.${payload}.fake-sig`;
+}
+
+function makeRecoveryFile(
+  publicKey: Uint8Array,
+  secretKey: Uint8Array,
+): string {
+  return JSON.stringify({
+    version: 1,
+    developer_id: DEV_ID,
+    email: DEV_EMAIL,
+    public_key: toBase64(publicKey),
+    private_key: toBase64(secretKey),
+    created_at: "2026-01-01T00:00:00.000Z",
+    warning: "test",
+  });
+}
+
+describe("RecoverKeypairModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+    globalThis.indexedDB = new IDBFactory();
+    mockGetAccessToken.mockReturnValue(fakeAccessToken(DEV_ID));
+    mockSaveKeypair.mockResolvedValue(undefined);
+    mockDeleteKeypair.mockResolvedValue(undefined);
+    mockReloadKeypair.mockResolvedValue(undefined);
+  });
+
+  it("renders the modal with two options", () => {
+    render(
+      <RecoverKeypairModal
+        developerId={DEV_ID}
+        onReload={mockReloadKeypair}
+      />,
+    );
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(
+      screen.getByText(/upload recovery file/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/generate new keypair/i),
+    ).toBeInTheDocument();
+  });
+
+  it("upload flow: parses JSON, validates public key match, stores in IndexedDB", async () => {
+    const user = userEvent.setup();
+
+    // Mock GET /v1/auth/me/public-key — returns the matching key
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ public_key: toBase64(MOCK_PUBLIC_KEY) }),
+    });
+
+    render(
+      <RecoverKeypairModal
+        developerId={DEV_ID}
+        onReload={mockReloadKeypair}
+      />,
+    );
+
+    // Click upload option
+    await user.click(screen.getByText(/upload recovery file/i));
+
+    // Create a recovery file and upload it
+    const fileContent = makeRecoveryFile(MOCK_PUBLIC_KEY, MOCK_SECRET_KEY);
+    const file = new File([fileContent], "recovery.json", {
+      type: "application/json",
+    });
+
+    const input = screen.getByTestId("recovery-file-input");
+    await user.upload(input, file);
+
+    // Wait for the save to complete
+    await waitFor(() => {
+      expect(mockSaveKeypair).toHaveBeenCalledWith(DEV_ID, {
+        publicKey: MOCK_PUBLIC_KEY,
+        secretKey: MOCK_SECRET_KEY,
+      });
+    });
+
+    expect(mockReloadKeypair).toHaveBeenCalled();
+  });
+
+  it("upload flow: rejects mismatched public key", async () => {
+    const user = userEvent.setup();
+
+    // Mock GET /v1/auth/me/public-key — returns DIFFERENT key
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ public_key: toBase64(MOCK_PUBLIC_KEY_2) }),
+    });
+
+    render(
+      <RecoverKeypairModal
+        developerId={DEV_ID}
+        onReload={mockReloadKeypair}
+      />,
+    );
+
+    await user.click(screen.getByText(/upload recovery file/i));
+
+    const fileContent = makeRecoveryFile(MOCK_PUBLIC_KEY, MOCK_SECRET_KEY);
+    const file = new File([fileContent], "recovery.json", {
+      type: "application/json",
+    });
+
+    const input = screen.getByTestId("recovery-file-input");
+    await user.upload(input, file);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/does not match your account/i),
+      ).toBeInTheDocument();
+    });
+
+    // Should NOT have saved
+    expect(mockSaveKeypair).not.toHaveBeenCalled();
+    expect(mockReloadKeypair).not.toHaveBeenCalled();
+  });
+
+  it("regenerate flow: generates keypair, PUTs new key, saves to IndexedDB", async () => {
+    const user = userEvent.setup();
+
+    mockGenerateKeyPair.mockResolvedValue({
+      publicKey: MOCK_PUBLIC_KEY_2,
+      secretKey: MOCK_SECRET_KEY_2,
+    });
+
+    // Mock PUT /v1/auth/me/public-key
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+
+    render(
+      <RecoverKeypairModal
+        developerId={DEV_ID}
+        onReload={mockReloadKeypair}
+      />,
+    );
+
+    // Click regenerate option
+    await user.click(screen.getByText(/generate new keypair/i));
+
+    // Should show warning
+    expect(
+      screen.getByText(/will become unrecoverable/i),
+    ).toBeInTheDocument();
+
+    // Checkbox must be checked before proceeding
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).not.toBeChecked();
+
+    const confirmButton = screen.getByRole("button", { name: /confirm/i });
+    expect(confirmButton).toBeDisabled();
+
+    // Check the checkbox
+    await user.click(checkbox);
+    expect(confirmButton).toBeEnabled();
+
+    // Click confirm
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockGenerateKeyPair).toHaveBeenCalled();
+    });
+
+    // Verify PUT was called with new public key
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/v1/auth/me/public-key",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({
+            public_key: toBase64(MOCK_PUBLIC_KEY_2),
+          }),
+        }),
+      );
+    });
+
+    // Verify old keypair was deleted and new one saved
+    await waitFor(() => {
+      expect(mockDeleteKeypair).toHaveBeenCalledWith(DEV_ID);
+    });
+    expect(mockSaveKeypair).toHaveBeenCalledWith(DEV_ID, {
+      publicKey: MOCK_PUBLIC_KEY_2,
+      secretKey: MOCK_SECRET_KEY_2,
+    });
+    expect(mockReloadKeypair).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Who
Isaac Quintero + Claude Opus 4.6 (pair-programming)

## What
- Add `PUT /v1/auth/me/public-key` backend endpoint for ML-KEM-768 key rotation (validates base64, enforces 1184-byte length, requires bearer auth)
- Add `RecoverKeypairModal` component with two flows: upload recovery file (validates public key matches server) or regenerate keypair (red warning + checkbox confirmation)
- Add `reload()` callback to `KeypairState` interface so the modal can trigger context refresh after IndexedDB write
- Replace placeholder `KeypairBanner` from US-005a with the full recovery modal in `__root.tsx`
- Export `developerIdFromToken` from keypair-context for root layout use

## When
2026-04-10

## Where
- `backend/src/pqdb_api/routes/auth.py` — PUT endpoint, request/response models, validator
- `backend/tests/integration/test_auth_public_key.py` — integration tests for PUT endpoint
- `dashboard/src/components/recover-keypair-modal.tsx` — new recovery modal component
- `dashboard/src/lib/keypair-context.tsx` — added `reload()` to KeypairState, exported `developerIdFromToken`
- `dashboard/src/routes/__root.tsx` — replaced KeypairBanner with KeypairRecovery (renders modal)
- `dashboard/tests/unit/recover-keypair-modal.test.tsx` — 4 unit tests for modal flows

## Why
When a developer logs in on a new device or clears browser storage, their ML-KEM-768 keypair is missing from IndexedDB. Without a recovery flow, encrypted projects are permanently inaccessible. US-005a added detection (error='missing' + placeholder banner) but no actionable recovery path. This PR completes the story by giving two concrete options: restore from backup or start fresh with a new keypair.

## How
**Upload flow:** User selects a recovery JSON file. The modal parses it, fetches `GET /v1/auth/me/public-key` from the server, and compares the file's public key against the server's stored key. If they match, the private key is saved to IndexedDB via `saveKeypair()`. If they don't match, a clear error is shown: "This recovery file does not match your account."

**Regenerate flow:** User sees a red warning about data loss, must check an "I understand" checkbox. On confirm, `generateKeyPair()` from `@pqdb/client` creates a new ML-KEM-768 keypair, `PUT /v1/auth/me/public-key` uploads the new public key, old IndexedDB entry is deleted, new keypair is saved.

**Reload mechanism:** Added a `loadGeneration` counter to `KeypairProvider`. The `reload()` callback bumps this counter, which is in the dependency array of the IndexedDB load effect, triggering a re-read.

**Considered:**
- Inline banner with action buttons: Rejected — recovery is a critical flow that deserves a modal to prevent accidental navigation
- Separate recovery page/route: Rejected — adds routing complexity; modal overlay is simpler
- PATCH instead of PUT for backend: Rejected — this is a full replacement, PUT is idempotent and semantically correct

**Trade-offs:**
- No rate limiting on PUT endpoint yet (acceptable for Phase 1)
- Old ciphertexts encrypted to the previous public key become unrecoverable after regeneration (by design — warned in UI)

## Test plan
- [x] Backend integration test: PUT requires auth, accepts valid key, rejects wrong length/invalid base64, replaces existing key (6 tests)
- [x] Frontend unit tests: modal renders with two options, upload happy path, upload mismatch rejection, regenerate happy path (4 tests)
- [x] Existing keypair-context tests still pass (6/6)
- [x] Full dashboard test suite: 584/585 pass (1 pre-existing failure in login-mcp-redirect.test.tsx, confirmed on main)
- [x] TypeScript typecheck passes (`tsc --noEmit`)
- [x] Production build succeeds (`vite build`)
- [x] Backend lint (`ruff check`) and type check (`mypy`) pass
- [x] gitleaks: no secrets detected

## Non-goals
- E2E tests (deferred — requires running infrastructure + browser automation)
- Rate limiting on PUT endpoint (Phase 2)
- Key rotation notification to other devices (Phase 2)
- Recovery file encryption/password protection (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)