### PR TITLE
[US-014] CLI integration and developer experience

### DIFF
--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -10,6 +10,9 @@
  *
  *   # HTTP with OAuth (no API key needed — browser login):
  *   pqdb-mcp --project-url http://localhost:8000 --transport http --port 3002
+ *
+ *   # Crypto proxy (connects to a hosted MCP server):
+ *   pqdb-mcp --mode proxy --target http://localhost:3002/mcp --project-url http://localhost:8000
  */
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
@@ -17,10 +20,40 @@ import express from "express";
 import { parseArgs, buildConfig } from "./config.js";
 import { createPqdbMcpServer } from "./server.js";
 import { createMcpHttpApp } from "./http-app.js";
+import {
+  discoverRecoveryFile,
+  loadPrivateKeyFromRecovery,
+  createCryptoProxyServer,
+} from "./proxy/index.js";
+import type { ProxyConfig } from "./proxy/index.js";
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const config = buildConfig(args);
+
+  if (config.mode === "proxy") {
+    // Crypto proxy mode: discover recovery file, load private key,
+    // connect to hosted MCP server, and expose via stdio.
+    const recoveryPath = discoverRecoveryFile(config.recoveryFile);
+    const privateKey = loadPrivateKeyFromRecovery(recoveryPath);
+
+    const proxyConfig: ProxyConfig = {
+      targetUrl: config.target!,
+      privateKey,
+      backendUrl: config.projectUrl,
+      authToken: "", // populated after OAuth in a future phase
+    };
+
+    const { mcpServer, upstream } = await createCryptoProxyServer(proxyConfig);
+
+    const transport = new StdioServerTransport();
+    await mcpServer.connect(transport);
+
+    console.error(
+      `[pqdb-proxy] Crypto proxy → ${config.target} (key from ${recoveryPath})`,
+    );
+    return;
+  }
 
   if (config.transport === "stdio") {
     const { mcpServer } = createPqdbMcpServer(config);

--- a/mcp/src/config.ts
+++ b/mcp/src/config.ts
@@ -4,6 +4,8 @@
 
 export type Transport = "stdio" | "sse" | "http";
 
+export type Mode = "full" | "proxy";
+
 /** Expected length (bytes) of an ML-KEM-768 private (secret) key (FIPS 203). */
 export const ML_KEM_768_SECRET_KEY_BYTES = 2400;
 
@@ -29,22 +31,35 @@ export interface ServerConfig {
    * key and unwraps them on project selection.
    */
   privateKey: Uint8Array | undefined;
+  /** Operating mode: "full" runs the complete MCP server, "proxy" runs the crypto proxy. */
+  mode: Mode;
+  /** URL of the hosted MCP server to proxy (required when mode=proxy). */
+  target: string | undefined;
+  /** Optional explicit path to the recovery file (overrides auto-discovery). */
+  recoveryFile: string | undefined;
 }
 
 export interface ParsedArgs {
   projectUrl: string | undefined;
   transport: Transport;
   port: number;
+  mode: Mode;
+  target: string | undefined;
+  recoveryFile: string | undefined;
 }
 
 /**
  * Parse CLI arguments from argv.
  * Supports: --project-url <url> --transport <stdio|sse> --port <number>
+ *           --mode <full|proxy> --target <url> --recovery-file <path>
  */
 export function parseArgs(argv: string[]): ParsedArgs {
   let projectUrl: string | undefined;
   let transport: Transport = "stdio";
   let port = 3001;
+  let mode: Mode = "full";
+  let target: string | undefined;
+  let recoveryFile: string | undefined;
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -61,10 +76,20 @@ export function parseArgs(argv: string[]): ParsedArgs {
       if (isNaN(port) || port < 1 || port > 65535) {
         throw new Error(`Invalid port: ${argv[i]}. Must be 1-65535.`);
       }
+    } else if (arg === "--mode" && i + 1 < argv.length) {
+      const val = argv[++i];
+      if (val !== "full" && val !== "proxy") {
+        throw new Error(`Invalid mode: ${val}. Must be "full" or "proxy".`);
+      }
+      mode = val;
+    } else if (arg === "--target" && i + 1 < argv.length) {
+      target = argv[++i];
+    } else if (arg === "--recovery-file" && i + 1 < argv.length) {
+      recoveryFile = argv[++i];
     }
   }
 
-  return { projectUrl, transport, port };
+  return { projectUrl, transport, port, mode, target, recoveryFile };
 }
 
 /**
@@ -132,9 +157,21 @@ export function parsePrivateKey(raw: string): Uint8Array {
  * Build a complete ServerConfig from CLI args + environment variables.
  */
 export function buildConfig(args: ParsedArgs): ServerConfig {
+  const mode = args.mode ?? "full";
+
+  // Proxy mode: validate --target, skip API key requirement
+  if (mode === "proxy") {
+    if (!args.target) {
+      throw new Error(
+        "--target is required when --mode proxy. " +
+          "Example: --mode proxy --target http://localhost:3002/mcp",
+      );
+    }
+  }
+
   const apiKey = process.env.PQDB_API_KEY ?? "";
-  // API key is required for stdio/sse (pre-configured), optional for http (OAuth provides auth)
-  if (!apiKey && args.transport !== "http") {
+  // API key is required for stdio/sse in full mode, optional for http and proxy mode
+  if (!apiKey && args.transport !== "http" && mode !== "proxy") {
     throw new Error("PQDB_API_KEY environment variable is required.");
   }
 
@@ -160,5 +197,8 @@ export function buildConfig(args: ParsedArgs): ServerConfig {
     devToken: process.env.PQDB_DEV_TOKEN || undefined,
     projectId: undefined,
     privateKey,
+    mode,
+    target: args.target,
+    recoveryFile: args.recoveryFile,
   };
 }

--- a/mcp/src/http-app.ts
+++ b/mcp/src/http-app.ts
@@ -262,6 +262,9 @@ export function createMcpHttpApp(options: HttpAppOptions): Express {
           devToken: devJwt,
           projectId,
           privateKey: undefined,
+          mode: "full",
+          target: undefined,
+          recoveryFile: undefined,
         };
 
         const { mcpServer } = createPqdbMcpServer(config);

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -7,7 +7,7 @@
 export { createPqdbMcpServer, SERVER_NAME, SERVER_VERSION } from "./server.js";
 export type { PqdbMcpServer } from "./server.js";
 export { parseArgs, buildConfig } from "./config.js";
-export type { ServerConfig, Transport, ParsedArgs } from "./config.js";
+export type { ServerConfig, Transport, Mode, ParsedArgs } from "./config.js";
 export { registerSchemaTools } from "./schema-tools.js";
 export { registerCrudTools } from "./crud-tools.js";
 export { registerAuthTools } from "./auth-tools.js";

--- a/mcp/tests/unit/config.test.ts
+++ b/mcp/tests/unit/config.test.ts
@@ -8,6 +8,9 @@ describe("parseArgs", () => {
       projectUrl: undefined,
       transport: "stdio",
       port: 3001,
+      mode: "full",
+      target: undefined,
+      recoveryFile: undefined,
     });
   });
 
