### PR TITLE
feat(mcp): recovery file discovery and private key loading (US-010)

### DIFF
--- a/mcp/src/proxy/recovery.ts
+++ b/mcp/src/proxy/recovery.ts
@@ -1,0 +1,119 @@
+/**
+ * Recovery file discovery and private key loading (US-010).
+ *
+ * Discovers the developer's recovery file from well-known locations
+ * and extracts the ML-KEM-768 private key for use in the crypto proxy.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { ML_KEM_768_SECRET_KEY_BYTES } from "../config.js";
+
+/**
+ * Discover the recovery file path using the following priority order:
+ *
+ * 1. Explicit path (e.g. from --recovery-file flag)
+ * 2. ~/.pqdb/recovery.json
+ * 3. Most recent ~/Downloads/pqdb-recovery-*.json (by mtime)
+ *
+ * @throws Error if no recovery file is found, listing all locations checked.
+ */
+export function discoverRecoveryFile(explicitPath?: string): string {
+  if (explicitPath !== undefined) {
+    if (!fs.existsSync(explicitPath)) {
+      throw new Error(
+        `Recovery file not found at specified path: ${explicitPath}`,
+      );
+    }
+    return explicitPath;
+  }
+
+  const home = os.homedir();
+
+  // Priority 2: ~/.pqdb/recovery.json
+  const pqdbPath = path.join(home, ".pqdb", "recovery.json");
+  if (fs.existsSync(pqdbPath)) {
+    return pqdbPath;
+  }
+
+  // Priority 3: most recent ~/Downloads/pqdb-recovery-*.json
+  const downloadsDir = path.join(home, "Downloads");
+  if (fs.existsSync(downloadsDir)) {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(downloadsDir, { withFileTypes: true });
+    } catch {
+      entries = [];
+    }
+
+    const recoveryFiles: { filePath: string; mtime: number }[] = [];
+    for (const entry of entries) {
+      if (
+        entry.isFile() &&
+        entry.name.startsWith("pqdb-recovery-") &&
+        entry.name.endsWith(".json")
+      ) {
+        const filePath = path.join(downloadsDir, entry.name);
+        const stat = fs.statSync(filePath);
+        recoveryFiles.push({ filePath, mtime: stat.mtimeMs });
+      }
+    }
+
+    if (recoveryFiles.length > 0) {
+      // Sort descending by mtime — most recent first
+      recoveryFiles.sort((a, b) => b.mtime - a.mtime);
+      return recoveryFiles[0].filePath;
+    }
+  }
+
+  throw new Error(
+    "No recovery file found. Checked the following locations:\n" +
+      "  1. ~/.pqdb/recovery.json\n" +
+      "  2. ~/Downloads/pqdb-recovery-*.json\n\n" +
+      "To fix this, save your recovery file to ~/.pqdb/recovery.json\n" +
+      "or pass --recovery-file <path> to specify the location explicitly.",
+  );
+}
+
+/**
+ * Load and validate the ML-KEM-768 private key from a recovery file.
+ *
+ * The recovery file is JSON with at least a `private_key` field containing
+ * a base64-encoded ML-KEM-768 secret key (exactly 2400 bytes when decoded).
+ *
+ * @throws Error with a clear message on invalid JSON, missing field, or wrong key length.
+ */
+export function loadPrivateKeyFromRecovery(filePath: string): Uint8Array {
+  const raw = fs.readFileSync(filePath, "utf-8");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("Recovery file is not valid JSON");
+  }
+
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("private_key" in parsed) ||
+    typeof (parsed as Record<string, unknown>).private_key !== "string"
+  ) {
+    throw new Error("Recovery file missing private_key field");
+  }
+
+  const privateKeyB64 = (parsed as Record<string, unknown>).private_key as string;
+
+  // Decode base64 to bytes
+  const buf = Buffer.from(privateKeyB64, "base64");
+  const decoded = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+
+  if (decoded.length !== ML_KEM_768_SECRET_KEY_BYTES) {
+    throw new Error(
+      `Private key must be exactly ${ML_KEM_768_SECRET_KEY_BYTES} bytes (ML-KEM-768), got ${decoded.length}`,
+    );
+  }
+
+  return decoded;
+}

