### PR TITLE
[US-012] Crypto interceptor for MCP proxy

### DIFF
--- a/mcp/src/proxy/crypto-interceptor.ts
+++ b/mcp/src/proxy/crypto-interceptor.ts
@@ -1,0 +1,566 @@
+/**
+ * Crypto interceptor for the pqdb MCP proxy (US-012).
+ *
+ * Intercepts crypto-relevant tool calls, encrypts data before forwarding
+ * to the hosted MCP server, and decrypts responses before returning to
+ * Claude Code. Reuses all crypto functions from @pqdb/client.
+ */
+import {
+  deriveKeyPair,
+  transformInsertRows,
+  transformSelectResponse,
+  transformFilters,
+  encapsulate,
+  decapsulate,
+  defineTableSchema,
+  ColumnDef,
+} from "@pqdb/client";
+import type { KeyPair, TableSchema, FilterClause } from "@pqdb/client";
+
+/** The 7 tool names that require crypto interception. */
+const CRYPTO_TOOLS = new Set([
+  "pqdb_insert_rows",
+  "pqdb_query_rows",
+  "pqdb_update_rows",
+  "pqdb_delete_rows",
+  "pqdb_create_project",
+  "pqdb_select_project",
+  "pqdb_natural_language_query",
+]);
+
+/** Check whether a tool name requires crypto interception. */
+export function isCryptoTool(name: string): boolean {
+  return CRYPTO_TOOLS.has(name);
+}
+
+/** Column info from introspection endpoint. */
+interface IntrospectColumn {
+  name: string;
+  type: string;
+  sensitivity: "plain" | "searchable" | "private";
+}
+
+interface IntrospectTable {
+  name: string;
+  columns: IntrospectColumn[];
+}
+
+/** Tool call result shape (matches upstream-client.ts CallToolResult). */
+interface ToolResult {
+  content: Array<{
+    type: string;
+    text?: string;
+    [key: string]: unknown;
+  }>;
+  isError?: boolean;
+  [key: string]: unknown;
+}
+
+/** Configuration for CryptoInterceptor. */
+export interface CryptoInterceptorConfig {
+  privateKey: Uint8Array;
+  backendUrl: string;
+  authToken: string;
+}
+
+/** Convert hex string to Uint8Array. */
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+/** Encode Uint8Array to standard base64. */
+function bytesToBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64");
+}
+
+/** Decode standard base64 to Uint8Array. */
+function base64ToBytes(b64: string): Uint8Array {
+  const buf = Buffer.from(b64, "base64");
+  return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+}
+
+/** Encode bytes to base64url without padding (for deriveKeyPair). */
+function bytesToBase64UrlNoPad(bytes: Uint8Array): string {
+  return Buffer.from(bytes)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * CryptoInterceptor — standalone class that intercepts MCP tool calls,
+ * encrypts outgoing data and decrypts incoming responses using @pqdb/client
+ * crypto functions.
+ */
+export class CryptoInterceptor {
+  private readonly privateKey: Uint8Array;
+  private readonly backendUrl: string;
+  private readonly authToken: string;
+
+  private sharedSecret: Uint8Array | null = null;
+  private pendingSharedSecret: Uint8Array | null = null;
+
+  /** Schema cache with 60s TTL. */
+  private readonly schemaCache = new Map<
+    string,
+    { schema: TableSchema; timestamp: number }
+  >();
+  private readonly SCHEMA_TTL = 60_000;
+
+  constructor(config: CryptoInterceptorConfig) {
+    this.privateKey = config.privateKey;
+    this.backendUrl = config.backendUrl;
+    this.authToken = config.authToken;
+  }
+
+  /** Whether a shared secret is currently available for CRUD encryption. */
+  hasSharedSecret(): boolean {
+    return this.sharedSecret !== null;
+  }
+
+  /** Manually set the shared secret (e.g. for testing or external setup). */
+  setSharedSecret(secret: Uint8Array): void {
+    this.sharedSecret = secret;
+  }
+
+  /**
+   * Transform tool arguments before forwarding to the upstream MCP server.
+   * Encrypts data for crypto-relevant tools; passes through unchanged for others.
+   */
+  async transformRequest(
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    if (!isCryptoTool(toolName)) {
+      return args;
+    }
+
+    switch (toolName) {
+      case "pqdb_insert_rows":
+        return this.transformInsertRequest(args);
+      case "pqdb_query_rows":
+        return this.transformQueryRequest(args);
+      case "pqdb_update_rows":
+        return this.transformUpdateRequest(args);
+      case "pqdb_delete_rows":
+        return this.transformDeleteRequest(args);
+      case "pqdb_create_project":
+        return this.transformCreateProjectRequest(args);
+      case "pqdb_select_project":
+        // Select project: args pass through unchanged; decapsulation happens on response
+        return args;
+      case "pqdb_natural_language_query":
+        // NL query: args pass through unchanged; decryption happens on response
+        return args;
+      default:
+        return args;
+    }
+  }
+
+  /**
+   * Transform tool response before returning to the caller.
+   * Decrypts data for crypto-relevant tools; passes through unchanged for others.
+   */
+  async transformResponse(
+    toolName: string,
+    result: ToolResult,
+    metadata: Record<string, unknown>,
+  ): Promise<ToolResult> {
+    if (!isCryptoTool(toolName)) {
+      return result;
+    }
+
+    switch (toolName) {
+      case "pqdb_query_rows":
+        return this.transformQueryResponse(result, metadata);
+      case "pqdb_select_project":
+        return this.transformSelectProjectResponse(result);
+      case "pqdb_create_project":
+        return this.transformCreateProjectResponse(result);
+      case "pqdb_natural_language_query":
+        return this.transformNlQueryResponse(result);
+      default:
+        return result;
+    }
+  }
+
+  // ── Private: request transforms ─────────────────────────────────────
+
+  private async transformInsertRequest(
+    args: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    if (!this.sharedSecret) return args;
+
+    const table = args.table as string;
+    const rows = args.rows as Record<string, unknown>[];
+
+    const { keyPair, hmacKey, schema } = await this.getCryptoContext(table);
+
+    if (!this.tableHasEncryptedColumns(schema)) {
+      return args;
+    }
+
+    const transformedRows = await transformInsertRows(rows, schema, keyPair, hmacKey);
+    return { ...args, rows: transformedRows };
+  }
+
+  private async transformQueryRequest(
+    args: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    if (!this.sharedSecret) return args;
+
+    const table = args.table as string;
+    const filters = args.filters as FilterClause[] | undefined;
+
+    if (!filters || filters.length === 0) {
+      // No filters to transform — schema fetch needed only for response decryption
+      return args;
+    }
+
+    const { hmacKey, schema } = await this.getCryptoContext(table);
+
+    if (!this.tableHasEncryptedColumns(schema)) {
+      return args;
+    }
+
+    const transformedFilters = transformFilters(filters, schema, hmacKey);
+    return { ...args, filters: transformedFilters };
+  }
+
+  private async transformUpdateRequest(
+    args: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    if (!this.sharedSecret) return args;
+
+    const table = args.table as string;
+    const values = args.values as Record<string, unknown>;
+    const filters = args.filters as FilterClause[] | undefined;
+
+    const { keyPair, hmacKey, schema } = await this.getCryptoContext(table);
+
+    if (!this.tableHasEncryptedColumns(schema)) {
+      return args;
+    }
+
+    // transformInsertRows works for updates too — wrap as single-row array, unwrap
+    const [transformedValues] = await transformInsertRows(
+      [values],
+      schema,
+      keyPair,
+      hmacKey,
+    );
+
+    let transformedFilters = filters ?? [];
+    if (transformedFilters.length > 0) {
+      transformedFilters = transformFilters(transformedFilters, schema, hmacKey);
+    }
+
+    return { ...args, values: transformedValues, filters: transformedFilters };
+  }
+
+  private async transformDeleteRequest(
+    args: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    if (!this.sharedSecret) return args;
+
+    const table = args.table as string;
+    const filters = args.filters as FilterClause[] | undefined;
+
+    if (!filters || filters.length === 0) {
+      return args;
+    }
+
+    const { hmacKey, schema } = await this.getCryptoContext(table);
+
+    if (!this.tableHasEncryptedColumns(schema)) {
+      return args;
+    }
+
+    const transformedFilters = transformFilters(filters, schema, hmacKey);
+    return { ...args, filters: transformedFilters };
+  }
+
+  private async transformCreateProjectRequest(
+    args: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    // Fetch the developer's ML-KEM public key
+    const pkResp = await this.fetchJson<{ public_key: string | null }>(
+      "/v1/auth/me/public-key",
+    );
+
+    if (!pkResp.public_key) {
+      // No public key on file — pass through without encryption
+      return args;
+    }
+
+    const publicKey = base64ToBytes(pkResp.public_key);
+    const { ciphertext, sharedSecret } = await encapsulate(publicKey);
+
+    // Store the pending secret — will be committed on successful response
+    this.pendingSharedSecret = sharedSecret;
+
+    return {
+      ...args,
+      wrapped_encryption_key: bytesToBase64(ciphertext),
+    };
+  }
+
+  // ── Private: response transforms ────────────────────────────────────
+
+  private async transformQueryResponse(
+    result: ToolResult,
+    metadata: Record<string, unknown>,
+  ): Promise<ToolResult> {
+    if (!this.sharedSecret) return result;
+
+    const parsed = this.parseResponseContent(result);
+    if (!parsed || !Array.isArray(parsed.data) || parsed.data.length === 0) {
+      return result;
+    }
+
+    // Determine table name from metadata or from the original args
+    const table = metadata.table as string | undefined;
+    if (!table) return result;
+
+    const { keyPair, schema } = await this.getDecryptionContext(table);
+
+    if (!this.tableHasEncryptedColumns(schema)) {
+      return result;
+    }
+
+    const decryptedData = await transformSelectResponse(
+      parsed.data,
+      schema,
+      keyPair.secretKey,
+    );
+
+    return this.replaceResponseData(result, { ...parsed, data: decryptedData });
+  }
+
+  private async transformSelectProjectResponse(
+    result: ToolResult,
+  ): Promise<ToolResult> {
+    const parsed = this.parseResponseContent(result);
+    if (!parsed || !parsed.data) return result;
+
+    const data = parsed.data as Record<string, unknown>;
+    const project = (data.project ?? data) as Record<string, unknown>;
+    const wrappedKey = project?.wrapped_encryption_key;
+
+    if (!wrappedKey || typeof wrappedKey !== "string") {
+      // No wrapped key — project doesn't use encryption
+      return result;
+    }
+
+    const wrapped = base64ToBytes(wrappedKey);
+    const sharedSecret = await decapsulate(wrapped, this.privateKey);
+    this.sharedSecret = sharedSecret;
+
+    // Update the response to reflect encryption is now active
+    const updatedData = { ...parsed.data, encryption_active: true };
+    return this.replaceResponseData(result, { ...parsed, data: updatedData });
+  }
+
+  private async transformCreateProjectResponse(
+    result: ToolResult,
+  ): Promise<ToolResult> {
+    // Only commit the pending shared secret if the response is successful
+    if (result.isError || !this.pendingSharedSecret) {
+      this.pendingSharedSecret = null;
+      return result;
+    }
+
+    const parsed = this.parseResponseContent(result);
+    if (!parsed || parsed.error) {
+      this.pendingSharedSecret = null;
+      return result;
+    }
+
+    this.sharedSecret = this.pendingSharedSecret;
+    this.pendingSharedSecret = null;
+    return result;
+  }
+
+  private async transformNlQueryResponse(
+    result: ToolResult,
+  ): Promise<ToolResult> {
+    if (!this.sharedSecret) return result;
+
+    const parsed = this.parseResponseContent(result);
+    if (!parsed || !Array.isArray(parsed.data) || parsed.data.length === 0) {
+      return result;
+    }
+
+    // NL query responses include translated_query with the table name
+    const translatedQuery = parsed.translated_query as Record<string, unknown> | undefined;
+    const table = translatedQuery?.table as string | undefined;
+    if (!table) return result;
+
+    const { keyPair, schema } = await this.getDecryptionContext(table);
+
+    if (!this.tableHasEncryptedColumns(schema)) {
+      return result;
+    }
+
+    const decryptedData = await transformSelectResponse(
+      parsed.data,
+      schema,
+      keyPair.secretKey,
+    );
+
+    return this.replaceResponseData(result, { ...parsed, data: decryptedData });
+  }
+
+  // ── Private: crypto context helpers ─────────────────────────────────
+
+  /**
+   * Get the full crypto context for a table: key pair, HMAC key, and schema.
+   * Used by request transforms that need encryption + blind indexing.
+   */
+  private async getCryptoContext(tableName: string): Promise<{
+    keyPair: KeyPair;
+    hmacKey: Uint8Array;
+    schema: TableSchema;
+  }> {
+    const keyPair = await this.deriveCurrentKeyPair();
+    const schema = await this.getTableSchema(tableName);
+    const hmacKey = await this.fetchHmacKey();
+
+    return { keyPair, hmacKey, schema };
+  }
+
+  /**
+   * Get decryption context: key pair and schema only (no HMAC key needed).
+   * Used by response transforms that only need to decrypt.
+   */
+  private async getDecryptionContext(tableName: string): Promise<{
+    keyPair: KeyPair;
+    schema: TableSchema;
+  }> {
+    const keyPair = await this.deriveCurrentKeyPair();
+    const schema = await this.getTableSchema(tableName);
+    return { keyPair, schema };
+  }
+
+  /** Derive a key pair from the current shared secret. */
+  private async deriveCurrentKeyPair(): Promise<KeyPair> {
+    if (!this.sharedSecret) {
+      throw new Error("No shared secret available for key derivation");
+    }
+    const keyString = bytesToBase64UrlNoPad(this.sharedSecret);
+    return deriveKeyPair(keyString);
+  }
+
+  /** Fetch the HMAC key from the backend. */
+  private async fetchHmacKey(): Promise<Uint8Array> {
+    const resp = await this.fetchJson<{
+      current_version: number;
+      keys: Record<string, string>;
+    }>("/v1/db/hmac-key");
+
+    const currentKey = resp.keys[String(resp.current_version)];
+    return hexToBytes(currentKey);
+  }
+
+  /** Fetch and cache table schema from introspection endpoint. */
+  private async getTableSchema(tableName: string): Promise<TableSchema> {
+    const cached = this.schemaCache.get(tableName);
+    if (cached && Date.now() - cached.timestamp < this.SCHEMA_TTL) {
+      return cached.schema;
+    }
+
+    const introspect = await this.fetchJson<{ tables: IntrospectTable[] }>(
+      "/v1/db/introspect",
+    );
+
+    const tableData = introspect.tables.find((t) => t.name === tableName);
+    if (!tableData) {
+      throw new Error(`Table "${tableName}" not found in schema`);
+    }
+
+    const schema = this.buildTableSchema(tableName, tableData.columns);
+    this.schemaCache.set(tableName, { schema, timestamp: Date.now() });
+    return schema;
+  }
+
+  /** Build a TableSchema from introspection column data. */
+  private buildTableSchema(
+    tableName: string,
+    columns: IntrospectColumn[],
+  ): TableSchema {
+    const schemaCols: Record<string, ColumnDef> = {};
+    for (const col of columns) {
+      schemaCols[col.name] = new ColumnDef(col.type as "text", col.sensitivity);
+    }
+    return defineTableSchema(tableName, schemaCols);
+  }
+
+  /** Check if a table schema has any encrypted columns. */
+  private tableHasEncryptedColumns(schema: TableSchema): boolean {
+    return Object.values(schema.columns).some((col) => {
+      const c = col as { sensitivity: string };
+      return c.sensitivity === "searchable" || c.sensitivity === "private";
+    });
+  }
+
+  // ── Private: HTTP + response helpers ────────────────────────────────
+
+  /** Fetch JSON from the backend with auth. */
+  private async fetchJson<T>(path: string): Promise<T> {
+    const response = await fetch(`${this.backendUrl}${path}`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${this.authToken}` },
+    });
+
+    if (!response.ok) {
+      let detail: string;
+      try {
+        const body = (await response.json()) as { detail?: unknown };
+        detail =
+          typeof body.detail === "string"
+            ? body.detail
+            : JSON.stringify(body.detail);
+      } catch {
+        detail = response.statusText;
+      }
+      throw new Error(detail);
+    }
+
+    return (await response.json()) as T;
+  }
+
+  /** Parse the first text content from a tool result as JSON. */
+  private parseResponseContent(
+    result: ToolResult,
+  ): Record<string, unknown> | null {
+    const textContent = result.content.find((c) => c.type === "text");
+    if (!textContent?.text) return null;
+
+    try {
+      return JSON.parse(textContent.text) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Replace the data in a tool result's text content. */
+  private replaceResponseData(
+    result: ToolResult,
+    newData: Record<string, unknown>,
+  ): ToolResult {
+    return {
+      ...result,
+      content: result.content.map((c) => {
+        if (c.type === "text") {
+          return { ...c, text: JSON.stringify(newData) };
+        }
+        return c;
+      }),
+    };
+  }
+}

--- a/mcp/tests/unit/crypto-interceptor.test.ts
+++ b/mcp/tests/unit/crypto-interceptor.test.ts
@@ -1,0 +1,731 @@
+/**
+ * Unit tests for CryptoInterceptor (US-012).
+ *
+ * Verifies that the interceptor correctly routes each of the 7 crypto-relevant
+ * tools to the right transform, and passes non-crypto tools through unchanged.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock @pqdb/client crypto functions
+const mockDeriveKeyPair = vi.fn();
+const mockTransformInsertRows = vi.fn();
+const mockTransformSelectResponse = vi.fn();
+const mockTransformFilters = vi.fn();
+const mockEncapsulate = vi.fn();
+const mockDecapsulate = vi.fn();
+const mockDefineTableSchema = vi.fn();
+
+vi.mock("@pqdb/client", () => ({
+  deriveKeyPair: (...args: unknown[]) => mockDeriveKeyPair(...args),
+  transformInsertRows: (...args: unknown[]) => mockTransformInsertRows(...args),
+  transformSelectResponse: (...args: unknown[]) => mockTransformSelectResponse(...args),
+  transformFilters: (...args: unknown[]) => mockTransformFilters(...args),
+  encapsulate: (...args: unknown[]) => mockEncapsulate(...args),
+  decapsulate: (...args: unknown[]) => mockDecapsulate(...args),
+  defineTableSchema: (...args: unknown[]) => mockDefineTableSchema(...args),
+  ColumnDef: class ColumnDef {
+    type: string;
+    sensitivity: string;
+    constructor(type: string, sensitivity: string) {
+      this.type = type;
+      this.sensitivity = sensitivity;
+    }
+  },
+}));
+
+// Mock global fetch for backend HTTP calls
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import {
+  CryptoInterceptor,
+  isCryptoTool,
+} from "../../src/proxy/crypto-interceptor.js";
+
+// ── Test fixtures ─────────────────────────────────────────────────────
+
+const FAKE_PRIVATE_KEY = new Uint8Array(2400).fill(0xaa);
+const FAKE_SHARED_SECRET = new Uint8Array(32).fill(0xbb);
+const FAKE_PUBLIC_KEY = new Uint8Array(1184).fill(0xcc);
+const FAKE_CIPHERTEXT = new Uint8Array(1088).fill(0xdd);
+const FAKE_KEY_PAIR = {
+  publicKey: new Uint8Array(1184).fill(0x11),
+  secretKey: new Uint8Array(2400).fill(0x22),
+};
+const FAKE_HMAC_KEY = new Uint8Array(32).fill(0x33);
+
+const BACKEND_URL = "http://localhost:8000";
+const AUTH_TOKEN = "test-jwt-token";
+
+function createInterceptor(): CryptoInterceptor {
+  return new CryptoInterceptor({
+    privateKey: FAKE_PRIVATE_KEY,
+    backendUrl: BACKEND_URL,
+    authToken: AUTH_TOKEN,
+  });
+}
+
+/** Mock a successful fetch response. */
+function mockFetchOk(data: unknown): void {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: async () => data,
+  });
+}
+
+/** Build a fake introspection response with some encrypted columns. */
+function mockIntrospectionResponse(): void {
+  mockFetchOk({
+    tables: [
+      {
+        name: "users",
+        columns: [
+          { name: "id", type: "uuid", sensitivity: "plain" },
+          { name: "email", type: "text", sensitivity: "searchable" },
+          { name: "ssn", type: "text", sensitivity: "private" },
+          { name: "age", type: "integer", sensitivity: "plain" },
+        ],
+      },
+    ],
+  });
+}
+
+/** Mock HMAC key fetch response. */
+function mockHmacKeyResponse(): void {
+  mockFetchOk({
+    current_version: 1,
+    keys: { "1": FAKE_HMAC_KEY.reduce((s, b) => s + b.toString(16).padStart(2, "0"), "") },
+  });
+}
+
+// ── isCryptoTool ──────────────────────────────────────────────────────
+
+describe("isCryptoTool", () => {
+  it("returns true for pqdb_insert_rows", () => {
+    expect(isCryptoTool("pqdb_insert_rows")).toBe(true);
+  });
+
+  it("returns true for pqdb_query_rows", () => {
+    expect(isCryptoTool("pqdb_query_rows")).toBe(true);
+  });
+
+  it("returns true for pqdb_update_rows", () => {
+    expect(isCryptoTool("pqdb_update_rows")).toBe(true);
+  });
+
+  it("returns true for pqdb_delete_rows", () => {
+    expect(isCryptoTool("pqdb_delete_rows")).toBe(true);
+  });
+
+  it("returns true for pqdb_create_project", () => {
+    expect(isCryptoTool("pqdb_create_project")).toBe(true);
+  });
+
+  it("returns true for pqdb_select_project", () => {
+    expect(isCryptoTool("pqdb_select_project")).toBe(true);
+  });
+
+  it("returns true for pqdb_natural_language_query", () => {
+    expect(isCryptoTool("pqdb_natural_language_query")).toBe(true);
+  });
+
+  it("returns false for non-crypto tools", () => {
+    expect(isCryptoTool("pqdb_list_projects")).toBe(false);
+    expect(isCryptoTool("pqdb_get_project")).toBe(false);
+    expect(isCryptoTool("pqdb_create_table")).toBe(false);
+    expect(isCryptoTool("some_other_tool")).toBe(false);
+  });
+});
+
+// ── CryptoInterceptor: constructor ────────────────────────────────────
+
+describe("CryptoInterceptor constructor", () => {
+  it("creates an instance with required config", () => {
+    const interceptor = createInterceptor();
+    expect(interceptor).toBeInstanceOf(CryptoInterceptor);
+  });
+
+  it("starts with no shared secret", () => {
+    const interceptor = createInterceptor();
+    expect(interceptor.hasSharedSecret()).toBe(false);
+  });
+});
+
+// ── transformRequest: pqdb_insert_rows ────────────────────────────────
+
+describe("CryptoInterceptor.transformRequest — pqdb_insert_rows", () => {
+  let interceptor: CryptoInterceptor;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    interceptor = createInterceptor();
+    // Set shared secret so encryption is available
+    interceptor.setSharedSecret(FAKE_SHARED_SECRET);
+
+    // Mock deriveKeyPair and schema/hmac fetches
+    mockDeriveKeyPair.mockResolvedValue(FAKE_KEY_PAIR);
+    mockDefineTableSchema.mockReturnValue({
+      name: "users",
+      columns: {
+        id: { type: "uuid", sensitivity: "plain" },
+        email: { type: "text", sensitivity: "searchable" },
+        ssn: { type: "text", sensitivity: "private" },
+        age: { type: "integer", sensitivity: "plain" },
+      },
+    });
+  });
+
+  it("encrypts rows using transformInsertRows", async () => {
+    mockIntrospectionResponse();
+    mockHmacKeyResponse();
+
+    const transformedRows = [
+      { id: "1", email: "encrypted-email", email_index: "hmac-hash", ssn: "encrypted-ssn", age: 30 },
+    ];
+    mockTransformInsertRows.mockResolvedValue(transformedRows);
+
+    const args = {
+      table: "users",
+      rows: [{ id: "1", email: "alice@example.com", ssn: "123-45-6789", age: 30 }],
+    };
+
+    const result = await interceptor.transformRequest("pqdb_insert_rows", args);
+
+    expect(mockTransformInsertRows).toHaveBeenCalledOnce();
+    expect(result.rows).toEqual(transformedRows);
+    expect(result.table).toBe("users");
+  });
+
+  it("passes through when no shared secret is set", async () => {
+    interceptor = createInterceptor(); // No shared secret
+    const args = {
+      table: "users",
+      rows: [{ id: "1", age: 30 }],
+    };
+
+    const result = await interceptor.transformRequest("pqdb_insert_rows", args);
+    expect(result).toEqual(args);
+    expect(mockTransformInsertRows).not.toHaveBeenCalled();
+  });
+});
+
+// ── transformRequest: pqdb_query_rows ─────────────────────────────────
+
+describe("CryptoInterceptor.transformRequest — pqdb_query_rows", () => {
+  let interceptor: CryptoInterceptor;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    interceptor = createInterceptor();
+    interceptor.setSharedSecret(FAKE_SHARED_SECRET);
+    mockDeriveKeyPair.mockResolvedValue(FAKE_KEY_PAIR);
+    mockDefineTableSchema.mockReturnValue({
+      name: "users",
+      columns: {
+        id: { type: "uuid", sensitivity: "plain" },
+        email: { type: "text", sensitivity: "searchable" },
+        ssn: { type: "text", sensitivity: "private" },
+        age: { type: "integer", sensitivity: "plain" },
+      },
+    });
+  });
+
+  it("transforms filters using transformFilters", async () => {
+    mockIntrospectionResponse();
+    mockHmacKeyResponse();
+
+    const transformedFilters = [{ column: "email", op: "eq", value: "hmac-hash-value" }];
+    mockTransformFilters.mockReturnValue(transformedFilters);
+
+    const args = {
+      table: "users",
+      filters: [{ column: "email", op: "eq", value: "alice@example.com" }],
+    };
+
+    const result = await interceptor.transformRequest("pqdb_query_rows", args);
+
+    expect(mockTransformFilters).toHaveBeenCalledOnce();
+    expect(result.filters).toEqual(transformedFilters);
+  });
+
+  it("does not transform when no filters present", async () => {
+    mockIntrospectionResponse();
+    // No HMAC key fetch needed since no filters
+    const args = { table: "users", columns: ["*"] };
+
+    const result = await interceptor.transformRequest("pqdb_query_rows", args);
+    expect(mockTransformFilters).not.toHaveBeenCalled();
+    expect(result.table).toBe("users");
+  });
+});
+
+// ── transformRequest: pqdb_update_rows ────────────────────────────────
+
+describe("CryptoInterceptor.transformRequest — pqdb_update_rows", () => {
+  let interceptor: CryptoInterceptor;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    interceptor = createInterceptor();
+    interceptor.setSharedSecret(FAKE_SHARED_SECRET);
+    mockDeriveKeyPair.mockResolvedValue(FAKE_KEY_PAIR);
+    mockDefineTableSchema.mockReturnValue({
+      name: "users",
+      columns: {
+        id: { type: "uuid", sensitivity: "plain" },
+        email: { type: "text", sensitivity: "searchable" },
+        ssn: { type: "text", sensitivity: "private" },
+        age: { type: "integer", sensitivity: "plain" },
+      },
+    });
+  });
+
+  it("encrypts values and transforms filters", async () => {
+    mockIntrospectionResponse();
+    mockHmacKeyResponse();
+
+    const transformedValues = [{ email: "enc-email", email_index: "hmac", ssn: "enc-ssn" }];
+    mockTransformInsertRows.mockResolvedValue(transformedValues);
+    const transformedFilters = [{ column: "email", op: "eq", value: "hmac-val" }];
+    mockTransformFilters.mockReturnValue(transformedFilters);
+
+    const args = {
+      table: "users",
+      values: { email: "bob@example.com", ssn: "999-88-7777" },
+      filters: [{ column: "email", op: "eq", value: "alice@example.com" }],
+    };
+
+    const result = await interceptor.transformRequest("pqdb_update_rows", args);
+
+    expect(mockTransformInsertRows).toHaveBeenCalledOnce();
+    expect(mockTransformFilters).toHaveBeenCalledOnce();
+    expect(result.values).toEqual(transformedValues[0]);
+    expect(result.filters).toEqual(transformedFilters);
+  });
+});
+
+// ── transformRequest: pqdb_delete_rows ────────────────────────────────
+
+describe("CryptoInterceptor.transformRequest — pqdb_delete_rows", () => {
+  let interceptor: CryptoInterceptor;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    interceptor = createInterceptor();
+    interceptor.setSharedSecret(FAKE_SHARED_SECRET);
+    mockDeriveKeyPair.mockResolvedValue(FAKE_KEY_PAIR);
+    mockDefineTableSchema.mockReturnValue({
+      name: "users",
+      columns: {
+        id: { type: "uuid", sensitivity: "plain" },
+        email: { type: "text", sensitivity: "searchable" },
+      },
+    });
+  });
+
+  it("transforms filters for delete", async () => {
+    mockIntrospectionResponse();
+    mockHmacKeyResponse();
+
+    const transformedFilters = [{ column: "email", op: "eq", value: "hmac-delete" }];
+    mockTransformFilters.mockReturnValue(transformedFilters);
+
+    const args = {
+      table: "users",
+      filters: [{ column: "email", op: "eq", value: "alice@example.com" }],
+    };
+
+    const result = await interceptor.transformRequest("pqdb_delete_rows", args);
+
+    expect(mockTransformFilters).toHaveBeenCalledOnce();
+    expect(result.filters).toEqual(transformedFilters);
+  });
+});
+
+// ── transformRequest: pqdb_create_project ─────────────────────────────
+
+describe("CryptoInterceptor.transformRequest — pqdb_create_project", () => {
+  let interceptor: CryptoInterceptor;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    interceptor = createInterceptor();
+  });
+
+  it("fetches public key, encapsulates, and adds wrapped_encryption_key", async () => {
+    // Mock public key fetch
+    mockFetchOk({ public_key: Buffer.from(FAKE_PUBLIC_KEY).toString("base64") });
+
+    mockEncapsulate.mockResolvedValue({
+      ciphertext: FAKE_CIPHERTEXT,
+      sharedSecret: FAKE_SHARED_SECRET,
+    });
+
+    const args = { name: "My Project", region: "us-east-1" };
+    const result = await interceptor.transformRequest("pqdb_create_project", args);
+
+    expect(mockEncapsulate).toHaveBeenCalledOnce();
+    expect(result.name).toBe("My Project");
+    expect(result.region).toBe("us-east-1");
+    expect(typeof result.wrapped_encryption_key).toBe("string");
+    // The shared secret should NOT be stored yet (only after response confirms success)
+    // but the pending secret should be tracked internally
+  });
+});
+
+// ── transformRequest: pqdb_select_project ─────────────────────────────
+
+describe("CryptoInterceptor.transformRequest — pqdb_select_project", () => {
+  let interceptor: CryptoInterceptor;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    interceptor = createInterceptor();
+  });
+
+  it("passes through args unchanged (decapsulation happens on response)", async () => {
+    const args = { project_id: "proj-123" };
+    const result = await interceptor.transformRequest("pqdb_select_project", args);
+    expect(result).toEqual(args);
+  });
+});
+
+// ── transformRequest: pqdb_natural_language_query ─────────────────────
+
+describe("CryptoInterceptor.transformRequest — pqdb_natural_language_query", () => {
+  let interceptor: CryptoInterceptor;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    interceptor = createInterceptor();
+  });
+
+  it("passes through NL query args unchanged (encryption happens server-side via query translation)", async () => {
+    const args = { query: "show all users" };
+    const result = await interceptor.transformRequest("pqdb_natural_language_query", args);
+    expect(result).toEqual(args);
+  });
+});
+
+// ── transformRequest: non-crypto tool ─────────────────────────────────
+
+describe("CryptoInterceptor.transformRequest — non-crypto tool", () => {
+  let interceptor: CryptoInterceptor;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    interceptor = createInterceptor();
+  });
+
+  it("returns args unchanged for non-crypto tools", async () => {
+    const args = { project_id: "proj-123" };
+    const result = await interceptor.transformRequest("pqdb_list_projects", args);
+    expect(result).toEqual(args);
+  });
+});
+
+// ── transformResponse: pqdb_query_rows ────────────────────────────────
+
+describe("CryptoInterceptor.transformResponse — pqdb_query_rows", () => {
+  let interceptor: CryptoInterceptor;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    interceptor = createInterceptor();
+    interceptor.setSharedSecret(FAKE_SHARED_SECRET);
+    mockDeriveKeyPair.mockResolvedValue(FAKE_KEY_PAIR);
+    mockDefineTableSchema.mockReturnValue({
+      name: "users",
+      columns: {
+        id: { type: "uuid", sensitivity: "plain" },
+        email: { type: "text", sensitivity: "searchable" },
+        ssn: { type: "text", sensitivity: "private" },
+      },
+    });
+  });
+
+  it("decrypts _encrypted columns in response data", async () => {
+    const responseContent = JSON.stringify({
+      data: [
+        { id: "1", email_encrypted: "enc-bytes", ssn_encrypted: "enc-bytes2" },
+      ],
+      error: null,
+    });
+
+    const decryptedRows = [
+      { id: "1", email: "alice@example.com", ssn: "123-45-6789" },
+    ];
+    mockTransformSelectResponse.mockResolvedValue(decryptedRows);
+
+    // Need introspection for schema
+    mockIntrospectionResponse();
+
+    const result = await interceptor.transformResponse(
+      "pqdb_query_rows",
+      {
+        content: [{ type: "text", text: responseContent }],
+      },
+      { table: "users" },
+    );
+
+    expect(mockTransformSelectResponse).toHaveBeenCalledOnce();
+    const parsed = JSON.parse(result.content[0].text!);
+    expect(parsed.data).toEqual(decryptedRows);
+  });
+});
+
+// ── transformResponse: pqdb_select_project ────────────────────────────
+
+describe("CryptoInterceptor.transformResponse — pqdb_select_project", () => {
+  let interceptor: CryptoInterceptor;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    interceptor = createInterceptor();
+  });
+
+  it("decapsulates wrapped key and stores shared secret", async () => {
+    mockDecapsulate.mockResolvedValue(FAKE_SHARED_SECRET);
+
+    const responseContent = JSON.stringify({
+      data: {
+        project: {
+          id: "proj-123",
+          name: "Test Project",
+          wrapped_encryption_key: Buffer.from(FAKE_CIPHERTEXT).toString("base64"),
+        },
+        encryption_active: false,
+      },
+      error: null,
+    });
+
+    const result = await interceptor.transformResponse(
+      "pqdb_select_project",
+      {
+        content: [{ type: "text", text: responseContent }],
+      },
+      {},
+    );
+
+    expect(mockDecapsulate).toHaveBeenCalledOnce();
+    expect(interceptor.hasSharedSecret()).toBe(true);
+
+    // Response should indicate encryption is now active
+    const parsed = JSON.parse(result.content[0].text!);
+    expect(parsed.data.encryption_active).toBe(true);
+  });
+
+  it("handles project without wrapped key gracefully", async () => {
+    const responseContent = JSON.stringify({
+      data: {
+        project: {
+          id: "proj-456",
+          name: "Plain Project",
+        },
+        encryption_active: false,
+      },
+      error: null,
+    });
+
+    const result = await interceptor.transformResponse(
+      "pqdb_select_project",
+      {
+        content: [{ type: "text", text: responseContent }],
+      },
+      {},
+    );
+
+    expect(mockDecapsulate).not.toHaveBeenCalled();
+    expect(interceptor.hasSharedSecret()).toBe(false);
+  });
+});
+
+// ── transformResponse: pqdb_create_project ────────────────────────────
+
+describe("CryptoInterceptor.transformResponse — pqdb_create_project", () => {
+  let interceptor: CryptoInterceptor;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    interceptor = createInterceptor();
+  });
+
+  it("commits pending shared secret after successful create", async () => {
+    // First: trigger transformRequest to set up the pending secret
+    mockFetchOk({ public_key: Buffer.from(FAKE_PUBLIC_KEY).toString("base64") });
+    mockEncapsulate.mockResolvedValue({
+      ciphertext: FAKE_CIPHERTEXT,
+      sharedSecret: FAKE_SHARED_SECRET,
+    });
+
+    await interceptor.transformRequest("pqdb_create_project", { name: "New Project" });
+
+    // Now transform the response
+    const responseContent = JSON.stringify({
+      data: {
+        project: { id: "proj-new", name: "New Project" },
+        encryption_active: true,
+      },
+      error: null,
+    });
+
+    await interceptor.transformResponse(
+      "pqdb_create_project",
+      {
+        content: [{ type: "text", text: responseContent }],
+      },
+      {},
+    );
+
+    expect(interceptor.hasSharedSecret()).toBe(true);
+  });
+
+  it("does not commit secret if response is an error", async () => {
+    // Trigger transformRequest
+    mockFetchOk({ public_key: Buffer.from(FAKE_PUBLIC_KEY).toString("base64") });
+    mockEncapsulate.mockResolvedValue({
+      ciphertext: FAKE_CIPHERTEXT,
+      sharedSecret: FAKE_SHARED_SECRET,
+    });
+
+    await interceptor.transformRequest("pqdb_create_project", { name: "New Project" });
+
+    const responseContent = JSON.stringify({
+      data: null,
+      error: "Project creation failed",
+    });
+
+    await interceptor.transformResponse(
+      "pqdb_create_project",
+      {
+        content: [{ type: "text", text: responseContent }],
+        isError: true,
+      },
+      {},
+    );
+
+    expect(interceptor.hasSharedSecret()).toBe(false);
+  });
+});
+
+// ── transformResponse: pqdb_natural_language_query ────────────────────
+
+describe("CryptoInterceptor.transformResponse — pqdb_natural_language_query", () => {
+  let interceptor: CryptoInterceptor;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    interceptor = createInterceptor();
+    interceptor.setSharedSecret(FAKE_SHARED_SECRET);
+    mockDeriveKeyPair.mockResolvedValue(FAKE_KEY_PAIR);
+    mockDefineTableSchema.mockReturnValue({
+      name: "users",
+      columns: {
+        id: { type: "uuid", sensitivity: "plain" },
+        email: { type: "text", sensitivity: "searchable" },
+      },
+    });
+  });
+
+  it("decrypts _encrypted columns in NL query results", async () => {
+    const responseContent = JSON.stringify({
+      data: [
+        { id: "1", email_encrypted: "enc-bytes" },
+      ],
+      error: null,
+      translated_query: {
+        table: "users",
+        columns: ["*"],
+        filters: [],
+      },
+    });
+
+    const decryptedRows = [{ id: "1", email: "alice@example.com" }];
+    mockTransformSelectResponse.mockResolvedValue(decryptedRows);
+
+    // Introspection for schema
+    mockIntrospectionResponse();
+
+    const result = await interceptor.transformResponse(
+      "pqdb_natural_language_query",
+      {
+        content: [{ type: "text", text: responseContent }],
+      },
+      {},
+    );
+
+    expect(mockTransformSelectResponse).toHaveBeenCalledOnce();
+    const parsed = JSON.parse(result.content[0].text!);
+    expect(parsed.data).toEqual(decryptedRows);
+  });
+});
+
+// ── transformResponse: non-crypto tool ────────────────────────────────
+
+describe("CryptoInterceptor.transformResponse — non-crypto tool", () => {
+  let interceptor: CryptoInterceptor;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    interceptor = createInterceptor();
+  });
+
+  it("returns result unchanged for non-crypto tools", async () => {
+    const result = {
+      content: [{ type: "text", text: '{"data": [], "error": null}' }],
+    };
+
+    const output = await interceptor.transformResponse(
+      "pqdb_list_projects",
+      result,
+      {},
+    );
+
+    expect(output).toEqual(result);
+  });
+});
+
+// ── Schema caching ────────────────────────────────────────────────────
+
+describe("CryptoInterceptor schema caching", () => {
+  let interceptor: CryptoInterceptor;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    interceptor = createInterceptor();
+    interceptor.setSharedSecret(FAKE_SHARED_SECRET);
+    mockDeriveKeyPair.mockResolvedValue(FAKE_KEY_PAIR);
+    mockDefineTableSchema.mockReturnValue({
+      name: "users",
+      columns: {
+        id: { type: "uuid", sensitivity: "plain" },
+        email: { type: "text", sensitivity: "searchable" },
+      },
+    });
+  });
+
+  it("caches schema and does not re-fetch within TTL", async () => {
+    mockIntrospectionResponse();
+    mockHmacKeyResponse();
+    mockTransformFilters.mockReturnValue([]);
+
+    const args = {
+      table: "users",
+      filters: [{ column: "email", op: "eq", value: "test@test.com" }],
+    };
+
+    await interceptor.transformRequest("pqdb_query_rows", args);
+
+    // Second call should use cache — only HMAC key fetch, no introspection
+    mockHmacKeyResponse();
+    mockTransformFilters.mockReturnValue([]);
+
+    await interceptor.transformRequest("pqdb_query_rows", args);
+
+    // fetch should have been called:
+    // 1st call: introspection + hmac
+    // 2nd call: hmac only (schema cached)
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Who

Isaac Quintero + Claude Opus 4.6

## What

- New `CryptoInterceptor` class at `mcp/src/proxy/crypto-interceptor.ts`
- Exports `isCryptoTool(name)` identifying all 7 crypto tools: `pqdb_insert_rows`, `pqdb_query_rows`, `pqdb_update_rows`, `pqdb_delete_rows`, `pqdb_create_project`, `pqdb_select_project`, `pqdb_natural_language_query`
- `transformRequest()` encrypts/transforms outgoing arguments (insert rows, query/update/delete filters, create_project encapsulation)
- `transformResponse()` decrypts/transforms incoming results (query row decryption, select_project decapsulation, NL query decryption)
- Non-crypto tools pass through unchanged
- 28 unit tests at `mcp/tests/unit/crypto-interceptor.test.ts`

## When

2026-04-11

## Where

- `mcp/src/proxy/crypto-interceptor.ts` -- new file, CryptoInterceptor class + isCryptoTool function
- `mcp/tests/unit/crypto-interceptor.test.ts` -- new file, 28 unit tests

## Why

The MCP crypto proxy (US-012) needs a standalone interceptor that sits between Claude Code and the hosted MCP server, transparently encrypting outgoing data and decrypting incoming responses. This must work independently of the existing MCP server tool registration (crud-tools.ts) because the proxy forwards tool calls to an upstream server rather than executing them locally. All crypto operations reuse `@pqdb/client` functions -- zero duplication of encrypt/decrypt logic.

Dependencies: US-010 (recovery.ts) and US-011 (upstream-client.ts) are merged on main.

## How

- Reuses ALL crypto functions from `@pqdb/client`: `deriveKeyPair`, `transformInsertRows`, `transformSelectResponse`, `transformFilters`, `encapsulate`, `decapsulate`
- Schema caching with 60s TTL avoids redundant introspection calls
- Separate `getCryptoContext` (writes -- needs HMAC key for blind indexing) vs `getDecryptionContext` (reads -- no HMAC needed) to minimize backend HTTP calls
- `pendingSharedSecret` pattern for `create_project` ensures shared secret is only committed after the backend confirms project creation succeeded

**Considered:**
- Extracting directly from crud-tools.ts: Rejected -- the interceptor must work without MCP server registration, importing from crud-tools would create circular dependencies
- Duplicating crypto logic: Rejected per zero-duplication rule
- Single getCryptoContext for all operations: Rejected in favor of split context to avoid unnecessary HMAC key fetches during response decryption

**Trade-offs:**
- Schema cache 60s TTL means schema changes take up to 60s to propagate (acceptable for interactive use)
- pendingSharedSecret adds internal state, but prevents committing a shared secret for a project that failed to create

## Test plan

- [x] `isCryptoTool` returns true for all 7 crypto tools, false for others
- [x] `transformRequest` encrypts insert rows via `transformInsertRows`
- [x] `transformRequest` transforms query/delete filters via `transformFilters`
- [x] `transformRequest` encrypts update values + transforms filters
- [x] `transformRequest` fetches public key + encapsulates for create_project
- [x] `transformRequest` passes through select_project and NL query args unchanged
- [x] `transformRequest` passes through non-crypto tool args unchanged
- [x] `transformResponse` decrypts query response via `transformSelectResponse`
- [x] `transformResponse` decapsulates wrapped key on select_project
- [x] `transformResponse` commits pending shared secret on create_project success
- [x] `transformResponse` does not commit secret on create_project error
- [x] `transformResponse` decrypts NL query response encrypted columns
- [x] Schema cache avoids redundant introspection within TTL
- [x] All 28 unit tests pass
- [x] Typecheck passes -- zero new errors
- [x] Production build succeeds
- [x] Gitleaks: no secrets detected

## Non-goals

- Proxy server assembly (US-013 -- next story)
- CLI integration (US-014)
- Wiring interceptor into actual proxy request flow (deferred to US-013)