### PR TITLE
feat(mcp): wire OAuth into proxy startup (US-016)

### DIFF
--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -24,34 +24,56 @@ import {
   discoverRecoveryFile,
   loadPrivateKeyFromRecovery,
   createCryptoProxyServer,
+  proxyLogin,
 } from "./proxy/index.js";
 import type { ProxyConfig } from "./proxy/index.js";
+import type { ServerConfig } from "./config.js";
+
+/**
+ * Start the crypto proxy: authenticate via OAuth, then connect to the
+ * upstream hosted MCP and expose tools over stdio.
+ *
+ * Exported for testability (US-016).
+ */
+export async function startProxy(config: ServerConfig): Promise<void> {
+  const dashboardUrl = process.env.PQDB_DASHBOARD_URL;
+  if (!dashboardUrl) {
+    throw new Error(
+      "PQDB_DASHBOARD_URL is required for proxy mode. " +
+        "Set it to the dashboard URL (e.g., https://localhost:8443).",
+    );
+  }
+
+  const recoveryPath = discoverRecoveryFile(config.recoveryFile);
+  const privateKey = loadPrivateKeyFromRecovery(recoveryPath);
+
+  // Authenticate via OAuth before connecting to upstream
+  const authResult = await proxyLogin(dashboardUrl);
+  console.error("[pqdb-proxy] Authenticated successfully");
+
+  const proxyConfig: ProxyConfig = {
+    targetUrl: config.target!,
+    privateKey,
+    backendUrl: config.projectUrl,
+    authToken: authResult.devJwt,
+  };
+
+  const { mcpServer } = await createCryptoProxyServer(proxyConfig);
+
+  const transport = new StdioServerTransport();
+  await mcpServer.connect(transport);
+
+  console.error(
+    `[pqdb-proxy] Crypto proxy connected to ${config.target} (key from ${recoveryPath})`,
+  );
+}
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const config = buildConfig(args);
 
   if (config.mode === "proxy") {
-    // Crypto proxy mode: discover recovery file, load private key,
-    // connect to hosted MCP server, and expose via stdio.
-    const recoveryPath = discoverRecoveryFile(config.recoveryFile);
-    const privateKey = loadPrivateKeyFromRecovery(recoveryPath);
-
-    const proxyConfig: ProxyConfig = {
-      targetUrl: config.target!,
-      privateKey,
-      backendUrl: config.projectUrl,
-      authToken: config.devToken ?? process.env.PQDB_DEV_TOKEN ?? "",
-    };
-
-    const { mcpServer, upstream } = await createCryptoProxyServer(proxyConfig);
-
-    const transport = new StdioServerTransport();
-    await mcpServer.connect(transport);
-
-    console.error(
-      `[pqdb-proxy] Crypto proxy → ${config.target} (key from ${recoveryPath})`,
-    );
+    await startProxy(config);
     return;
   }
 
@@ -120,7 +142,15 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err) => {
-  console.error("[pqdb-mcp] Fatal error:", err);
-  process.exit(1);
-});
+/* istanbul ignore next -- entry-point guard */
+const isEntryPoint =
+  typeof process !== "undefined" &&
+  process.argv[1] &&
+  (process.argv[1].endsWith("/cli.js") || process.argv[1].endsWith("/cli.ts"));
+
+if (isEntryPoint) {
+  main().catch((err) => {
+    console.error("[pqdb-mcp] Fatal error:", err);
+    process.exit(1);
+  });
+}