--- a/mcp/tests/unit/recovery.test.ts
+++ b/mcp/tests/unit/recovery.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+import {
+  discoverRecoveryFile,
+  loadPrivateKeyFromRecovery,
+} from "../../src/proxy/recovery.js";
+
+/** Generate a valid base64-encoded key of the given byte length. */
+function makeKeyBase64(length: number): string {
+  const bytes = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    bytes[i] = i % 256;
+  }
+  return Buffer.from(bytes).toString("base64");
+}
+
+/** ML-KEM-768 secret key is exactly 2400 bytes. */
+const VALID_KEY_B64 = makeKeyBase64(2400);
+
+function makeRecoveryJson(overrides: Record<string, unknown> = {}): string {
+  const doc = {
+    version: 1,
+    developer_id: "dev_123",
+    email: "dev@example.com",
+    public_key: "pubkey-placeholder",
+    private_key: VALID_KEY_B64,
+    created_at: "2026-01-01T00:00:00Z",
+    warning: "Keep this file safe",
+    ...overrides,
+  };
+  return JSON.stringify(doc);
+}
+
+describe("loadPrivateKeyFromRecovery", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pqdb-recovery-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("loads a valid recovery file and returns 2400-byte Uint8Array", () => {
+    const filePath = path.join(tmpDir, "recovery.json");
+    fs.writeFileSync(filePath, makeRecoveryJson());
+
+    const key = loadPrivateKeyFromRecovery(filePath);
+    expect(key).toBeInstanceOf(Uint8Array);
+    expect(key.length).toBe(2400);
+    // Verify first few bytes match what we encoded
+    expect(key[0]).toBe(0);
+    expect(key[1]).toBe(1);
+    expect(key[255]).toBe(255);
+  });
+
+  it("rejects invalid JSON with clear error", () => {
+    const filePath = path.join(tmpDir, "recovery.json");
+    fs.writeFileSync(filePath, "not { valid json!!!");
+
+    expect(() => loadPrivateKeyFromRecovery(filePath)).toThrow(
+      "Recovery file is not valid JSON",
+    );
+  });
+
+  it("rejects missing private_key field with clear error", () => {
+    const filePath = path.join(tmpDir, "recovery.json");
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({ version: 1, email: "dev@example.com" }),
+    );
+
+    expect(() => loadPrivateKeyFromRecovery(filePath)).toThrow(
+      "Recovery file missing private_key field",
+    );
+  });
+
+  it("rejects wrong key length with clear error showing actual length", () => {
+    const filePath = path.join(tmpDir, "recovery.json");
+    const wrongKey = makeKeyBase64(100);
+    fs.writeFileSync(filePath, makeRecoveryJson({ private_key: wrongKey }));
+
+    expect(() => loadPrivateKeyFromRecovery(filePath)).toThrow(
+      "Private key must be exactly 2400 bytes (ML-KEM-768), got 100",
+    );
+  });
+
+  it("rejects oversized key with clear error", () => {
+    const filePath = path.join(tmpDir, "recovery.json");
+    const bigKey = makeKeyBase64(5000);
+    fs.writeFileSync(filePath, makeRecoveryJson({ private_key: bigKey }));
+
+    expect(() => loadPrivateKeyFromRecovery(filePath)).toThrow(
+      "Private key must be exactly 2400 bytes (ML-KEM-768), got 5000",
+    );
+  });
+
+  it("rejects non-string private_key field", () => {
+    const filePath = path.join(tmpDir, "recovery.json");
+    fs.writeFileSync(
+      filePath,
+      makeRecoveryJson({ private_key: 12345 }),
+    );
+
+    expect(() => loadPrivateKeyFromRecovery(filePath)).toThrow(
+      "Recovery file missing private_key field",
+    );
+  });
+
+  it("throws when file does not exist", () => {
+    const missingPath = path.join(tmpDir, "nonexistent.json");
+    expect(() => loadPrivateKeyFromRecovery(missingPath)).toThrow();
+  });
+});
+
+describe("discoverRecoveryFile", () => {
+  let tmpDir: string;
+  let fakePqdbDir: string;
+  let fakeDownloadsDir: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pqdb-discover-test-"));
+    // Create fake ~/.pqdb and ~/Downloads
+    fakePqdbDir = path.join(tmpDir, ".pqdb");
+    fakeDownloadsDir = path.join(tmpDir, "Downloads");
+    fs.mkdirSync(fakePqdbDir, { recursive: true });
+    fs.mkdirSync(fakeDownloadsDir, { recursive: true });
+    origHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns explicit path when provided and file exists", () => {
+    const explicitPath = path.join(tmpDir, "my-recovery.json");
+    fs.writeFileSync(explicitPath, makeRecoveryJson());
+
+    const result = discoverRecoveryFile(explicitPath);
+    expect(result).toBe(explicitPath);
+  });
+
+  it("throws when explicit path is provided but file does not exist", () => {
+    const missingPath = path.join(tmpDir, "missing.json");
+    expect(() => discoverRecoveryFile(missingPath)).toThrow(missingPath);
+  });
+
+  it("discovers ~/.pqdb/recovery.json as second priority", () => {
+    const pqdbFile = path.join(fakePqdbDir, "recovery.json");
+    fs.writeFileSync(pqdbFile, makeRecoveryJson());
+
+    const result = discoverRecoveryFile();
+    expect(result).toBe(pqdbFile);
+  });
+
+  it("discovers most recent ~/Downloads/pqdb-recovery-*.json by mtime", () => {
+    // Create two recovery files with different mtimes
+    const older = path.join(fakeDownloadsDir, "pqdb-recovery-2026-01-01.json");
+    const newer = path.join(fakeDownloadsDir, "pqdb-recovery-2026-04-10.json");
+    fs.writeFileSync(older, makeRecoveryJson());
+    fs.writeFileSync(newer, makeRecoveryJson());
+
+    // Set mtimes explicitly: newer file should win
+    const oldTime = new Date("2026-01-01T00:00:00Z");
+    const newTime = new Date("2026-04-10T00:00:00Z");
+    fs.utimesSync(older, oldTime, oldTime);
+    fs.utimesSync(newer, newTime, newTime);
+
+    const result = discoverRecoveryFile();
+    expect(result).toBe(newer);
+  });
+
+  it("prefers ~/.pqdb/recovery.json over ~/Downloads glob", () => {
+    const pqdbFile = path.join(fakePqdbDir, "recovery.json");
+    fs.writeFileSync(pqdbFile, makeRecoveryJson());
+
+    const dlFile = path.join(fakeDownloadsDir, "pqdb-recovery-2026-04-10.json");
+    fs.writeFileSync(dlFile, makeRecoveryJson());
+
+    const result = discoverRecoveryFile();
+    expect(result).toBe(pqdbFile);
+  });
+
+  it("skips non-matching files in ~/Downloads", () => {
+    // Files that don't match the pattern should be ignored
+    fs.writeFileSync(
+      path.join(fakeDownloadsDir, "some-other-file.json"),
+      makeRecoveryJson(),
+    );
+    fs.writeFileSync(
+      path.join(fakeDownloadsDir, "pqdb-something-else.json"),
+      makeRecoveryJson(),
+    );
+
+    expect(() => discoverRecoveryFile()).toThrow(/No recovery file found/);
+  });
+
+  it("throws with helpful error listing all locations when no file is found", () => {
+    // Empty — no recovery files anywhere
+    try {
+      discoverRecoveryFile();
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toMatch(/No recovery file found/);
+      expect(msg).toMatch(/~\/\.pqdb\/recovery\.json/);
+      expect(msg).toMatch(/~\/Downloads\/pqdb-recovery-\*\.json/);
+    }
+  });
+});