@@ -59,12 +62,81 @@ describe("parseArgs", () => {
       projectUrl: "http://api.example.com",
       transport: "sse",
       port: 5000,
+      mode: "full",
+      target: undefined,
+      recoveryFile: undefined,
     });
   });
 
   it("parses https:// project URL", () => {
     const result = parseArgs(["--project-url", "https://localhost"]);
     expect(result.projectUrl).toBe("https://localhost");
+  });
+
+  // ── --mode flag (US-014) ────────────────────────────────────────────
+
+  it("defaults mode to 'full' when --mode is not specified", () => {
+    const result = parseArgs([]);
+    expect(result.mode).toBe("full");
+  });
+
+  it("parses --mode full", () => {
+    const result = parseArgs(["--mode", "full"]);
+    expect(result.mode).toBe("full");
+  });
+
+  it("parses --mode proxy", () => {
+    const result = parseArgs(["--mode", "proxy"]);
+    expect(result.mode).toBe("proxy");
+  });
+
+  it("throws on invalid mode", () => {
+    expect(() => parseArgs(["--mode", "invalid"])).toThrow(
+      'Invalid mode: invalid. Must be "full" or "proxy".',
+    );
+  });
+
+  // ── --target flag (US-014) ──────────────────────────────────────────
+
+  it("parses --target URL", () => {
+    const result = parseArgs(["--target", "http://localhost:3002/mcp"]);
+    expect(result.target).toBe("http://localhost:3002/mcp");
+  });
+
+  it("target is undefined when not specified", () => {
+    const result = parseArgs([]);
+    expect(result.target).toBeUndefined();
+  });
+
+  // ── --recovery-file flag (US-014) ───────────────────────────────────
+
+  it("parses --recovery-file path", () => {
+    const result = parseArgs(["--recovery-file", "/path/to/recovery.json"]);
+    expect(result.recoveryFile).toBe("/path/to/recovery.json");
+  });
+
+  it("recoveryFile is undefined when not specified", () => {
+    const result = parseArgs([]);
+    expect(result.recoveryFile).toBeUndefined();
+  });
+
+  // ── combined proxy args (US-014) ────────────────────────────────────
+
+  it("parses all proxy args together", () => {
+    const result = parseArgs([
+      "--mode", "proxy",
+      "--target", "http://hosted:3002/mcp",
+      "--recovery-file", "/tmp/recovery.json",
+      "--project-url", "http://localhost:8000",
+    ]);
+    expect(result).toEqual({
+      projectUrl: "http://localhost:8000",
+      transport: "stdio",
+      port: 3001,
+      mode: "proxy",
+      target: "http://hosted:3002/mcp",
+      recoveryFile: "/tmp/recovery.json",
+    });
   });
 });
 