--- a/mcp/tests/unit/cli-proxy-oauth.test.ts
+++ b/mcp/tests/unit/cli-proxy-oauth.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Unit tests for US-016: Wire OAuth into proxy startup.
+ *
+ * Verifies that proxy mode in cli.ts:
+ * - Requires PQDB_DASHBOARD_URL environment variable
+ * - Calls proxyLogin() before createCryptoProxyServer()
+ * - Populates ProxyConfig.authToken with the JWT from proxyLogin()
+ * - Logs the expected connection message
+ * - Exits with a clear error if login times out
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+// Mock proxyLogin to return a fake JWT
+const mockProxyLogin = vi.fn<
+  (dashboardUrl: string) => Promise<{ devJwt: string; refreshToken?: string; encryptionKey?: string }>
+>();
+
+// Mock createCryptoProxyServer to return a fake MCP server
+const mockMcpConnect = vi.fn<() => Promise<void>>();
+const mockCreateCryptoProxyServer = vi.fn();
+
+// Mock recovery file helpers
+const mockDiscoverRecoveryFile = vi.fn<(explicit?: string) => string>();
+const mockLoadPrivateKeyFromRecovery = vi.fn<(path: string) => Uint8Array>();
+
+// Mock StdioServerTransport
+const mockStdioTransportInstance = { sessionId: "test" };
+const MockStdioServerTransport = vi.fn(() => mockStdioTransportInstance);
+
+vi.mock("../../src/proxy/index.js", () => ({
+  proxyLogin: (...args: unknown[]) => mockProxyLogin(...(args as [string])),
+  discoverRecoveryFile: (...args: unknown[]) => mockDiscoverRecoveryFile(...(args as [string?])),
+  loadPrivateKeyFromRecovery: (...args: unknown[]) => mockLoadPrivateKeyFromRecovery(...(args as [string])),
+  createCryptoProxyServer: (...args: unknown[]) => mockCreateCryptoProxyServer(...args),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({
+  StdioServerTransport: MockStdioServerTransport,
+}));
+
+// Mock the other imports that cli.ts uses but we don't need
+vi.mock("@modelcontextprotocol/sdk/server/sse.js", () => ({
+  SSEServerTransport: vi.fn(),
+}));
+
+vi.mock("express", () => ({
+  default: vi.fn(() => ({
+    get: vi.fn(),
+    post: vi.fn(),
+    listen: vi.fn(),
+  })),
+}));
+
+vi.mock("../../src/server.js", () => ({
+  createPqdbMcpServer: vi.fn(),
+}));
+
+vi.mock("../../src/http-app.js", () => ({
+  createMcpHttpApp: vi.fn(),
+}));
+
+describe("CLI proxy mode OAuth wiring (US-016)", () => {
+  const originalEnv = process.env;
+  const originalArgv = process.argv;
+  let callOrder: string[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    callOrder = [];
+
+    // Default mock implementations
+    mockDiscoverRecoveryFile.mockReturnValue("/fake/recovery.json");
+    mockLoadPrivateKeyFromRecovery.mockReturnValue(new Uint8Array(2400));
+
+    mockProxyLogin.mockImplementation(async () => {
+      callOrder.push("proxyLogin");
+      return { devJwt: "test-jwt-token-from-oauth" };
+    });
+
+    mockCreateCryptoProxyServer.mockImplementation(async () => {
+      callOrder.push("createCryptoProxyServer");
+      return {
+        mcpServer: { connect: mockMcpConnect },
+        upstream: {},
+      };
+    });
+
+    mockMcpConnect.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    process.argv = originalArgv;
+  });
+
+  /**
+   * Helper to import and run main() with proxy mode args.
+   * Uses dynamic import to pick up fresh mocks each time.
+   */
+  async function runProxyMode(extraEnv?: Record<string, string>): Promise<void> {
+    if (extraEnv) {
+      Object.assign(process.env, extraEnv);
+    }
+    process.argv = [
+      "node",
+      "cli.js",
+      "--mode", "proxy",
+      "--target", "http://localhost:3002/mcp",
+      "--project-url", "http://localhost:8000",
+    ];
+
+    // Re-import cli.ts to trigger main()
+    // We need to import the module fresh each time
+    const mod = await import("../../src/cli.js");
+  }
+
+  it("requires PQDB_DASHBOARD_URL when running in proxy mode", async () => {
+    delete process.env.PQDB_DASHBOARD_URL;
+
+    // Since cli.ts calls main() at module level, we need to test the error
+    // We'll test the logic by extracting it — but for now, test via the
+    // config + the new validation in proxy mode.
+    //
+    // Actually, the simpler approach: test the proxy startup function directly.
+    // Let's import the pieces and test the wiring logic.
+
+    // The acceptance criteria says: "PQDB_DASHBOARD_URL env var" is required.
+    // We verify this by directly testing the behavior.
+    delete process.env.PQDB_DASHBOARD_URL;
+    delete process.env.PQDB_API_KEY;
+
+    const { buildConfig } = await import("../../src/config.js");
+    const config = buildConfig({
+      projectUrl: "http://localhost:8000",
+      transport: "stdio",
+      port: 3001,
+      mode: "proxy",
+      target: "http://localhost:3002/mcp",
+      recoveryFile: undefined,
+    });
+
+    // Import the startProxy function
+    const { startProxy } = await import("../../src/cli.js");
+
+    await expect(startProxy(config)).rejects.toThrow("PQDB_DASHBOARD_URL");
+  });
+
+  it("calls proxyLogin() before createCryptoProxyServer()", async () => {
+    process.env.PQDB_DASHBOARD_URL = "https://localhost:8443";
+    delete process.env.PQDB_API_KEY;
+
+    const { buildConfig } = await import("../../src/config.js");
+    const config = buildConfig({
+      projectUrl: "http://localhost:8000",
+      transport: "stdio",
+      port: 3001,
+      mode: "proxy",
+      target: "http://localhost:3002/mcp",
+      recoveryFile: undefined,
+    });
+
+    const { startProxy } = await import("../../src/cli.js");
+    await startProxy(config);
+
+    expect(callOrder).toEqual(["proxyLogin", "createCryptoProxyServer"]);
+  });
+
+  it("passes dashboardUrl from PQDB_DASHBOARD_URL to proxyLogin()", async () => {
+    process.env.PQDB_DASHBOARD_URL = "https://my-dash.example.com";
+    delete process.env.PQDB_API_KEY;
+
+    const { buildConfig } = await import("../../src/config.js");
+    const config = buildConfig({
+      projectUrl: "http://localhost:8000",
+      transport: "stdio",
+      port: 3001,
+      mode: "proxy",
+      target: "http://localhost:3002/mcp",
+      recoveryFile: undefined,
+    });
+
+    const { startProxy } = await import("../../src/cli.js");
+    await startProxy(config);
+
+    expect(mockProxyLogin).toHaveBeenCalledWith("https://my-dash.example.com");
+  });
+
+  it("populates ProxyConfig.authToken with the JWT from proxyLogin()", async () => {
+    process.env.PQDB_DASHBOARD_URL = "https://localhost:8443";
+    delete process.env.PQDB_API_KEY;
+
+    mockProxyLogin.mockResolvedValue({
+      devJwt: "my-special-jwt-999",
+    });
+
+    const { buildConfig } = await import("../../src/config.js");
+    const config = buildConfig({
+      projectUrl: "http://localhost:8000",
+      transport: "stdio",
+      port: 3001,
+      mode: "proxy",
+      target: "http://localhost:3002/mcp",
+      recoveryFile: undefined,
+    });
+
+    const { startProxy } = await import("../../src/cli.js");
+    await startProxy(config);
+
+    // Verify createCryptoProxyServer was called with the JWT as authToken
+    expect(mockCreateCryptoProxyServer).toHaveBeenCalledOnce();
+    const proxyConfig = mockCreateCryptoProxyServer.mock.calls[0][0];
+    expect(proxyConfig.authToken).toBe("my-special-jwt-999");
+  });
+
+  it("connects stdio transport after createCryptoProxyServer()", async () => {
+    process.env.PQDB_DASHBOARD_URL = "https://localhost:8443";
+    delete process.env.PQDB_API_KEY;
+
+    const { buildConfig } = await import("../../src/config.js");
+    const config = buildConfig({
+      projectUrl: "http://localhost:8000",
+      transport: "stdio",
+      port: 3001,
+      mode: "proxy",
+      target: "http://localhost:3002/mcp",
+      recoveryFile: undefined,
+    });
+
+    const { startProxy } = await import("../../src/cli.js");
+    await startProxy(config);
+
+    expect(MockStdioServerTransport).toHaveBeenCalledOnce();
+    expect(mockMcpConnect).toHaveBeenCalledWith(mockStdioTransportInstance);
+  });
+
+  it("logs connection message with target URL", async () => {
+    process.env.PQDB_DASHBOARD_URL = "https://localhost:8443";
+    delete process.env.PQDB_API_KEY;
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { buildConfig } = await import("../../src/config.js");
+    const config = buildConfig({
+      projectUrl: "http://localhost:8000",
+      transport: "stdio",
+      port: 3001,
+      mode: "proxy",
+      target: "http://localhost:3002/mcp",
+      recoveryFile: undefined,
+    });
+
+    const { startProxy } = await import("../../src/cli.js");
+    await startProxy(config);
+
+    // Verify the expected log message
+    const logCalls = consoleSpy.mock.calls.map((c) => c[0]);
+    expect(logCalls).toContainEqual(
+      expect.stringContaining("[pqdb-proxy] Crypto proxy connected to http://localhost:3002/mcp"),
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it("propagates login timeout error", async () => {
+    process.env.PQDB_DASHBOARD_URL = "https://localhost:8443";
+    delete process.env.PQDB_API_KEY;
+
+    mockProxyLogin.mockRejectedValue(
+      new Error("Login timed out. Please restart and try again."),
+    );
+
+    const { buildConfig } = await import("../../src/config.js");
+    const config = buildConfig({
+      projectUrl: "http://localhost:8000",
+      transport: "stdio",
+      port: 3001,
+      mode: "proxy",
+      target: "http://localhost:3002/mcp",
+      recoveryFile: undefined,
+    });
+
+    const { startProxy } = await import("../../src/cli.js");
+    await expect(startProxy(config)).rejects.toThrow("Login timed out");
+  });
+
+  it("passes correct targetUrl and backendUrl in ProxyConfig", async () => {
+    process.env.PQDB_DASHBOARD_URL = "https://localhost:8443";
+    delete process.env.PQDB_API_KEY;
+
+    const { buildConfig } = await import("../../src/config.js");
+    const config = buildConfig({
+      projectUrl: "http://localhost:8000",
+      transport: "stdio",
+      port: 3001,
+      mode: "proxy",
+      target: "http://hosted:3002/mcp",
+      recoveryFile: undefined,
+    });
+
+    const { startProxy } = await import("../../src/cli.js");
+    await startProxy(config);
+
+    const proxyConfig = mockCreateCryptoProxyServer.mock.calls[0][0];
+    expect(proxyConfig.targetUrl).toBe("http://hosted:3002/mcp");
+    expect(proxyConfig.backendUrl).toBe("http://localhost:8000");
+  });
+});


### PR DESCRIPTION
## Who

Isaac Quintero + Claude Opus 4.6 (pair-programming)

## What

- Wire `proxyLogin()` (from US-015) into proxy mode startup in `cli.ts`
- Proxy authenticates via OAuth browser flow before connecting to upstream MCP
- `PQDB_DASHBOARD_URL` env var required in proxy mode; clear error if missing
- `ProxyConfig.authToken` populated with JWT from OAuth login
- Console logs `[pqdb-proxy] Crypto proxy connected to {target}` on success
- Login timeout from `proxyLogin()` propagates as a clear error
- Extract `startProxy()` as exported function for testability
- Guard module-level `main()` to prevent side effects on import

## When

2026-04-11

## Where

- `mcp/src/cli.ts` — proxy startup logic refactored and OAuth wiring added
- `mcp/tests/unit/cli-proxy-oauth.test.ts` — 8 new unit tests

## Why

The proxy mode previously used a static `PQDB_DEV_TOKEN` for authentication, requiring manual token management. US-016 completes the crypto proxy OAuth flow by wiring `proxyLogin()` (delivered in US-015) into the proxy startup path, so the full flow works end-to-end without manual token management. This is the final story in the proxy OAuth chain.

## How

Extracted the proxy startup logic from the inline `main()` function into an exported `startProxy(config)` function. This function:
1. Validates `PQDB_DASHBOARD_URL` is set (throws clear error if not)
2. Discovers recovery file and loads private key (unchanged from US-014)
3. Calls `proxyLogin(dashboardUrl)` to authenticate via browser OAuth flow
4. Passes the resulting JWT as `ProxyConfig.authToken` to `createCryptoProxyServer()`
5. Connects stdio transport for Claude Code communication

**Considered:**
- Keeping proxy logic inline in `main()`: Rejected — not testable without module-level side effects
- Extracting `startProxy()` as exported function: Chosen — allows mocked unit tests, clean separation

**Trade-offs:**
- Entry-point guard checks `process.argv[1]` suffix — fragile if CLI filename changes, but necessary to prevent `main()` from executing during test imports

## Test plan

- [x] 8 unit tests covering all acceptance criteria (PQDB_DASHBOARD_URL required, call order, JWT wiring, stdio connection, log message, timeout propagation, config passthrough)
- [x] Full mcp unit test suite: no regressions (pre-existing failures in admin/auth/project tools are unrelated to this PR)
- [x] Typecheck passes (`tsc --noEmit`)
- [x] Production build succeeds (`tsup`)
- [x] No secret leaks (`gitleaks detect`)

## Non-goals

- Integration test with real hosted MCP server (requires full infra; deferred to E2E test suite)
- Refresh token handling / token renewal (Phase 2 scope)
- Semgrep SAST/SCA scan (to be run by reviewer before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
