### PR TITLE
test(mcp): repair 15 stale tool-handler unit tests

### DIFF
--- a/mcp/tests/unit/admin-tools.test.ts
+++ b/mcp/tests/unit/admin-tools.test.ts
@@ -3,6 +3,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createPqdbMcpServer } from "../../src/server.js";
 import type { ServerConfig } from "../../src/config.js";
+import { setAuthState } from "../../src/auth-state.js";
 
 // Mock @pqdb/client
 vi.mock("@pqdb/client", () => ({
@@ -66,7 +67,7 @@ describe("pqdb_execute_sql tool", () => {
   let client: Client;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     client = await createTestClient();
   });
 
@@ -150,7 +151,7 @@ describe("pqdb_list_extensions tool", () => {
   let client: Client;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     client = await createTestClient();
   });
 
@@ -207,8 +208,19 @@ describe("pqdb_list_migrations tool", () => {
   let client: Client;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     client = await createTestClient({ devToken: "dev-jwt-token-123" });
+    // pqdb_list_migrations hits the backend via `apikeyGet` with an
+    // empty apiKey string, which then reads the developer JWT and
+    // project ID from auth-state to build headers. Tests have to
+    // populate auth-state explicitly — `createPqdbMcpServer` does
+    // not (in production, `http-app.ts` sets auth-state on the
+    // initialize request).
+    setAuthState({
+      devToken: "dev-jwt-token-123",
+      projectId: "proj-test-123",
+      projectUrl: "http://localhost:8000",
+    });
   });
 
   it("is registered and listed", async () => {
@@ -217,7 +229,7 @@ describe("pqdb_list_migrations tool", () => {
     expect(names).toContain("pqdb_list_migrations");
   });
 
-  it("calls GET /v1/db/migrations with Authorization header", async () => {
+  it("calls GET /v1/projects/migrations with Bearer + x-project-id headers", async () => {
     const migrations = [
       { revision: "abc123", description: "create users table", applied_at: "2026-01-01" },
       { revision: "def456", description: "add posts table", applied_at: "2026-01-02" },
@@ -230,10 +242,13 @@ describe("pqdb_list_migrations tool", () => {
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8000/v1/db/migrations",
+      "http://localhost:8000/v1/projects/migrations",
       {
         method: "GET",
-        headers: { Authorization: "Bearer dev-jwt-token-123" },
+        headers: {
+          Authorization: "Bearer dev-jwt-token-123",
+          "x-project-id": "proj-test-123",
+        },
       },
     );
 
@@ -244,7 +259,7 @@ describe("pqdb_list_migrations tool", () => {
   });
 
   it("returns error when devToken is not set", async () => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     const clientNoToken = await createTestClient({ devToken: undefined });
 
     const result = await clientNoToken.callTool({

--- a/mcp/tests/unit/auth-tools.test.ts
+++ b/mcp/tests/unit/auth-tools.test.ts
@@ -3,6 +3,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createPqdbMcpServer } from "../../src/server.js";
 import type { ServerConfig } from "../../src/config.js";
+import { setAuthState } from "../../src/auth-state.js";
 
 // Mock @pqdb/client
 vi.mock("@pqdb/client", () => ({
@@ -65,7 +66,7 @@ describe("pqdb_list_users tool", () => {
   let client: Client;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     client = await createTestClient();
   });
 
@@ -75,29 +76,42 @@ describe("pqdb_list_users tool", () => {
     expect(names).toContain("pqdb_list_users");
   });
 
-  it("calls GET /v1/auth/users with apikey header", async () => {
-    const users = [
-      { id: "u1", email: "alice@test.com", role: "authenticated", email_verified: true },
-      { id: "u2", email: "bob@test.com", role: "admin", email_verified: false },
-    ];
-    mockFetchOk(users);
+  it("POSTs a read-only SQL query against _pqdb_users using the apikey", async () => {
+    // The handler was refactored away from a dedicated /v1/auth/users
+    // endpoint to a SQL query against the `_pqdb_users` table (there
+    // is no dedicated list-users REST endpoint). The proper assertion
+    // is that the handler sends a read-only SQL SELECT and forwards
+    // the `rows` payload.
+    const sqlResponse = {
+      rows: [
+        { id: "u1", email: "alice@test.com", role: "authenticated", email_verified: true, created_at: "2026-01-01T00:00:00Z" },
+        { id: "u2", email: "bob@test.com", role: "admin", email_verified: false, created_at: "2026-01-02T00:00:00Z" },
+      ],
+      columns: ["id", "email", "role", "email_verified", "created_at"],
+      row_count: 2,
+    };
+    mockFetchOk(sqlResponse);
 
     const result = await client.callTool({
       name: "pqdb_list_users",
       arguments: {},
     });
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8000/v1/auth/users",
-      {
-        method: "GET",
-        headers: { apikey: "pqdb_service_testkey123" },
-      },
-    );
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, options] = mockFetch.mock.calls[0] as [
+      string,
+      { method: string; headers: Record<string, string>; body: string },
+    ];
+    expect(url).toBe("http://localhost:8000/v1/db/sql");
+    expect(options.method).toBe("POST");
+    expect(options.headers).toMatchObject({ apikey: "pqdb_service_testkey123" });
+    const body = JSON.parse(options.body) as { query: string; mode: string };
+    expect(body.mode).toBe("read");
+    expect(body.query).toMatch(/SELECT .* FROM _pqdb_users/);
 
     const text = (result.content[0] as { type: string; text: string }).text;
     const parsed = JSON.parse(text);
-    expect(parsed.data).toEqual(users);
+    expect(parsed.data).toEqual(sqlResponse.rows);
     expect(parsed.error).toBeNull();
   });
 
@@ -123,8 +137,18 @@ describe("pqdb_list_roles tool", () => {
   let client: Client;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     client = await createTestClient();
+    // pqdb_list_roles hits the project-scoped endpoint
+    // /v1/projects/{project_id}/auth/roles and reads both the
+    // developer JWT and the project ID from auth-state. The test
+    // helper has to populate auth-state explicitly — in production,
+    // http-app.ts sets it on the initialize request.
+    setAuthState({
+      devToken: "dev-jwt-token-123",
+      projectId: "proj-test-123",
+      projectUrl: "http://localhost:8000",
+    });
   });
 
   it("is registered and listed", async () => {
@@ -133,7 +157,7 @@ describe("pqdb_list_roles tool", () => {
     expect(names).toContain("pqdb_list_roles");
   });
 
-  it("calls GET /v1/auth/roles with apikey header", async () => {
+  it("calls GET /v1/projects/{pid}/auth/roles with Bearer header", async () => {
     const roles = [
       { id: "r1", name: "anon", description: "Anonymous" },
       { id: "r2", name: "authenticated", description: "Authenticated user" },
@@ -147,11 +171,8 @@ describe("pqdb_list_roles tool", () => {
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:8000/v1/auth/roles",
-      {
-        method: "GET",
-        headers: { apikey: "pqdb_service_testkey123" },
-      },
+      "http://localhost:8000/v1/projects/proj-test-123/auth/roles",
+      { headers: { Authorization: "Bearer dev-jwt-token-123" } },
     );
 
     const text = (result.content[0] as { type: string; text: string }).text;
@@ -182,7 +203,7 @@ describe("pqdb_list_policies tool", () => {
   let client: Client;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     client = await createTestClient();
   });
 

--- a/mcp/tests/unit/project-tools.test.ts
+++ b/mcp/tests/unit/project-tools.test.ts
@@ -66,8 +66,10 @@ describe("pqdb_get_project tool", () => {
   let client: Client;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
-    client = await createTestClient();
+    vi.resetAllMocks();
+    // pqdb_get_project requires a developer JWT — it hits the backend
+    // via `devGet` which sends `Authorization: Bearer <devToken>`.
+    client = await createTestClient({ devToken: "dev-jwt-token-123" });
   });
 
   it("is registered and listed", async () => {
@@ -82,7 +84,7 @@ describe("pqdb_get_project tool", () => {
     expect(tool?.inputSchema.required).toContain("project_id");
   });
 
-  it("calls GET /v1/projects/{id} with apikey header", async () => {
+  it("calls GET /v1/projects/{id} with Authorization Bearer header", async () => {
     const project = {
       id: "proj-123",
       name: "My Project",
@@ -102,7 +104,7 @@ describe("pqdb_get_project tool", () => {
       "http://localhost:8000/v1/projects/proj-123",
       {
         method: "GET",
-        headers: { apikey: "pqdb_service_testkey123" },
+        headers: { Authorization: "Bearer dev-jwt-token-123" },
       },
     );
 
@@ -134,7 +136,7 @@ describe("pqdb_list_projects tool", () => {
   let client: Client;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     client = await createTestClient({ devToken: "dev-jwt-token-123" });
   });
 
@@ -171,7 +173,7 @@ describe("pqdb_list_projects tool", () => {
   });
 
   it("returns error when devToken is not set", async () => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     const clientNoToken = await createTestClient({ devToken: undefined });
 
     const result = await clientNoToken.callTool({
@@ -192,7 +194,7 @@ describe("pqdb_create_project tool", () => {
   let client: Client;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     client = await createTestClient({ devToken: "dev-jwt-token-123" });
   });
 
@@ -245,7 +247,7 @@ describe("pqdb_create_project tool", () => {
   });
 
   it("returns error when devToken is not set", async () => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     const clientNoToken = await createTestClient({ devToken: undefined });
 
     const result = await clientNoToken.callTool({
@@ -280,8 +282,9 @@ describe("pqdb_get_logs tool", () => {
   let client: Client;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
-    client = await createTestClient();
+    vi.resetAllMocks();
+    // pqdb_get_logs uses `devGet` — developer JWT with Bearer auth.
+    client = await createTestClient({ devToken: "dev-jwt-token-123" });
   });
 
   it("is registered and listed", async () => {
@@ -296,7 +299,7 @@ describe("pqdb_get_logs tool", () => {
     expect(tool?.inputSchema.required).toContain("project_id");
   });
 
-  it("calls GET /v1/projects/{id}/logs with apikey header", async () => {
+  it("calls GET /v1/projects/{id}/logs with Authorization Bearer header", async () => {
     const logs = [
       { id: "l1", action: "insert", table: "users", timestamp: "2026-01-01T00:00:00Z" },
       { id: "l2", action: "select", table: "posts", timestamp: "2026-01-01T01:00:00Z" },
@@ -312,7 +315,7 @@ describe("pqdb_get_logs tool", () => {
       "http://localhost:8000/v1/projects/proj-123/logs",
       {
         method: "GET",
-        headers: { apikey: "pqdb_service_testkey123" },
+        headers: { Authorization: "Bearer dev-jwt-token-123" },
       },
     );
 
@@ -343,7 +346,7 @@ describe("pqdb_pause_project tool", () => {
   let client: Client;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     client = await createTestClient({ devToken: "dev-jwt-token-123" });
   });
 
@@ -381,7 +384,7 @@ describe("pqdb_pause_project tool", () => {
   });
 
   it("returns error when devToken is not set", async () => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     const clientNoToken = await createTestClient({ devToken: undefined });
 
     const result = await clientNoToken.callTool({
@@ -402,7 +405,7 @@ describe("pqdb_restore_project tool", () => {
   let client: Client;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     client = await createTestClient({ devToken: "dev-jwt-token-123" });
   });
 
@@ -440,7 +443,7 @@ describe("pqdb_restore_project tool", () => {
   });
 
   it("returns error when devToken is not set", async () => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     const clientNoToken = await createTestClient({ devToken: undefined });
 
     const result = await clientNoToken.callTool({


### PR DESCRIPTION
## Who

- Isaac Quintero (author)
- Claude Opus 4.6 (pair-programming)

## What

- Switch `vi.clearAllMocks()` to `vi.resetAllMocks()` in all 3 test files to stop `mockResolvedValueOnce` queue leakage between tests
- Update `pqdb_get_project` + `pqdb_get_logs` tests to expect `Authorization: Bearer` headers instead of `apikey` (handlers were refactored to use `devGet`)
- Rewrite `pqdb_list_users` test to match the current SQL-query-based handler (POST `/v1/db/sql` instead of GET `/v1/auth/users`)
- Add `setAuthState()` calls to `pqdb_list_migrations` and `pqdb_list_roles` test setups — these handlers read from module-level auth-state, which tests were not populating
- Update expected URLs + header shapes to match current handlers (`/v1/projects/{pid}/auth/roles`, `/v1/projects/migrations`, Bearer + x-project-id)

## When

2026-04-12

## Where

- `mcp/tests/unit/project-tools.test.ts`
- `mcp/tests/unit/auth-tools.test.ts`
- `mcp/tests/unit/admin-tools.test.ts`

## Why

15 unit tests in tool-handler test files had been failing silently since the dev-JWT auth refactor. They ran on every CI build, were visible in the output, but nobody had fixed them because each failure looked narrow and unrelated to current work. They represented a broken-windows signal in the test suite and masked real regressions behind noise — exactly the kind of thing that lets bugs like the Phase 5e proxy crypto gap slip through.

Root causes, in order of impact:

1. **Mock leakage**: Every failing test that returned early (before consuming its `mockFetchOk` / `mockFetchError`) left queued return values behind. `vi.clearAllMocks()` does NOT clear the queue — it only clears call history. Switching to `vi.resetAllMocks()` wipes both implementations and queues. This single change recovered 7 of the 15 failures because downstream tests had been receiving poisoned mock values from their stale predecessors.

2. **Auth mode drift**: `pqdb_get_project` and `pqdb_get_logs` were refactored to use `devGet` (Authorization: Bearer) but the tests still passed `apiKey` and asserted on `{apikey: ...}` headers.

3. **Stale URL / method / payload expectations**: `pqdb_list_users` was refactored from GET `/v1/auth/users` to a read-only POST `/v1/db/sql` with a SELECT against `_pqdb_users`. The old test asserted on URL + method + response shape that no longer exist.

4. **Missing auth-state setup**: `pqdb_list_migrations` (admin-tools) and `pqdb_list_roles` (auth-tools) pull the developer JWT and project_id from `auth-state.ts` module-level globals at call time, not from their registration closures. Tests that don't explicitly call `setAuthState()` get empty auth headers because `buildAuthHeaders()` falls through to `return {}`.

## How

**Chosen approach**: Repair the tests to match current handler behavior. Do not modify handlers.

**Considered alternatives (rejected)**:

- **Fix the handler instead**: Rejected. The module-level auth-state is load-bearing — it survives JWT refresh in the middle of a long-running MCP session, which function-arg passing doesn't. The tests were wrong, not the handlers.
- **Delete the broken tests as dead weight**: Rejected. The assertions are valuable — they pin URL + auth header + response shape, which is exactly what you want to catch if a future refactor accidentally changes them again. The tests were stale, not useless.

**Trade-offs accepted**:

- The rewritten `pqdb_list_users` test asserts on the SQL query text via a regex match. If a future refactor changes the SELECT column list, the test will break — and it should, because the response row shape depends on those columns.
- The `setAuthState()` calls leak global state between tests within the same file. `resetAllMocks()` doesn't undo them, but each describe's `beforeEach` overwrites them before each test body runs, so it washes out in practice.

## Test plan

- [x] `mcp/tests/unit/project-tools.test.ts`: 22/22 pass (was 8 failing)
- [x] `mcp/tests/unit/auth-tools.test.ts`: 10/10 pass (was 4 failing)
- [x] `mcp/tests/unit/admin-tools.test.ts`: 12/12 pass (was 1 failing)
- [x] Full `mcp/tests/unit/` suite: 350/350 pass across 23 files
- [ ] CI: full unit test suite
- [ ] CI: typecheck + production build

## Non-goals

- Fixing pre-existing TypeScript diagnostic warnings in the test files (result.content is unknown, missing projectId in ServerConfig default). Those exist independently of this test logic repair and have their own fix pattern.
- Adding new test coverage. This PR only brings existing tests back to green — expanding coverage belongs to follow-ups tied to specific tool changes.
- The e2e phase3b-mcp test and crud-tools tests. Those are separate test files with their own failure patterns and scope.

Generated with Claude Code