@@ -155,6 +227,9 @@ describe("buildConfig", () => {
       devToken: undefined,
       projectId: undefined,
       privateKey: undefined,
+      mode: "full",
+      target: undefined,
+      recoveryFile: undefined,
     });
   });
 
@@ -216,6 +291,64 @@ describe("buildConfig", () => {
       port: 3001,
     });
     expect(config.projectUrl).toBe("https://localhost");
+  });
+
+  // ── proxy mode (US-014) ───────────────────────────────────────────────
+
+  it("throws when mode=proxy but --target is missing", () => {
+    delete process.env.PQDB_API_KEY;
+    expect(() =>
+      buildConfig({
+        projectUrl: "http://localhost:8000",
+        transport: "stdio",
+        port: 3001,
+        mode: "proxy",
+        target: undefined,
+        recoveryFile: undefined,
+      }),
+    ).toThrow("--target is required when --mode proxy");
+  });
+
+  it("does not require PQDB_API_KEY in proxy mode", () => {
+    delete process.env.PQDB_API_KEY;
+    const config = buildConfig({
+      projectUrl: "http://localhost:8000",
+      transport: "stdio",
+      port: 3001,
+      mode: "proxy",
+      target: "http://localhost:3002/mcp",
+      recoveryFile: undefined,
+    });
+    expect(config.mode).toBe("proxy");
+    expect(config.target).toBe("http://localhost:3002/mcp");
+  });
+
+  it("mode defaults to 'full' and retains existing behavior", () => {
+    process.env.PQDB_API_KEY = "pqdb_anon_testkey123";
+    const config = buildConfig({
+      projectUrl: "http://localhost:8000",
+      transport: "stdio",
+      port: 3001,
+      mode: "full",
+      target: undefined,
+      recoveryFile: undefined,
+    });
+    expect(config.mode).toBe("full");
+    expect(config.target).toBeUndefined();
+    expect(config.recoveryFile).toBeUndefined();
+  });
+
+  it("passes recoveryFile through in proxy mode", () => {
+    delete process.env.PQDB_API_KEY;
+    const config = buildConfig({
+      projectUrl: "http://localhost:8000",
+      transport: "stdio",
+      port: 3001,
+      mode: "proxy",
+      target: "http://localhost:3002/mcp",
+      recoveryFile: "/custom/path.json",
+    });
+    expect(config.recoveryFile).toBe("/custom/path.json");
   });
 
   // ── PQDB_PRIVATE_KEY (US-008) ─────────────────────────────────────────


