### PR TITLE
feat(mcp): add proxy OAuth login handler (US-015)

### DIFF
--- a/mcp/src/proxy/index.ts
+++ b/mcp/src/proxy/index.ts
@@ -10,3 +10,5 @@ export type { CryptoInterceptorConfig } from "./crypto-interceptor.js";
 export { UpstreamClient } from "./upstream-client.js";
 export type { ToolInfo, CallToolResult } from "./upstream-client.js";
 export { discoverRecoveryFile, loadPrivateKeyFromRecovery } from "./recovery.js";
+export { proxyLogin } from "./proxy-auth.js";
+export type { ProxyAuthResult, ProxyLoginOptions } from "./proxy-auth.js";

--- a/mcp/src/proxy/proxy-auth.ts
+++ b/mcp/src/proxy/proxy-auth.ts
@@ -1,0 +1,103 @@
+/**
+ * Proxy OAuth login handler (US-015).
+ *
+ * Opens the developer's browser to the pqdb Dashboard login page and captures
+ * the JWT via a local HTTP callback. Uses execFile (not exec) to avoid shell
+ * injection when opening the browser.
+ */
+import { randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
+import express from "express";
+import type { AddressInfo } from "node:net";
+
+export interface ProxyAuthResult {
+  devJwt: string;
+  refreshToken?: string;
+  encryptionKey?: string;
+}
+
+export interface ProxyLoginOptions {
+  /** Timeout in milliseconds. Defaults to 120_000 (2 minutes). */
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+/**
+ * Start a temporary local Express server, open the browser to the Dashboard
+ * login page, and wait for the JWT callback.
+ *
+ * @param dashboardUrl - Base URL of the pqdb Dashboard (e.g. "https://localhost")
+ * @param options - Optional configuration (timeout)
+ * @returns The developer JWT and optional refresh/encryption keys
+ */
+export function proxyLogin(
+  dashboardUrl: string,
+  options?: ProxyLoginOptions,
+): Promise<ProxyAuthResult> {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  return new Promise<ProxyAuthResult>((resolve, reject) => {
+    const requestId = randomUUID();
+    const app = express();
+    app.use(express.json());
+
+    app.post("/mcp-auth-complete", (req, res) => {
+      const bodyRequestId = req.body?.request_id as string | undefined;
+      const token = req.body?.token as string | undefined;
+
+      if (bodyRequestId !== requestId) {
+        res.status(400).json({ error: "Invalid request_id" });
+        return;
+      }
+
+      if (!token) {
+        res.status(400).json({ error: "Missing required field: token" });
+        return;
+      }
+
+      const result: ProxyAuthResult = {
+        devJwt: token,
+        refreshToken: req.body.refresh_token ?? undefined,
+        encryptionKey: req.body.encryption_key ?? undefined,
+      };
+
+      res.json({ ok: true });
+      clearTimeout(timer);
+      server.close();
+      resolve(result);
+    });
+
+    const server = app.listen(0, () => {
+      const port = (server.address() as AddressInfo).port;
+      const callbackUrl = `http://localhost:${port}/mcp-auth-complete`;
+      const loginUrl = new URL("/login", dashboardUrl);
+      loginUrl.searchParams.set(
+        "mcp_callback",
+        callbackUrl,
+      );
+      loginUrl.searchParams.set("request_id", requestId);
+
+      console.error("[pqdb-proxy] Opening browser for login...");
+      openBrowser(loginUrl.toString());
+    });
+
+    const timer = setTimeout(() => {
+      server.close();
+      reject(new Error("Login timed out. Please restart and try again."));
+    }, timeoutMs);
+  });
+}
+
+/**
+ * Open a URL in the user's default browser.
+ * Uses execFile (not exec) to prevent shell injection (CWE-78).
+ */
+function openBrowser(url: string): void {
+  const cmd = process.platform === "darwin" ? "open" : "xdg-open";
+  execFile(cmd, [url], (err) => {
+    if (err) {
+      console.error("[pqdb-proxy] Could not open browser:", err.message);
+    }
+  });
+}

--- a/mcp/tests/unit/proxy-auth.test.ts
+++ b/mcp/tests/unit/proxy-auth.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Unit tests for proxyLogin (US-015).
+ *
+ * Verifies the proxy OAuth login handler:
+ * - Starts an Express server on a random port
+ * - Opens the browser to the dashboard login page
+ * - Handles POST /mcp-auth-complete callback
+ * - Validates request_id
+ * - Times out after configured duration
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import http from "node:http";
+
+// Mock child_process.execFile before importing the module under test.
+// NOTE: We use execFile (NOT exec) — it avoids shell injection by design.
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn((_cmd: string, _args: string[], _cb: (err: Error | null) => void) => {
+    // no-op: don't actually open a browser
+  }),
+}));
+
+import { proxyLogin, type ProxyAuthResult } from "../../src/proxy/proxy-auth.js";
+import { execFile } from "node:child_process";
+
+const mockedExecFile = vi.mocked(execFile);
+
+/**
+ * Helper: POST JSON to a given URL.
+ * Uses raw http.request to avoid adding a test dependency.
+ */
+function postJson(url: string, body: Record<string, unknown>): Promise<{ statusCode: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const data = JSON.stringify(body);
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data),
+        },
+      },
+      (res) => {
+        let responseBody = "";
+        res.on("data", (chunk: Buffer) => {
+          responseBody += chunk.toString();
+        });
+        res.on("end", () => {
+          resolve({ statusCode: res.statusCode ?? 0, body: responseBody });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+/**
+ * Extract the port from the login URL that was passed to execFile.
+ */
+function extractPortFromExecFile(): number {
+  const call = mockedExecFile.mock.calls[0];
+  const loginUrl = call[1][0]; // second arg is the array of args, first element is the URL
+  const parsed = new URL(new URL(loginUrl).searchParams.get("mcp_callback")!);
+  return parseInt(parsed.port, 10);
+}
+
+/**
+ * Extract the request_id from the login URL that was passed to execFile.
+ */
+function extractRequestIdFromExecFile(): string {
+  const call = mockedExecFile.mock.calls[0];
+  const loginUrl = call[1][0];
+  return new URL(loginUrl).searchParams.get("request_id")!;
+}
+
+describe("proxyLogin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves with JWT on valid callback", async () => {
+    const dashboardUrl = "http://localhost:3000";
+
+    // Start proxyLogin — it will open a server and wait for callback
+    const loginPromise = proxyLogin(dashboardUrl);
+
+    // Wait for execFile to be called (server is up)
+    await vi.waitFor(() => {
+      expect(mockedExecFile).toHaveBeenCalledOnce();
+    });
+
+    const port = extractPortFromExecFile();
+    const requestId = extractRequestIdFromExecFile();
+
+    // POST the callback with a valid request_id
+    const response = await postJson(`http://localhost:${port}/mcp-auth-complete`, {
+      request_id: requestId,
+      token: "jwt-token-abc",
+      refresh_token: "refresh-xyz",
+      encryption_key: "enc-key-123",
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const result = await loginPromise;
+    expect(result).toEqual({
+      devJwt: "jwt-token-abc",
+      refreshToken: "refresh-xyz",
+      encryptionKey: "enc-key-123",
+    });
+  });
+
+  it("returns 400 for mismatched request_id", async () => {
+    const dashboardUrl = "http://localhost:3000";
+    const loginPromise = proxyLogin(dashboardUrl);
+
+    await vi.waitFor(() => {
+      expect(mockedExecFile).toHaveBeenCalledOnce();
+    });
+
+    const port = extractPortFromExecFile();
+
+    // POST with a WRONG request_id
+    const response = await postJson(`http://localhost:${port}/mcp-auth-complete`, {
+      request_id: "wrong-id",
+      token: "jwt-token-abc",
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body);
+    expect(body.error).toMatch(/request_id/i);
+
+    // Now send the correct one so the promise resolves and the server shuts down
+    const requestId = extractRequestIdFromExecFile();
+    await postJson(`http://localhost:${port}/mcp-auth-complete`, {
+      request_id: requestId,
+      token: "jwt-token-abc",
+    });
+    await loginPromise;
+  });
+
+  it("times out after the configured duration", async () => {
+    const dashboardUrl = "http://localhost:3000";
+
+    // Use a very short timeout for the test
+    const loginPromise = proxyLogin(dashboardUrl, { timeoutMs: 100 });
+
+    await expect(loginPromise).rejects.toThrow(/timed? out/i);
+  });
+
+  it("handles callback with only token (no refresh_token or encryption_key)", async () => {
+    const dashboardUrl = "http://localhost:3000";
+    const loginPromise = proxyLogin(dashboardUrl);
+
+    await vi.waitFor(() => {
+      expect(mockedExecFile).toHaveBeenCalledOnce();
+    });
+
+    const port = extractPortFromExecFile();
+    const requestId = extractRequestIdFromExecFile();
+
+    const response = await postJson(`http://localhost:${port}/mcp-auth-complete`, {
+      request_id: requestId,
+      token: "jwt-only",
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const result = await loginPromise;
+    expect(result).toEqual({
+      devJwt: "jwt-only",
+      refreshToken: undefined,
+      encryptionKey: undefined,
+    });
+  });
+
+  it("returns 400 when token is missing from callback body", async () => {
+    const dashboardUrl = "http://localhost:3000";
+    const loginPromise = proxyLogin(dashboardUrl);
+
+    await vi.waitFor(() => {
+      expect(mockedExecFile).toHaveBeenCalledOnce();
+    });
+
+    const port = extractPortFromExecFile();
+    const requestId = extractRequestIdFromExecFile();
+
+    // POST without a token field
+    const response = await postJson(`http://localhost:${port}/mcp-auth-complete`, {
+      request_id: requestId,
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body);
+    expect(body.error).toMatch(/token/i);
+
+    // Clean up: send a valid callback so the server shuts down
+    await postJson(`http://localhost:${port}/mcp-auth-complete`, {
+      request_id: requestId,
+      token: "cleanup-jwt",
+    });
+    await loginPromise;
+  });
+
+  it("opens the browser with the correct login URL", async () => {
+    const dashboardUrl = "https://my-dashboard.example.com";
+    const loginPromise = proxyLogin(dashboardUrl);
+
+    await vi.waitFor(() => {
+      expect(mockedExecFile).toHaveBeenCalledOnce();
+    });
+
+    // Verify execFile was called with the right command
+    const call = mockedExecFile.mock.calls[0];
+    const cmd = call[0];
+    const loginUrl = call[1][0];
+
+    // On Linux, should use xdg-open
+    if (process.platform === "linux") {
+      expect(cmd).toBe("xdg-open");
+    } else if (process.platform === "darwin") {
+      expect(cmd).toBe("open");
+    }
+
+    const parsed = new URL(loginUrl);
+    expect(parsed.origin).toBe("https://my-dashboard.example.com");
+    expect(parsed.pathname).toBe("/login");
+    expect(parsed.searchParams.has("mcp_callback")).toBe(true);
+    expect(parsed.searchParams.has("request_id")).toBe(true);
+
+    // The callback URL should point to localhost with a port
+    const callbackUrl = new URL(parsed.searchParams.get("mcp_callback")!);
+    expect(callbackUrl.hostname).toBe("localhost");
+    expect(callbackUrl.pathname).toBe("/mcp-auth-complete");
+
+    // Clean up
+    const port = extractPortFromExecFile();
+    const requestId = extractRequestIdFromExecFile();
+    await postJson(`http://localhost:${port}/mcp-auth-complete`, {
+      request_id: requestId,
+      token: "cleanup",
+    });
+    await loginPromise;
+  });
+
+  it("shuts down the Express server after successful callback", async () => {
+    const dashboardUrl = "http://localhost:3000";
+    const loginPromise = proxyLogin(dashboardUrl);
+
+    await vi.waitFor(() => {
+      expect(mockedExecFile).toHaveBeenCalledOnce();
+    });
+
+    const port = extractPortFromExecFile();
+    const requestId = extractRequestIdFromExecFile();
+
+    await postJson(`http://localhost:${port}/mcp-auth-complete`, {
+      request_id: requestId,
+      token: "jwt-token",
+    });
+
+    await loginPromise;
+
+    // The server should be closed — another request should fail
+    await expect(
+      postJson(`http://localhost:${port}/mcp-auth-complete`, {
+        request_id: requestId,
+        token: "jwt-token",
+      }),
+    ).rejects.toThrow(); // ECONNREFUSED
+  });
+});


### PR DESCRIPTION
## Who

Isaac Quintero + Claude Opus 4.6 (pair-programming)

## What

- Add `proxyLogin(dashboardUrl)` function in `mcp/src/proxy/proxy-auth.ts` that starts a temporary Express server on a random port, opens the developer's browser to the Dashboard login page, and captures the JWT via `/mcp-auth-complete` POST callback
- Validate `request_id` to prevent cross-request token injection (returns 400 on mismatch)
- Time out after 120 seconds (configurable via `ProxyLoginOptions.timeoutMs`) with a clear error message
- Use `child_process.execFile` (not `exec`) to open the browser safely (CWE-78 prevention)
- Export `ProxyAuthResult` and `ProxyLoginOptions` types via the proxy barrel (`proxy/index.ts`)
- Add 7 unit tests covering all acceptance criteria

## When

2026-04-11

## Where

- `mcp/src/proxy/proxy-auth.ts` — new file, implementation
- `mcp/src/proxy/index.ts` — barrel export additions
- `mcp/tests/unit/proxy-auth.test.ts` — new file, 7 unit tests

## Why

The crypto proxy needs a way to authenticate the developer without requiring manual token entry. By opening the browser to the pqdb Dashboard login page and capturing the JWT via a local HTTP callback, the proxy can seamlessly obtain authentication credentials. This uses the same `/mcp-auth-complete` endpoint format and `mcp_callback` query parameter that the Dashboard already supports (see `oauth-provider.ts` and `http-app.ts`).

## How

**Approach:** A standalone Express server listens on port 0 (OS-assigned random port), constructs a login URL with `mcp_callback` and `request_id` query parameters, and opens the browser via `execFile`. When the Dashboard POSTs the JWT to `/mcp-auth-complete`, the handler validates `request_id`, extracts the token, shuts down the server, and resolves the promise.

**Considered:**
- Manual token entry via CLI prompt: Rejected — poor UX, error-prone
- Reuse `oauth-provider.ts` directly: Rejected — coupled to full MCP OAuth PKCE flow; proxy needs simpler one-shot browser-to-callback
- Standalone Express callback server (chosen): Minimal, self-contained, mirrors existing Dashboard endpoint format

**Trade-offs:**
- Requires a browser available on the developer's machine
- 120s default timeout means very slow logins will fail (but configurable)
- Uses `execFile` with `xdg-open`/`open` — no Windows support yet (deferred)

## Test plan

- [x] Unit tests pass: `npx -w mcp vitest run tests/unit/proxy-auth.test.ts` (7/7)
- [x] Full MCP test suite: no new failures (pre-existing failures in admin-tools, auth-tools, project-tools, e2e are unrelated)
- [x] Typecheck passes: `npm run typecheck -w mcp` (zero errors)
- [x] Production build succeeds: `npm run build -w mcp`
- [x] Gitleaks: no secrets detected in new files

## Non-goals

- Windows browser-open support (`start` command) — deferred to future PR
- Integration with `--mode proxy` CLI flag — separate story (US-014 already merged)
- Auto-refresh of expired JWTs within the proxy — handled by existing `auth-state.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)