### PR TITLE
[US-011] Upstream MCP client for crypto proxy

### DIFF
--- a/mcp/src/proxy/upstream-client.ts
+++ b/mcp/src/proxy/upstream-client.ts
@@ -1,0 +1,143 @@
+/**
+ * UpstreamClient — connects to a hosted MCP server as an MCP client.
+ *
+ * US-011: Upstream MCP client for the crypto proxy.
+ * Forwards tool calls to the hosted server and returns responses.
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+/** Simplified tool descriptor returned by listTools(). */
+export interface ToolInfo {
+  name: string;
+  description?: string;
+  inputSchema: {
+    type: "object";
+    properties?: Record<string, object>;
+    required?: string[];
+    [key: string]: unknown;
+  };
+}
+
+/** Result returned by callTool(). */
+export interface CallToolResult {
+  content: Array<{
+    type: string;
+    text?: string;
+    [key: string]: unknown;
+  }>;
+  isError?: boolean;
+  [key: string]: unknown;
+}
+
+export class UpstreamClient {
+  private readonly targetUrl: string;
+  private readonly authHeaders?: Record<string, string>;
+  private client: Client | null = null;
+
+  constructor(targetUrl: string, authHeaders?: Record<string, string>) {
+    this.targetUrl = targetUrl;
+    this.authHeaders = authHeaders;
+  }
+
+  /**
+   * Establishes a StreamableHTTPClientTransport connection to the hosted MCP server.
+   */
+  async connect(): Promise<void> {
+    const url = new URL(this.targetUrl);
+
+    const transportOpts = this.authHeaders
+      ? { requestInit: { headers: this.authHeaders } }
+      : undefined;
+
+    const transport = new StreamableHTTPClientTransport(url, transportOpts);
+
+    const client = new Client(
+      { name: "pqdb-proxy", version: "0.1.0" },
+      { capabilities: {} },
+    );
+
+    try {
+      await client.connect(transport);
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : String(err);
+      const name = err instanceof Error ? err.name : "";
+      const code =
+        err !== null &&
+        typeof err === "object" &&
+        "code" in err
+          ? (err as Record<string, unknown>).code
+          : undefined;
+
+      if (name === "AbortError" || message.includes("aborted")) {
+        throw new Error(
+          `Connection timed out to upstream MCP server at ${this.targetUrl}: ${message}`,
+        );
+      }
+
+      if (
+        code === 401 ||
+        code === 403 ||
+        /unauthori|forbidden/i.test(message)
+      ) {
+        throw new Error(
+          `Auth failed for upstream MCP server at ${this.targetUrl}: ${message}`,
+        );
+      }
+
+      throw new Error(
+        `Failed to connect to upstream MCP server at ${this.targetUrl}: ${message}`,
+      );
+    }
+
+    this.client = client;
+  }
+
+  /**
+   * Returns all tools from the hosted MCP server with their names,
+   * descriptions, and input schemas.
+   */
+  async listTools(): Promise<ToolInfo[]> {
+    if (!this.client) {
+      throw new Error("Not connected — call connect() first");
+    }
+
+    const result = await this.client.listTools();
+
+    return result.tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+    }));
+  }
+
+  /**
+   * Forwards a tool call to the hosted MCP server and returns the result.
+   */
+  async callTool(
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<CallToolResult> {
+    if (!this.client) {
+      throw new Error("Not connected — call connect() first");
+    }
+
+    const result = await this.client.callTool({
+      name,
+      arguments: args,
+    });
+
+    return result as CallToolResult;
+  }
+
+  /**
+   * Cleanly disconnects from the hosted MCP server.
+   */
+  async close(): Promise<void> {
+    if (this.client) {
+      await this.client.close();
+      this.client = null;
+    }
+  }
+}