### PR DESCRIPTION
## Who
Isaac Quintero + Claude Opus 4.6 (pair-programming)

## What
- Add `--mode proxy` CLI flag that routes to the crypto proxy startup path
- Add `--target <url>` (required in proxy mode) and `--recovery-file <path>` (optional override) CLI flags
- `--mode full` (or no `--mode`) retains existing behavior with zero regression
- Proxy mode auto-discovers recovery file, loads ML-KEM-768 private key, connects to hosted MCP, and exposes via stdio
- Startup log: `[pqdb-proxy] Crypto proxy -> <target-url> (key from <recovery-file-path>)`
- 12 new unit tests for CLI arg parsing and buildConfig proxy mode behavior

## When
2026-04-11

## Where
- `mcp/src/config.ts` -- Added `Mode` type, `--mode`/`--target`/`--recovery-file` to `ParsedArgs` and `ServerConfig`
- `mcp/src/cli.ts` -- Added proxy mode branch with recovery discovery + crypto proxy startup
- `mcp/src/http-app.ts` -- Added new fields to inline `ServerConfig` construction
- `mcp/src/index.ts` -- Exported `Mode` type
- `mcp/tests/unit/config.test.ts` -- 12 new unit tests, updated existing assertions for new fields

## Why
US-014 is the final story in the crypto proxy feature chain (US-010 through US-014). Developers need a simple CLI command to start the crypto proxy that auto-discovers their recovery file and connects to a hosted MCP server. Without this, developers would have no way to invoke the proxy infrastructure built in US-010 through US-013 -- the proxy server, interceptor, upstream client, and recovery modules would be dead code with no entry point.

## How
**Approach:** Extended the existing `parseArgs`/`buildConfig` pipeline with three new CLI flags (`--mode`, `--target`, `--recovery-file`) and added a new branch at the top of `main()` in `cli.ts` that short-circuits into proxy mode before the existing transport handling.

**Considered:**
- Separate binary for proxy: Rejected -- `--mode` flag is simpler and keeps a single entry point, consistent with how `--transport` already switches behavior
- Environment variable for target URL: Rejected -- CLI arg is more explicit and discoverable; env vars are used for secrets (API keys, private keys), not for connection targets

**Trade-offs:**
- Proxy mode always uses stdio transport (matches Claude Code usage pattern)
- `authToken` is empty string until OAuth integration in a future phase
- Proxy mode skips `PQDB_API_KEY` requirement (like `http` transport) since auth comes from the hosted MCP server

## Test plan
- [x] `npx -w mcp vitest run tests/unit/config.test.ts` -- 42 tests pass (12 new)
- [x] All proxy-related tests pass (111/111 across config, recovery, upstream-client, crypto-interceptor, proxy-server)
- [x] Pre-existing test failures unchanged (identical to main)
- [x] `npx -w mcp tsc --noEmit` -- zero new errors
- [x] `npm run build -w mcp` -- production build succeeds
- [x] `gitleaks detect` -- no leaks
- [x] `semgrep scan --config auto` -- 0 findings on changed files

## Non-goals
- OAuth token population for `authToken` (future phase)
- HTTP transport for proxy mode (only stdio needed for Claude Code)
- npm publishing of the MCP package (deferred per PRD)