### PR TITLE
[US-007] Dashboard project-load decapsulates wrapped_encryption_key

### DIFF
--- a/dashboard/src/lib/auto-unlock.tsx
+++ b/dashboard/src/lib/auto-unlock.tsx
@@ -1,0 +1,51 @@
+/**
+ * AutoUnlock — component that automatically unlocks the encryption context
+ * using the best available project key.
+ *
+ * Priority:
+ * 1. PQC project key from decapsulate (useProjectKeys) — base64url encoded
+ * 2. Legacy envelope encryption key (useEnvelopeKeys) — used as-is
+ *
+ * Renders nothing — pure side-effect component.
+ */
+
+import * as React from "react";
+import { useProjectKeys, useEnvelopeKeys } from "./keypair-context";
+import { useEncryption } from "./encryption-context";
+
+/**
+ * Encode bytes to base64url without padding.
+ * Matches the MCP server's bytesToBase64UrlNoPad — the SDK's deriveKeyPair
+ * consumes this format.
+ */
+export function bytesToBase64UrlNoPad(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export function AutoUnlock({ projectId }: { projectId: string }) {
+  const { getProjectKey } = useProjectKeys();
+  const { getEncryptionKey } = useEnvelopeKeys();
+  const { unlock, isUnlocked } = useEncryption();
+
+  React.useEffect(() => {
+    if (isUnlocked) return;
+
+    // Prefer PQC project key from decapsulate
+    const pqcKey = getProjectKey(projectId);
+    if (pqcKey) {
+      unlock(bytesToBase64UrlNoPad(pqcKey));
+      return;
+    }
+
+    // Fall back to legacy envelope key
+    const legacyKey = getEncryptionKey(projectId);
+    if (legacyKey) {
+      unlock(legacyKey);
+    }
+  }, [projectId, getProjectKey, getEncryptionKey, unlock, isUnlocked]);
+
+  return null;
+}

--- a/dashboard/src/lib/keypair-context.tsx
+++ b/dashboard/src/lib/keypair-context.tsx
@@ -56,6 +56,20 @@ function developerIdFromToken(token: string): string | null {
 }
 
 /* ------------------------------------------------------------------ */
+/*  Per-project key context (PQC shared secrets from decapsulate)     */
+/* ------------------------------------------------------------------ */
+
+export interface ProjectKeysState {
+  setProjectKey: (projectId: string, sharedSecret: Uint8Array) => void;
+  getProjectKey: (projectId: string) => Uint8Array | null;
+}
+
+const ProjectKeysContext = React.createContext<ProjectKeysState>({
+  setProjectKey: () => {},
+  getProjectKey: () => null,
+});
+
+/* ------------------------------------------------------------------ */
 /*  Legacy envelope-key context (backward compat)                     */
 /* ------------------------------------------------------------------ */
 
@@ -203,6 +217,31 @@ export function KeypairProvider({
       cancelled = true;
     };
   }, [token]);