### PR DESCRIPTION
## Who
Isaac Quintero + Claude Opus 4.6 (pair programming)

## What
- Add `discoverRecoveryFile(explicitPath?)` — searches explicit path > `~/.pqdb/recovery.json` > most recent `~/Downloads/pqdb-recovery-*.json` (by mtime)
- Add `loadPrivateKeyFromRecovery(path)` — parses recovery JSON, extracts base64-encoded ML-KEM-768 private key, validates exactly 2400 bytes
- Clear error messages for: invalid JSON, missing `private_key` field, wrong key length, no file found (lists all locations checked with suggestion)
- 14 unit tests covering all acceptance criteria

## When
2026-04-10

## Where
- `mcp/src/proxy/recovery.ts` (new file)
- `mcp/tests/unit/recovery.test.ts` (new file)

## Why
US-010: The crypto proxy needs to automatically find the developer's recovery file containing their ML-KEM-768 private key. Without this, developers must manually extract the base64 key from the recovery JSON and paste it into an environment variable — error-prone and bad DX. This module provides automatic discovery with a clear priority chain (explicit flag > well-known path > Downloads glob) so the proxy "just works" after dashboard signup.

## How
- Discovery uses synchronous `fs` operations (`existsSync`, `readdirSync`, `statSync`) since it runs once at startup, not in a hot path
- Downloads scanning filters for `pqdb-recovery-*.json` pattern and sorts by `mtimeMs` descending to pick the most recent file
- Reuses `ML_KEM_768_SECRET_KEY_BYTES` constant from `config.ts` for the 2400-byte validation
- JSON parsing and field extraction done manually rather than reusing `parsePrivateKey` from config.ts because the AC requires different error messages than the `PQDB_PRIVATE_KEY` env var path

Considered:
- Reusing `parsePrivateKey` directly: rejected — AC requires specific error messages ("Recovery file is not valid JSON", "Recovery file missing private_key field") different from the env var error messages
- Using `glob` npm package for Downloads scanning: rejected — `fs.readdirSync` + filter is simpler and avoids adding a dependency
- Async fs operations: rejected — discovery runs once at startup, sync is simpler and sufficient

Trade-offs:
- `~/Downloads` path is Unix-specific (acceptable for Phase 1 local dev tooling)
- Synchronous I/O blocks the event loop briefly at startup (single directory read, negligible)

## Test plan
- [x] Unit tests pass: `npx -w mcp vitest run tests/unit/recovery.test.ts` — 14/14 passing
- [x] Tests cover: explicit path, ~/.pqdb fallback, ~/Downloads glob (mtime ordering), missing file error, invalid JSON, missing field, wrong key length, non-string field, non-matching filenames
- [x] All tests use `fs.mkdtempSync` for isolated temp directories — no real ~/.pqdb or ~/Downloads touched
- [x] No typecheck errors in recovery.ts (pre-existing @pqdb/client errors in other files)
- [x] Build succeeds (ESM + CJS stages pass; DTS error is pre-existing)
- [x] Gitleaks: no secrets detected
- [x] Semgrep SAST: 0 findings

## Non-goals
- CLI `--recovery-file` flag parsing (US-014)
- Proxy server assembly that wires recovery into the startup flow (US-013)
- Key rotation or re-encryption with a new recovery file (Phase 2)
- Windows Downloads folder path support (Phase 1 is local Unix dev only)

Generated with [Claude Code](https://claude.com/claude-code)