--- a/mcp/tests/unit/upstream-client.test.ts
+++ b/mcp/tests/unit/upstream-client.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Unit tests for UpstreamClient — US-011
+ *
+ * Mocks the MCP SDK Client and StreamableHTTPClientTransport to verify
+ * the connect/listTools/callTool/close lifecycle without hitting a real server.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// --- Mock the MCP SDK modules before importing UpstreamClient ---
+
+const mockConnect = vi.fn().mockResolvedValue(undefined);
+const mockListTools = vi.fn().mockResolvedValue({
+  tools: [
+    {
+      name: "pqdb_status",
+      description: "Check server status",
+      inputSchema: { type: "object" as const, properties: {} },
+    },
+    {
+      name: "pqdb_insert",
+      description: "Insert a row",
+      inputSchema: {
+        type: "object" as const,
+        properties: { table: { type: "string" } },
+        required: ["table"],
+      },
+    },
+  ],
+});
+const mockCallTool = vi.fn().mockResolvedValue({
+  content: [{ type: "text", text: '{"ok":true}' }],
+});
+const mockClose = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    connect: mockConnect,
+    listTools: mockListTools,
+    callTool: mockCallTool,
+    close: mockClose,
+  })),
+}));
+
+const mockTransportStart = vi.fn().mockResolvedValue(undefined);
+const mockTransportClose = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: vi.fn().mockImplementation(() => ({
+    start: mockTransportStart,
+    close: mockTransportClose,
+  })),
+}));
+
+import { UpstreamClient } from "../../src/proxy/upstream-client.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+describe("UpstreamClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("stores targetUrl and optional authHeaders", () => {
+      const client = new UpstreamClient("http://localhost:3000/mcp");
+      expect(client).toBeDefined();
+    });
+
+    it("accepts optional authHeaders", () => {
+      const client = new UpstreamClient("http://localhost:3000/mcp", {
+        Authorization: "Bearer token123",
+      });
+      expect(client).toBeDefined();
+    });
+  });
+
+  describe("connect()", () => {
+    it("creates a StreamableHTTPClientTransport and connects the Client", async () => {
+      const client = new UpstreamClient("http://localhost:3000/mcp");
+      await client.connect();
+
+      expect(StreamableHTTPClientTransport).toHaveBeenCalledTimes(1);
+      // Verify URL is constructed from targetUrl
+      const transportCalls = vi.mocked(StreamableHTTPClientTransport).mock
+        .calls;
+      expect(transportCalls[0][0]).toBeInstanceOf(URL);
+      expect(transportCalls[0][0].toString()).toBe(
+        "http://localhost:3000/mcp",
+      );
+
+      expect(Client).toHaveBeenCalledTimes(1);
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes authHeaders via requestInit to the transport", async () => {
+      const headers = {
+        Authorization: "Bearer secret",
+        "X-Custom": "value",
+      };
+      const client = new UpstreamClient(
+        "http://localhost:3000/mcp",
+        headers,
+      );
+      await client.connect();
+
+      const transportCalls = vi.mocked(StreamableHTTPClientTransport).mock
+        .calls;
+      expect(transportCalls[0][1]).toEqual(
+        expect.objectContaining({
+          requestInit: {
+            headers,
+          },
+        }),
+      );
+    });
+
+    it("does not pass requestInit when no authHeaders provided", async () => {
+      const client = new UpstreamClient("http://localhost:3000/mcp");
+      await client.connect();
+
+      const transportCalls = vi.mocked(StreamableHTTPClientTransport).mock
+        .calls;
+      // Second arg should be undefined or not contain requestInit with headers
+      const opts = transportCalls[0][1];
+      expect(opts).toBeUndefined();
+    });
+
+    it("throws with clear message on connection refused", async () => {
+      mockConnect.mockRejectedValueOnce(new Error("fetch failed"));
+
+      const client = new UpstreamClient("http://localhost:3000/mcp");
+      await expect(client.connect()).rejects.toThrow(
+        /failed to connect.*http:\/\/localhost:3000\/mcp/i,
+      );
+    });
+
+    it("throws with clear message on timeout", async () => {
+      const timeoutError = new Error("The operation was aborted");
+      timeoutError.name = "AbortError";
+      mockConnect.mockRejectedValueOnce(timeoutError);
+
+      const client = new UpstreamClient("http://localhost:3000/mcp");
+      await expect(client.connect()).rejects.toThrow(
+        /timed out.*http:\/\/localhost:3000\/mcp/i,
+      );
+    });
+
+    it("throws with clear message on auth failure (401/403)", async () => {
+      const authError = new Error("Unauthorized");
+      (authError as Record<string, unknown>).code = 401;
+      mockConnect.mockRejectedValueOnce(authError);
+
+      const client = new UpstreamClient("http://localhost:3000/mcp");
+      await expect(client.connect()).rejects.toThrow(
+        /auth.*failed.*http:\/\/localhost:3000\/mcp/i,
+      );
+    });
+  });
+
+  describe("listTools()", () => {
+    it("returns tools with names, descriptions, and input schemas", async () => {
+      const client = new UpstreamClient("http://localhost:3000/mcp");
+      await client.connect();
+
+      const tools = await client.listTools();
+
+      expect(mockListTools).toHaveBeenCalledTimes(1);
+      expect(tools).toHaveLength(2);
+      expect(tools[0]).toEqual({
+        name: "pqdb_status",
+        description: "Check server status",
+        inputSchema: { type: "object", properties: {} },
+      });
+      expect(tools[1]).toEqual({
+        name: "pqdb_insert",
+        description: "Insert a row",
+        inputSchema: {
+          type: "object",
+          properties: { table: { type: "string" } },
+          required: ["table"],
+        },
+      });
+    });
+
+    it("throws if not connected", async () => {
+      const client = new UpstreamClient("http://localhost:3000/mcp");
+      await expect(client.listTools()).rejects.toThrow(/not connected/i);
+    });
+  });
+
+  describe("callTool()", () => {
+    it("forwards tool call and returns result", async () => {
+      const client = new UpstreamClient("http://localhost:3000/mcp");
+      await client.connect();
+
+      const result = await client.callTool("pqdb_insert", {
+        table: "users",
+      });
+
+      expect(mockCallTool).toHaveBeenCalledWith({
+        name: "pqdb_insert",
+        arguments: { table: "users" },
+      });
+      expect(result).toEqual({
+        content: [{ type: "text", text: '{"ok":true}' }],
+      });
+    });
+
+    it("throws if not connected", async () => {
+      const client = new UpstreamClient("http://localhost:3000/mcp");
+      await expect(
+        client.callTool("pqdb_insert", { table: "users" }),
+      ).rejects.toThrow(/not connected/i);
+    });
+
+    it("propagates errors from callTool", async () => {
+      mockCallTool.mockRejectedValueOnce(new Error("tool execution failed"));
+
+      const client = new UpstreamClient("http://localhost:3000/mcp");
+      await client.connect();
+
+      await expect(
+        client.callTool("bad_tool", {}),
+      ).rejects.toThrow("tool execution failed");
+    });
+  });
+
+  describe("close()", () => {
+    it("cleanly disconnects the client", async () => {
+      const client = new UpstreamClient("http://localhost:3000/mcp");
+      await client.connect();
+      await client.close();
+
+      expect(mockClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("is safe to call when not connected", async () => {
+      const client = new UpstreamClient("http://localhost:3000/mcp");
+      // Should not throw
+      await client.close();
+    });
+
+    it("prevents further operations after close", async () => {
+      const client = new UpstreamClient("http://localhost:3000/mcp");
+      await client.connect();
+      await client.close();
+
+      await expect(client.listTools()).rejects.toThrow(/not connected/i);
+    });
+  });
+
+  describe("full lifecycle", () => {
+    it("connect → listTools → callTool → close", async () => {
+      const client = new UpstreamClient("http://localhost:3000/mcp", {
+        Authorization: "Bearer test",
+      });
+
+      await client.connect();
+      const tools = await client.listTools();
+      expect(tools).toHaveLength(2);
+
+      const result = await client.callTool("pqdb_status", {});
+      expect(result.content).toBeDefined();
+
+      await client.close();
+
+      // Verify the full sequence of SDK calls
+      expect(StreamableHTTPClientTransport).toHaveBeenCalledTimes(1);
+      expect(Client).toHaveBeenCalledTimes(1);
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+      expect(mockListTools).toHaveBeenCalledTimes(1);
+      expect(mockCallTool).toHaveBeenCalledTimes(1);
+      expect(mockClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Who

Isaac Quintero + Claude Opus 4.6 (pair-programming)

## What

- Add `UpstreamClient` class that connects to a hosted MCP server as an MCP client
- Implements full lifecycle: `connect()`, `listTools()`, `callTool(name, args)`, `close()`
- Connection error handling with clear, categorized messages (refused, timeout, auth failure)
- 17 unit tests covering constructor, lifecycle, error paths, and post-close behavior

## When

2026-04-10

## Where

- `mcp/src/proxy/upstream-client.ts` — new file, implementation
- `mcp/tests/unit/upstream-client.test.ts` — new file, unit tests

## Why

The crypto proxy (US-010 through US-014) needs to forward tool calls to the hosted MCP server after applying client-side encryption. This upstream client is the foundation: it wraps the SDK's `Client` + `StreamableHTTPClientTransport` into a clean interface that the proxy server assembly (US-013) will compose with the crypto interceptor (US-012).

## How

Uses the existing `@modelcontextprotocol/sdk` dependency — no new packages added.

**Considered:**
- Raw HTTP/fetch: Rejected — reinvents MCP protocol handling (JSON-RPC framing, session negotiation, SSE streaming)
- Wrapping `McpServer` as a client: Rejected — SDK provides a dedicated `Client` class designed for this
- SDK `Client` + `StreamableHTTPClientTransport` (chosen): Official SDK client, handles protocol negotiation, session management, and reconnection automatically

**Trade-offs:**
- Coupled to `StreamableHTTPClientTransport` (sufficient for hosted MCP; stdio not needed for remote servers)
- Error classification uses heuristics (string matching on "aborted", status codes) — adequate for user-facing messages

## Test plan

- [x] `cd mcp && npx vitest run tests/unit/upstream-client.test.ts` — 17/17 pass
- [x] `tsc --noEmit` — no errors in new files (pre-existing `@pqdb/client` resolution errors only)
- [x] `gitleaks detect --no-git` — no secrets
- [ ] CI pipeline

## Non-goals

- Proxy server assembly (US-013)
- Crypto interceptor integration (US-012)
- CLI wiring (US-014)
- OAuth/token refresh for upstream auth (future phase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)