+
+  /* --- Per-project key state (PQC decapsulate results) --- */
+  const projectKeysRef = React.useRef<Map<string, Uint8Array>>(new Map());
+  const [projectKeysVersion, setProjectKeysVersion] = React.useState(0);
+
+  const setProjectKey = React.useCallback(
+    (projectId: string, sharedSecret: Uint8Array) => {
+      projectKeysRef.current.set(projectId, sharedSecret);
+      setProjectKeysVersion((v) => v + 1);
+    },
+    [],
+  );
+
+  const getProjectKey = React.useCallback(
+    (projectId: string): Uint8Array | null => {
+      return projectKeysRef.current.get(projectId) ?? null;
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [projectKeysVersion],
+  );
+
+  const projectKeysValue = React.useMemo(
+    () => ({ setProjectKey, getProjectKey }),
+    [setProjectKey, getProjectKey],
+  );
 
   /* --- Legacy envelope-key state --- */
   const [wrappingKey, setWrappingKeyState] = React.useState<CryptoKey | null>(
@@ -376,9 +415,11 @@ export function KeypairProvider({
 
   return (
     <KeypairContext.Provider value={keypairState}>
-      <EnvelopeKeyContext.Provider value={envelopeValue}>
-        {children}
-      </EnvelopeKeyContext.Provider>
+      <ProjectKeysContext.Provider value={projectKeysValue}>
+        <EnvelopeKeyContext.Provider value={envelopeValue}>
+          {children}
+        </EnvelopeKeyContext.Provider>
+      </ProjectKeysContext.Provider>
     </KeypairContext.Provider>
   );
 }
@@ -390,6 +431,11 @@ export function KeypairProvider({
 /** New PQC keypair hook: {publicKey, privateKey, loaded, error}. */
 export function useKeypair(): KeypairState {
   return React.useContext(KeypairContext);
+}
+
+/** Per-project PQC key hook: {setProjectKey, getProjectKey}. */
+export function useProjectKeys(): ProjectKeysState {
+  return React.useContext(ProjectKeysContext);
 }
 
 /** Legacy envelope-key hook — backward compat for existing consumers. */

--- a/dashboard/src/lib/project-decapsulate-gate.tsx
+++ b/dashboard/src/lib/project-decapsulate-gate.tsx
@@ -1,0 +1,50 @@
+/**
+ * ProjectDecapsulateGate — triggers PQC decapsulation for the current project
+ * and renders informational banners for error/missing-key states.
+ *
+ * Always renders children — banners are informational, not blocking.
+ */
+
+import * as React from "react";
+import { useProjectDecapsulate } from "./use-project-decapsulate";
+
+interface Props {
+  projectId: string;
+  wrappedEncryptionKey: string | null;
+  children: React.ReactNode;
+}
+
+export function ProjectDecapsulateGate({
+  projectId,
+  wrappedEncryptionKey,
+  children,
+}: Props) {
+  const { status, error } = useProjectDecapsulate(
+    projectId,
+    wrappedEncryptionKey,
+  );
+
+  return (
+    <>
+      {status === "no-key" && (
+        <div
+          role="status"
+          className="rounded-md border border-blue-500/50 bg-blue-50 dark:bg-blue-950/30 p-3 text-sm text-blue-800 dark:text-blue-200 mb-4"
+        >
+          This project has no encryption key configured. Sensitive columns will
+          be unavailable.
+        </div>
+      )}
+      {(status === "error" || status === "no-keypair") && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive mb-4"
+        >
+          {error ??
+            "Could not decrypt this project. You may need to upload a different recovery file."}
+        </div>
+      )}
+      {children}
+    </>
+  );
+}

--- a/dashboard/src/lib/use-project-decapsulate.ts
+++ b/dashboard/src/lib/use-project-decapsulate.ts
@@ -1,0 +1,98 @@
+/**
+ * useProjectDecapsulate — React hook that decapsulates a project's
+ * wrapped_encryption_key using the developer's ML-KEM-768 private key.
+ *
+ * On success, stores the recovered shared secret via useProjectKeys().
+ * Returns a status string for the UI to render appropriate banners.
+ */
+
+import * as React from "react";
+import { decapsulate } from "@pqdb/client";
+import { useKeypair, useProjectKeys } from "./keypair-context";
+
+export type DecapsulateStatus =
+  | "loading"
+  | "no-keypair"
+  | "no-key"
+  | "ready"
+  | "error";
+
+export interface DecapsulateResult {
+  status: DecapsulateStatus;
+  error: string | null;
+}
+
+/**
+ * Decode a standard base64 string to Uint8Array.
+ */
+function fromBase64(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export function useProjectDecapsulate(
+  projectId: string,
+  wrappedEncryptionKey: string | null,
+): DecapsulateResult {
+  const { privateKey, loaded } = useKeypair();
+  const { getProjectKey, setProjectKey } = useProjectKeys();
+  const [status, setStatus] = React.useState<DecapsulateStatus>("loading");
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!loaded) {
+      setStatus("loading");
+      return;
+    }
+
+    if (!privateKey) {
+      setStatus("no-keypair");
+      return;
+    }
+
+    // Already have the key for this project — skip decapsulation
+    const existingKey = getProjectKey(projectId);
+    if (existingKey) {
+      setStatus("ready");
+      return;
+    }
+
+    if (wrappedEncryptionKey === null) {
+      setStatus("no-key");
+      return;
+    }
+
+    let cancelled = false;
+
+    async function run() {
+      try {
+        const ciphertext = fromBase64(wrappedEncryptionKey!);
+        const sharedSecret = await decapsulate(ciphertext, privateKey!);
+        if (!cancelled) {
+          setProjectKey(projectId, sharedSecret);
+          setStatus("ready");
+          setError(null);
+        }
+      } catch {
+        if (!cancelled) {
+          setStatus("error");
+          setError(
+            "Could not decrypt this project. You may need to upload a different recovery file.",
+          );
+        }
+      }
+    }
+
+    run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loaded, privateKey, projectId, wrappedEncryptionKey, getProjectKey, setProjectKey]);
+
+  return { status, error };
+}

--- a/dashboard/src/routes/projects/$projectId.tsx
+++ b/dashboard/src/routes/projects/$projectId.tsx
@@ -1,14 +1,61 @@
+import * as React from "react";
 import { Outlet, createFileRoute } from "@tanstack/react-router";
 import { AuthGuard } from "~/components/auth-guard";
+import { ProjectDecapsulateGate } from "~/lib/project-decapsulate-gate";
+import { fetchProject, type Project } from "~/lib/projects";
 
 export const Route = createFileRoute("/projects/$projectId")({
   component: ProjectLayout,
 });
 
 function ProjectLayout() {
+  const { projectId } = Route.useParams();
+
   return (
     <AuthGuard>
+      <ProjectDecapsulateLoader projectId={projectId} />
       <Outlet />
     </AuthGuard>
+  );
+}
+
+/**
+ * Fetches the project detail and triggers PQC decapsulation of the
+ * wrapped_encryption_key. Renders banners for error states.
+ */
+function ProjectDecapsulateLoader({ projectId }: { projectId: string }) {
+  const [project, setProject] = React.useState<Project | null>(null);
+  const [loaded, setLoaded] = React.useState(false);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    fetchProject(projectId)
+      .then((p) => {
+        if (!cancelled) {
+          setProject(p);
+          setLoaded(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setLoaded(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  if (!loaded) return null;
+
+  return (
+    <ProjectDecapsulateGate
+      projectId={projectId}
+      wrappedEncryptionKey={project?.wrapped_encryption_key ?? null}
+    >
+      {null}
+    </ProjectDecapsulateGate>
   );
 }

--- a/dashboard/src/routes/projects/$projectId/tables/$tableName.tsx
+++ b/dashboard/src/routes/projects/$projectId/tables/$tableName.tsx
@@ -1,11 +1,10 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import * as React from "react";
 import { ChevronLeft } from "lucide-react";
 import { AuthGuard } from "~/components/auth-guard";
 import { TableDataViewer } from "~/components/table-data-viewer";
 import { Skeleton } from "~/components/ui/skeleton";
-import { EncryptionProvider, useEncryption } from "~/lib/encryption-context";
-import { useEnvelopeKeys } from "~/lib/keypair-context";
+import { EncryptionProvider } from "~/lib/encryption-context";
+import { AutoUnlock } from "~/lib/auto-unlock";
 import { ProjectProvider, useProjectContext } from "~/lib/project-context";
 
 export const Route = createFileRoute(
@@ -84,16 +83,3 @@ function TableDetailRouteInner({
   );
 }
 
-function AutoUnlock({ projectId }: { projectId: string }) {
-  const { getEncryptionKey } = useEnvelopeKeys();
-  const { unlock, isUnlocked } = useEncryption();
-
-  React.useEffect(() => {
-    const key = getEncryptionKey(projectId);
-    if (key && !isUnlocked) {
-      unlock(key);
-    }
-  }, [projectId, getEncryptionKey, unlock, isUnlocked]);
-
-  return null;
-}

--- a/dashboard/tests/unit/keypair-context.test.tsx
+++ b/dashboard/tests/unit/keypair-context.test.tsx
@@ -44,7 +44,7 @@ vi.mock("~/lib/envelope-crypto", () => ({
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-import { KeypairProvider, useKeypair } from "~/lib/keypair-context";
+import { KeypairProvider, useKeypair, useProjectKeys } from "~/lib/keypair-context";
 
 /**
  * Build a fake JWT access token with the given `sub` claim.
@@ -240,5 +240,92 @@ describe("keypair-context", () => {
     });
     expect(result.current.publicKey).toEqual(keypair2.publicKey);
     expect(result.current.privateKey).toEqual(keypair2.secretKey);
+  });
+});
+
+describe("useProjectKeys — per-project shared secret storage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+    loginCallbacks.clear();
+    logoutCallbacks.clear();
+    globalThis.indexedDB = new IDBFactory();
+    sessionStorage.clear();
+  });
+
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return <KeypairProvider>{children}</KeypairProvider>;
+  }
+
+  it("stores a shared secret via setProjectKey and retrieves it via getProjectKey", () => {
+    mockGetAccessToken.mockReturnValue(null);
+    mockFetch.mockResolvedValue({ ok: false });
+
+    const { result } = renderHook(() => useProjectKeys(), {
+      wrapper: Wrapper,
+    });
+
+    const projectId = "proj-111";
+    const sharedSecret = new Uint8Array([10, 20, 30, 40, 50]);
+
+    act(() => {
+      result.current.setProjectKey(projectId, sharedSecret);
+    });
+
+    const retrieved = result.current.getProjectKey(projectId);
+    expect(retrieved).toEqual(sharedSecret);
+  });
+
+  it("returns null for a project ID that has no stored key", () => {
+    mockGetAccessToken.mockReturnValue(null);
+    mockFetch.mockResolvedValue({ ok: false });
+
+    const { result } = renderHook(() => useProjectKeys(), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.getProjectKey("nonexistent")).toBeNull();
+  });
+
+  it("stores keys for multiple projects independently", () => {
+    mockGetAccessToken.mockReturnValue(null);
+    mockFetch.mockResolvedValue({ ok: false });
+
+    const { result } = renderHook(() => useProjectKeys(), {
+      wrapper: Wrapper,
+    });
+
+    const secret1 = new Uint8Array([1, 2, 3]);
+    const secret2 = new Uint8Array([4, 5, 6]);
+
+    act(() => {
+      result.current.setProjectKey("proj-a", secret1);
+      result.current.setProjectKey("proj-b", secret2);
+    });
+
+    expect(result.current.getProjectKey("proj-a")).toEqual(secret1);
+    expect(result.current.getProjectKey("proj-b")).toEqual(secret2);
+  });
+
+  it("overwrites a previously stored key for the same project", () => {
+    mockGetAccessToken.mockReturnValue(null);
+    mockFetch.mockResolvedValue({ ok: false });
+
+    const { result } = renderHook(() => useProjectKeys(), {
+      wrapper: Wrapper,
+    });
+
+    const original = new Uint8Array([1, 1, 1]);
+    const replacement = new Uint8Array([9, 9, 9]);
+
+    act(() => {
+      result.current.setProjectKey("proj-x", original);
+    });
+    expect(result.current.getProjectKey("proj-x")).toEqual(original);
+
+    act(() => {
+      result.current.setProjectKey("proj-x", replacement);
+    });
+    expect(result.current.getProjectKey("proj-x")).toEqual(replacement);
   });
 });

--- a/dashboard/tests/unit/project-decapsulate-autounlock.test.tsx
+++ b/dashboard/tests/unit/project-decapsulate-autounlock.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import * as React from "react";
+
+// Hoisted mocks
+const {
+  mockDecapsulate,
+  mockUseKeypair,
+  mockSetProjectKey,
+  mockGetProjectKey,
+  mockGetEncryptionKey,
+  mockUnlock,
+} = vi.hoisted(() => ({
+  mockDecapsulate: vi.fn(),
+  mockUseKeypair: vi.fn(),
+  mockSetProjectKey: vi.fn(),
+  mockGetProjectKey: vi.fn(),
+  mockGetEncryptionKey: vi.fn(),
+  mockUnlock: vi.fn(),
+}));
+
+vi.mock("@pqdb/client", () => ({
+  decapsulate: mockDecapsulate,
+}));
+
+vi.mock("~/lib/keypair-context", () => ({
+  useKeypair: mockUseKeypair,
+  useProjectKeys: () => ({
+    setProjectKey: mockSetProjectKey,
+    getProjectKey: mockGetProjectKey,
+  }),
+  useEnvelopeKeys: () => ({
+    getEncryptionKey: mockGetEncryptionKey,
+  }),
+}));
+
+vi.mock("~/lib/encryption-context", () => ({
+  useEncryption: () => ({
+    unlock: mockUnlock,
+    isUnlocked: false,
+    encryptionKey: null,
+    lock: vi.fn(),
+  }),
+}));
+
+import { AutoUnlock } from "~/lib/auto-unlock";
+
+/**
+ * Encode Uint8Array to base64url without padding (same as MCP pattern).
+ */
+function bytesToBase64UrlNoPad(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+describe("AutoUnlock — PQC key preference", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseKeypair.mockReturnValue({
+      publicKey: null,
+      privateKey: null,
+      loaded: true,
+      error: null,
+    });
+  });
+
+  it("uses PQC project key (base64url-encoded) when available", () => {
+    const sharedSecret = new Uint8Array(32).fill(0xab);
+    mockGetProjectKey.mockReturnValue(sharedSecret);
+    mockGetEncryptionKey.mockReturnValue(null);
+
+    render(<AutoUnlock projectId="proj-pqc" />);
+
+    expect(mockUnlock).toHaveBeenCalledWith(
+      bytesToBase64UrlNoPad(sharedSecret),
+    );
+  });
+
+  it("falls back to legacy envelope key when PQC key is not available", () => {
+    mockGetProjectKey.mockReturnValue(null);
+    mockGetEncryptionKey.mockReturnValue("legacy-key-abc");
+
+    render(<AutoUnlock projectId="proj-legacy" />);
+
+    expect(mockUnlock).toHaveBeenCalledWith("legacy-key-abc");
+  });
+
+  it("does not call unlock when neither PQC key nor legacy key is available", () => {
+    mockGetProjectKey.mockReturnValue(null);
+    mockGetEncryptionKey.mockReturnValue(null);
+
+    render(<AutoUnlock projectId="proj-none" />);
+
+    expect(mockUnlock).not.toHaveBeenCalled();
+  });
+
+  it("prefers PQC key over legacy key when both are available", () => {
+    const sharedSecret = new Uint8Array(32).fill(0xdd);
+    mockGetProjectKey.mockReturnValue(sharedSecret);
+    mockGetEncryptionKey.mockReturnValue("legacy-key-should-not-use");
+
+    render(<AutoUnlock projectId="proj-both" />);
+
+    expect(mockUnlock).toHaveBeenCalledWith(
+      bytesToBase64UrlNoPad(sharedSecret),
+    );
+    expect(mockUnlock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dashboard/tests/unit/project-decapsulate-gate.test.tsx
+++ b/dashboard/tests/unit/project-decapsulate-gate.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import * as React from "react";
+
+// Hoisted mocks
+const { mockUseProjectDecapsulate } = vi.hoisted(() => ({
+  mockUseProjectDecapsulate: vi.fn(),
+}));
+
+vi.mock("~/lib/use-project-decapsulate", () => ({
+  useProjectDecapsulate: mockUseProjectDecapsulate,
+}));
+
+import { ProjectDecapsulateGate } from "~/lib/project-decapsulate-gate";
+
+describe("ProjectDecapsulateGate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders children when status is 'ready'", () => {
+    mockUseProjectDecapsulate.mockReturnValue({ status: "ready", error: null });
+
+    render(
+      <ProjectDecapsulateGate projectId="p1" wrappedEncryptionKey="AAAA">
+        <p>Project content</p>
+      </ProjectDecapsulateGate>,
+    );
+
+    expect(screen.getByText("Project content")).toBeDefined();
+  });
+
+  it("shows 'no encryption key configured' banner when status is 'no-key'", () => {
+    mockUseProjectDecapsulate.mockReturnValue({ status: "no-key", error: null });
+
+    render(
+      <ProjectDecapsulateGate projectId="p2" wrappedEncryptionKey={null}>
+        <p>Project content</p>
+      </ProjectDecapsulateGate>,
+    );
+
+    expect(
+      screen.getByText(
+        "This project has no encryption key configured. Sensitive columns will be unavailable.",
+      ),
+    ).toBeDefined();
+    // Children should still render — project is usable for plain columns
+    expect(screen.getByText("Project content")).toBeDefined();
+  });
+
+  it("shows 'could not decrypt' error when status is 'error'", () => {
+    mockUseProjectDecapsulate.mockReturnValue({
+      status: "error",
+      error:
+        "Could not decrypt this project. You may need to upload a different recovery file.",
+    });
+
+    render(
+      <ProjectDecapsulateGate projectId="p3" wrappedEncryptionKey="AAAA">
+        <p>Project content</p>
+      </ProjectDecapsulateGate>,
+    );
+
+    expect(
+      screen.getByText(
+        "Could not decrypt this project. You may need to upload a different recovery file.",
+      ),
+    ).toBeDefined();
+    // Children should still render — project is usable for plain columns
+    expect(screen.getByText("Project content")).toBeDefined();
+  });
+
+  it("shows loading state when status is 'loading'", () => {
+    mockUseProjectDecapsulate.mockReturnValue({
+      status: "loading",
+      error: null,
+    });
+
+    render(
+      <ProjectDecapsulateGate projectId="p4" wrappedEncryptionKey="AAAA">
+        <p>Project content</p>
+      </ProjectDecapsulateGate>,
+    );
+
+    // Children still render during loading — decapsulation is non-blocking
+    expect(screen.getByText("Project content")).toBeDefined();
+  });
+
+  it("shows no-keypair banner when status is 'no-keypair'", () => {
+    mockUseProjectDecapsulate.mockReturnValue({
+      status: "no-keypair",
+      error: null,
+    });
+
+    render(
+      <ProjectDecapsulateGate projectId="p5" wrappedEncryptionKey="AAAA">
+        <p>Project content</p>
+      </ProjectDecapsulateGate>,
+    );
+
+    expect(
+      screen.getByText(
+        "Could not decrypt this project. You may need to upload a different recovery file.",
+      ),
+    ).toBeDefined();
+    expect(screen.getByText("Project content")).toBeDefined();
+  });
+});

--- a/dashboard/tests/unit/use-project-decapsulate.test.tsx
+++ b/dashboard/tests/unit/use-project-decapsulate.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import * as React from "react";
+
+// Hoisted mocks
+const {
+  mockDecapsulate,
+  mockSetProjectKey,
+  mockGetProjectKey,
+  mockUseKeypair,
+} = vi.hoisted(() => ({
+  mockDecapsulate: vi.fn(),
+  mockSetProjectKey: vi.fn(),
+  mockGetProjectKey: vi.fn(),
+  mockUseKeypair: vi.fn(),
+}));
+
+vi.mock("@pqdb/client", () => ({
+  decapsulate: mockDecapsulate,
+}));
+
+vi.mock("~/lib/keypair-context", () => ({
+  useKeypair: mockUseKeypair,
+  useProjectKeys: () => ({
+    setProjectKey: mockSetProjectKey,
+    getProjectKey: mockGetProjectKey,
+  }),
+}));
+
+import { useProjectDecapsulate } from "~/lib/use-project-decapsulate";
+
+/**
+ * Encode a Uint8Array to standard base64 (matching what the backend returns
+ * for wrapped_encryption_key).
+ */
+function toBase64(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes));
+}
+
+describe("useProjectDecapsulate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("decapsulates wrapped_encryption_key, stores the shared secret via setProjectKey", async () => {
+    const projectId = "proj-123";
+    const privateKey = new Uint8Array([10, 20, 30]);
+    const ciphertextBytes = new Uint8Array([1, 2, 3, 4, 5]);
+    const wrappedEncryptionKey = toBase64(ciphertextBytes);
+    const sharedSecret = new Uint8Array(32).fill(0xab);
+
+    mockUseKeypair.mockReturnValue({
+      publicKey: new Uint8Array([99]),
+      privateKey,
+      loaded: true,
+      error: null,
+    });
+    mockGetProjectKey.mockReturnValue(null);
+    mockDecapsulate.mockResolvedValue(sharedSecret);
+
+    const { result } = renderHook(() =>
+      useProjectDecapsulate(projectId, wrappedEncryptionKey),
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("ready");
+    });
+
+    expect(mockDecapsulate).toHaveBeenCalledWith(ciphertextBytes, privateKey);
+    expect(mockSetProjectKey).toHaveBeenCalledWith(projectId, sharedSecret);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns status 'no-key' when wrapped_encryption_key is null", async () => {
+    mockUseKeypair.mockReturnValue({
+      publicKey: new Uint8Array([99]),
+      privateKey: new Uint8Array([10]),
+      loaded: true,
+      error: null,
+    });
+    mockGetProjectKey.mockReturnValue(null);
+
+    const { result } = renderHook(() =>
+      useProjectDecapsulate("proj-456", null),
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("no-key");
+    });
+
+    expect(mockDecapsulate).not.toHaveBeenCalled();
+    expect(mockSetProjectKey).not.toHaveBeenCalled();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns status 'error' with message when decapsulate throws", async () => {
+    const privateKey = new Uint8Array([10, 20, 30]);
+    const ciphertextBytes = new Uint8Array([1, 2, 3]);
+    const wrappedKey = toBase64(ciphertextBytes);
+
+    mockUseKeypair.mockReturnValue({
+      publicKey: new Uint8Array([99]),
+      privateKey,
+      loaded: true,
+      error: null,
+    });
+    mockGetProjectKey.mockReturnValue(null);
+    mockDecapsulate.mockRejectedValue(new Error("Decapsulation failed"));
+
+    const { result } = renderHook(() =>
+      useProjectDecapsulate("proj-789", wrappedKey),
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("error");
+    });
+
+    expect(result.current.error).toBe(
+      "Could not decrypt this project. You may need to upload a different recovery file.",
+    );
+  });
+
+  it("returns status 'loading' when keypair has not loaded yet", () => {
+    mockUseKeypair.mockReturnValue({
+      publicKey: null,
+      privateKey: null,
+      loaded: false,
+      error: null,
+    });
+    mockGetProjectKey.mockReturnValue(null);
+
+    const { result } = renderHook(() =>
+      useProjectDecapsulate("proj-wait", "AAAA"),
+    );
+
+    expect(result.current.status).toBe("loading");
+  });
+
+  it("skips decapsulation when project key is already stored", async () => {
+    const existingSecret = new Uint8Array(32).fill(0xcc);
+
+    mockUseKeypair.mockReturnValue({
+      publicKey: new Uint8Array([99]),
+      privateKey: new Uint8Array([10]),
+      loaded: true,
+      error: null,
+    });
+    mockGetProjectKey.mockReturnValue(existingSecret);
+
+    const { result } = renderHook(() =>
+      useProjectDecapsulate("proj-cached", "AAAA"),
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("ready");
+    });
+
+    expect(mockDecapsulate).not.toHaveBeenCalled();
+    expect(mockSetProjectKey).not.toHaveBeenCalled();
+  });
+
+  it("returns status 'no-keypair' when keypair is loaded but privateKey is null", () => {
+    mockUseKeypair.mockReturnValue({
+      publicKey: null,
+      privateKey: null,
+      loaded: true,
+      error: "missing",
+    });
+    mockGetProjectKey.mockReturnValue(null);
+
+    const { result } = renderHook(() =>
+      useProjectDecapsulate("proj-nokey", "AAAA"),
+    );
+
+    expect(result.current.status).toBe("no-keypair");
+  });
+});


### PR DESCRIPTION
## Who

Isaac Quintero + Claude Opus 4.6 (pair-programming)

## What

- Add per-project shared secret storage (setProjectKey/getProjectKey) to KeypairContext using Map<string, Uint8Array>
- New useProjectDecapsulate hook: base64-decodes wrapped_encryption_key, calls SDK decapsulate(ciphertext, privateKey), stores recovered 32-byte shared secret in context
- New ProjectDecapsulateGate component: triggers decapsulation at the /projects/$projectId layout route, renders informational banners for null-key and decapsulate-error states
- Extracted AutoUnlock component that prefers PQC project key (base64url-encoded, same deriveKeyPair(string) pattern proven in US-008) over legacy envelope key

## When

2026-04-10

## Where

- dashboard/src/lib/keypair-context.tsx - Add ProjectKeysContext, useProjectKeys hook
- dashboard/src/lib/use-project-decapsulate.ts - New hook: decapsulate + store shared secret
- dashboard/src/lib/auto-unlock.tsx - New: extracted AutoUnlock with PQC key preference
- dashboard/src/lib/project-decapsulate-gate.tsx - New: triggers decapsulate + renders banners
- dashboard/src/routes/projects/$projectId.tsx - Wire decapsulate at layout level
- dashboard/src/routes/projects/$projectId/tables/$tableName.tsx - Use new AutoUnlock
- dashboard/tests/unit/ - 4 new test files (19 tests total)

## Why

When a developer navigates to /projects/{id}, the dashboard must recover the project encryption key by decapsulating the stored ciphertext with the developer's ML-KEM-768 private key (loaded from IndexedDB via US-005a). Without this, sensitive column data (searchable/private) remains as [encrypted] in the table viewer and cannot be decrypted client-side.

This is US-007 of Phase 5d, bridging the gap between keypair availability (US-005a) and project creation with encapsulate (US-006).

## How

**Approach:** Separate hook + layout-level trigger.

- useProjectDecapsulate(projectId, wrappedEncryptionKey) handles the async decapsulate flow with status tracking (loading/ready/no-key/error/no-keypair)
- ProjectDecapsulateGate wraps the hook and renders banners - triggered once at the $projectId.tsx layout route
- AutoUnlock prefers PQC key (base64url-encoded shared secret) over legacy envelope key, matching the MCP server pattern from US-008
- Per-project keys stored in a Map<string, Uint8Array> ref inside KeypairContext - in-memory only, cleared on page refresh

**Considered:**
- Inline decapsulate in each sub-route: Rejected - duplicates logic across tables, schema, SQL routes
- Add to ProjectProvider: Rejected - adds PQC dependency to a generic context
- Separate hook + layout-level trigger (chosen): Isolates decapsulate logic, triggered once, result shared via context

**Trade-offs:**
- Layout route makes additional fetchProject call - acceptable since browser caches the response
- Per-project keys in memory only - cleared on refresh, re-derived on navigation (desired for security)

## Test plan

- [x] npx vitest run - 599/600 pass (1 pre-existing failure in login-mcp-redirect.test.tsx, confirmed on main)
- [x] 19 new unit tests across 4 test files - all pass
- [x] npx tsc --noEmit - zero type errors
- [x] npm run build - production build succeeds
- [x] gitleaks detect - no leaks found
- [x] Semgrep SAST scan - zero findings
- [ ] CI pipeline

## Non-goals

- E2E test (create project -> close tab -> reopen -> decrypt): deferred to integration with US-006
- Key rotation support (Phase 2 per PRD)
- Passkey/WebAuthn developer login (Phase 3)